### PR TITLE
WIP - HTML attachments with preview

### DIFF
--- a/assets/test_embed.html.erb
+++ b/assets/test_embed.html.erb
@@ -1,0 +1,8 @@
+<div>
+  <img width="50" height="50" src="https://cdn3.iconfinder.com/data/icons/rcons-user-action/32/boy-512.png"></img>
+  <span>John Smith</span>
+  <p>
+    123 Shoestring Lane<br>
+    555-555-5555
+  </p>
+</div>

--- a/src/trix/operations/document_preload_operation.coffee
+++ b/src/trix/operations/document_preload_operation.coffee
@@ -1,0 +1,14 @@
+class Trix.DocumentPreloadOperation extends Trix.Operation
+  constructor: (@url) ->
+
+  perform: (callback) ->
+    request = new XMLHttpRequest
+    request.open("GET", @url)
+
+    request.onload = =>
+      callback(true, request.responseText)
+
+    request.onerror = ->
+      callback(false)
+
+    request.send()

--- a/src/trix/views/piece_view.coffee
+++ b/src/trix/views/piece_view.coffee
@@ -1,5 +1,6 @@
 #= require trix/views/attachment_view
 #= require trix/views/previewable_attachment_view
+#= require trix/views/previewable_document_attachment_view
 
 {makeElement, findInnerElement} = Trix
 
@@ -29,7 +30,10 @@ class Trix.PieceView extends Trix.ObjectView
 
   createAttachmentNodes: ->
     constructor = if @attachment.isPreviewable()
-      Trix.PreviewableAttachmentView
+      if @attachment.getContentType() == 'text/html'
+        Trix.PreviewableDocumentAttachmentView
+      else
+        Trix.PreviewableAttachmentView
     else
       Trix.AttachmentView
 

--- a/src/trix/views/previewable_document_attachment_view.coffee
+++ b/src/trix/views/previewable_document_attachment_view.coffee
@@ -1,0 +1,34 @@
+#= require trix/views/attachment_view
+
+{defer, makeElement, measureElement} = Trix
+
+class Trix.PreviewableDocumentAttachmentView extends Trix.AttachmentView
+  constructor: ->
+    super
+    @attachment.previewDelegate = this
+
+  createContentNodes: ->
+    @document = makeElement
+      tagName: "div"
+      data:
+        trixMutable: true
+        trixStoreKey: @attachment.getCacheKey("documentElement")
+
+    @refresh(@document)
+    [@document]
+
+  refresh: (doc) ->
+    doc ?= @findElement()?.querySelector("div")
+    @updateAttributesForDocument(doc) if doc
+
+  updateAttributesForDocument: (doc) ->
+    url = @attachment.getURL()
+
+    serializedAttributes = JSON.stringify(src: url)
+    doc.setAttribute("data-trix-serialized-attributes", serializedAttributes)
+
+  # Attachment delegate
+
+  attachmentDidPreload: ->
+    @refresh(@document)
+    @refresh()


### PR DESCRIPTION
I've been exploring the idea of a custom HTML attachment that lets me fetch an HTML snippet and embed it in my Trix editor. 

I'm opening this PR to get a general feel on the approach and whether or not this is something that could be useful to others or should remain outside of core.

![trix-html-attachments](https://cloud.githubusercontent.com/assets/378038/10761264/f0f6b108-7c96-11e5-8203-cd63f42017bf.gif)

The use case I have in mind would be: 

1. User references another resource on the same application that would benefit from a preview
2. A preview of that resource is embedded in the editor and treated as an attachment.
3. Ideally the content of the preview itself is not persisted as I'd like this preview to always be generated from the URL on the attachment.

Things I'm not sure about: 

- Previews seem to be geared towards Images only right now. I want to treat my HTML preview like an image in that it's fetched from an endpoint.
- I haven't round tripped this with persistence server side yet. Since I'm not intending to persist the actual preview content returned, when I render this comment I'd need to track additional info in order to find the right partial server side and render it.
- There's no progress tie in right now for the (HTML) Document attachment
- I *could* persist the content of the HTML however this would likely be a nightmare as the preview of each resource would change over time with new styles and become very inconsistent with historical entries.