### PR TITLE
Fixed punctuation

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -11,7 +11,7 @@ Examples of unacceptable behavior by participants include:
 * Trolling or insulting/derogatory comments
 * Public or private harassment
 * Publishing other's private information, such as physical or electronic addresses, without explicit permission
-* Other unethical or unprofessional conduct.
+* Other unethical or unprofessional conduct
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
 
@@ -19,4 +19,4 @@ This code of conduct applies both within project spaces and in public spaces whe
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one of the project maintainers, [Javan Makhmali](mailto:javan@basecamp.com) or [Sam Stephenson](mailto:sam@basecamp.com).
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/).


### PR DESCRIPTION
The first five items in the list of examples of unacceptable behavior were not trailed by periods, so period at the end of the sixth item stopped the list from being uniform.

The final line paragraph should end with a period, as all previous paragraphs have.