### PR TITLE
Mutation observer

### DIFF
--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -6,6 +6,7 @@
 #= require trix/models/text
 #= require trix/lib/dom
 #= require trix/lib/selection_observer
+#= require trix/lib/mutation_observer
 #= require trix/lib/html_parser
 
 class Trix.EditorController
@@ -27,6 +28,9 @@ class Trix.EditorController
 
     @selectionObserver = new Trix.SelectionObserver
     @selectionObserver.delegate = this
+
+    @mutationObserver = new Trix.MutationObserver @textElement
+    @mutationObserver.delegate = this
 
     @toolbarController = new Trix.ToolbarController @toolbarElement
     @toolbarController.delegate = this
@@ -58,8 +62,12 @@ class Trix.EditorController
 
   # Text controller delegate
 
+  textControllerWillRender: ->
+    @mutationObserver.stop()
+
   textControllerDidRender: ->
     @debugController.render()
+    @mutationObserver.start()
 
   textControllerDidFocus: ->
     @toolbarController.hideDialog() if @dialogWantsFocus
@@ -83,6 +91,11 @@ class Trix.EditorController
     @textController.selectionDidChange(range)
     @composition.updateCurrentAttributes()
     @debugController.render()
+
+  # Mutation observer delegate
+
+  elementDidMutate: (mutations) ->
+    @composition.replaceHTML(@textElement.innerHTML)
 
   # Toolbar controller delegate
 

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -1,5 +1,4 @@
 #= require trix/lib/helpers
-#= require trix/lib/mutation_observer
 
 {defer} = Trix.Helpers
 
@@ -15,15 +14,6 @@ class Trix.InputController
     for event, handler of @events
       @element.addEventListener(event, handler.bind(this), true)
 
-    @mutationObserver = new Trix.MutationObserver @element
-    @mutationObserver.delegate = this
-
-  # Mutation observer delegate
-
-  elementDidMutate: (mutations) ->
-    @mutationObserver.pause =>
-      @responder?.replaceHTML(@element.innerHTML)
-
   # Input handlers
 
   events:
@@ -34,8 +24,7 @@ class Trix.InputController
           when event.altKey then @keys.alt
           else @keys
 
-        @mutationObserver.pause =>
-          context[keyName]?.call(this, event)
+        context[keyName]?.call(this, event)
 
     keypress: (event) ->
       return if (event.metaKey or event.ctrlKey) and not event.altKey
@@ -47,8 +36,7 @@ class Trix.InputController
 
       if character
         event.preventDefault()
-        @mutationObserver.pause =>
-          @responder?.insertString(character)
+        @responder?.insertString(character)
 
     dragenter: (event) ->
       event.preventDefault()
@@ -75,15 +63,13 @@ class Trix.InputController
       @responder?.requestPositionAtPoint(point)
 
       if @draggedRange
-        @mutationObserver.pause =>
-          @responder?.moveTextFromRange(@draggedRange)
+        @responder?.moveTextFromRange(@draggedRange)
         delete @draggedRange
 
       else if files = event.dataTransfer.files
-        @mutationObserver.pause =>
-          for file in files
-            if @responder?.insertFile(file)
-              file.trixInserted = true
+        for file in files
+          if @responder?.insertFile(file)
+            file.trixInserted = true
 
     cut: (event) ->
       defer => @responder?.deleteBackward()
@@ -105,8 +91,7 @@ class Trix.InputController
     input: (event) ->
       if @composing
         if @composedString?
-          @mutationObserver.pause =>
-            @delegate?.inputControllerDidComposeCharacters?(@composedString)
+          @delegate?.inputControllerDidComposeCharacters?(@composedString)
           delete @composedString
           delete @composing
 

--- a/src/trix/controllers/text_controller.coffee
+++ b/src/trix/controllers/text_controller.coffee
@@ -24,6 +24,7 @@ class Trix.TextController
       @uninstallAttachmentController()
 
   render: ->
+    @delegate?.textControllerWillRender?()
     @textView.render()
     @delegate?.textControllerDidRender?()
 

--- a/src/trix/lib/mutation_observer.coffee
+++ b/src/trix/lib/mutation_observer.coffee
@@ -9,7 +9,7 @@ class Trix.MutationObserver
     characterData: true
     subtree: true
 
-  constructor: (@element, @callback) ->
+  constructor: (@element) ->
     @observer = new window.MutationObserver @didMutate
     @start()
 
@@ -21,8 +21,3 @@ class Trix.MutationObserver
 
   stop: ->
     @observer.disconnect()
-
-  pause: (block) ->
-    @stop()
-    block()
-    @start()


### PR DESCRIPTION
Use a `MutationObserver` to watch for DOM changes instead of listening for an (already unhelpful) input event, which isn't supported in IE 11 for contenteditable elements. What do you think, @sstephenson? 
