### PR TITLE
Compose current attributes

### DIFF
--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -236,15 +236,22 @@ class Trix.InputController extends Trix.BasicObject
       event.preventDefault()
 
     compositionstart: (event) ->
-      @insertPlaceholder()
+      unless @selectionIsExpanded()
+        textAdded = @responder?.insertPlaceholder()
+        @setInputSummary({textAdded})
+        @requestRender()
+
       @setInputSummary(composing: true, compositionStart: event.data)
 
     compositionupdate: (event) ->
-      @selectPlaceholder()
+      if @responder?.selectPlaceholder()
+        @responder?.forgetPlaceholder()
+
       @setInputSummary(composing: true, compositionUpdate: event.data)
 
     compositionend: (event) ->
-      @selectPlaceholder()
+      if @responder?.selectPlaceholder()
+        @responder?.forgetPlaceholder()
 
       {compositionStart} = @inputSummary
       {data} = event
@@ -335,20 +342,6 @@ class Trix.InputController extends Trix.BasicObject
         @delegate?.inputControllerWillPerformTyping()
 
   # Private
-
-  placeholder = " "
-
-  insertPlaceholder: ->
-    unless @selectionIsExpanded()
-      @placeholderPosition = @responder?.getPosition()
-      @setInputSummary(textAdded: placeholder)
-      @responder?.insertString(placeholder)
-      @requestRender()
-
-  selectPlaceholder: ->
-    if @placeholderPosition?
-      @responder?.setSelectedRange([@placeholderPosition, @placeholderPosition + placeholder.length])
-      @placeholderPosition = null
 
   handleInput: (callback) ->
     try

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -246,13 +246,13 @@ class Trix.InputController extends Trix.BasicObject
     compositionend: (event) ->
       @selectPlaceholder()
 
-      composedString = event.data
-      @setInputSummary(composing: true, compositionEnd: composedString)
+      {compositionStart} = @inputSummary
+      {data} = event
 
-      if composedString? and composedString isnt @inputSummary.compositionStart
+      if compositionStart? and data? and compositionStart isnt data
         @delegate?.inputControllerWillPerformTyping()
-        @responder?.insertString(composedString)
-        {added, removed} = summarizeStringChange(@inputSummary.compositionStart, composedString)
+        @responder?.insertString(data)
+        {added, removed} = summarizeStringChange(compositionStart, data)
         @setInputSummary(textAdded: added, didDelete: Boolean(removed))
 
     input: (event) ->

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -236,14 +236,16 @@ class Trix.InputController extends Trix.BasicObject
       event.preventDefault()
 
     compositionstart: (event) ->
-      @mutationObserver.stop()
+      @insertPlaceholder()
       @setInputSummary(composing: true, compositionStart: event.data)
 
     compositionupdate: (event) ->
+      @selectPlaceholder()
       @setInputSummary(composing: true, compositionUpdate: event.data)
 
     compositionend: (event) ->
-      @mutationObserver.start()
+      @selectPlaceholder()
+
       composedString = event.data
       @setInputSummary(composing: true, compositionEnd: composedString)
 
@@ -333,6 +335,20 @@ class Trix.InputController extends Trix.BasicObject
         @delegate?.inputControllerWillPerformTyping()
 
   # Private
+
+  placeholder = " "
+
+  insertPlaceholder: ->
+    unless @selectionIsExpanded()
+      @placeholderPosition = @responder?.getPosition()
+      @setInputSummary(textAdded: placeholder)
+      @responder?.insertString(placeholder)
+      @requestRender()
+
+  selectPlaceholder: ->
+    if @placeholderPosition?
+      @responder?.setSelectedRange([@placeholderPosition, @placeholderPosition + placeholder.length])
+      @placeholderPosition = null
 
   handleInput: (callback) ->
     try

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -197,6 +197,7 @@ class Trix.Composition extends Trix.BasicObject
   selectPlaceholder: ->
     if @placeholderPosition?
       @setSelectedRange([@placeholderPosition, @placeholderPosition + placeholder.length])
+      true
 
   forgetPlaceholder: ->
     @placeholderPosition = null

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -187,6 +187,20 @@ class Trix.Composition extends Trix.BasicObject
     @removeCurrentAttribute(block.getLastAttribute())
     @setSelection(startPosition)
 
+  placeholder = " "
+
+  insertPlaceholder: ->
+    @placeholderPosition = @getPosition()
+    @insertString(placeholder)
+    placeholder
+
+  selectPlaceholder: ->
+    if @placeholderPosition?
+      @setSelectedRange([@placeholderPosition, @placeholderPosition + placeholder.length])
+
+  forgetPlaceholder: ->
+    @placeholderPosition = null
+
   # Current attributes
 
   hasCurrentAttribute: (attributeName) ->

--- a/test/src/system/basic_input_test.coffee
+++ b/test/src/system/basic_input_test.coffee
@@ -4,16 +4,6 @@ editorTest "typing", (expectDocument) ->
   typeCharacters "abc", ->
     expectDocument "abc\n"
 
-editorTest "composing", (expectDocument) ->
-  composeString "abc", ->
-    expectDocument "abc\n"
-
-editorTest "typing and composing", (expectDocument) ->
-  typeCharacters "a", ->
-    composeString "bcd", ->
-      typeCharacters "e", ->
-        expectDocument "abcde\n"
-
 editorTest "backspacing", (expectDocument) ->
   typeCharacters "abc\b", ->
     assertLocationRange(index: 0, offset: 2)
@@ -30,12 +20,6 @@ editorTest "pressing return", (expectDocument) ->
     pressKey "return", ->
       typeCharacters "c", ->
         expectDocument "ab\nc\n"
-
-editorTest "pressing return after a canceled composition", (expectDocument) ->
-  typeCharacters "ab", ->
-    triggerEvent document.activeElement, "compositionend", data: "ab"
-    pressKey "return", ->
-      expectDocument "ab\n\n"
 
 editorTest "cursor left", (expectDocument) ->
   typeCharacters "ac", ->

--- a/test/src/system/basic_input_test.coffee
+++ b/test/src/system/basic_input_test.coffee
@@ -31,6 +31,12 @@ editorTest "pressing return", (expectDocument) ->
       typeCharacters "c", ->
         expectDocument "ab\nc\n"
 
+editorTest "pressing return after a canceled composition", (expectDocument) ->
+  typeCharacters "ab", ->
+    triggerEvent document.activeElement, "compositionend", data: "ab"
+    pressKey "return", ->
+      expectDocument "ab\n\n"
+
 editorTest "cursor left", (expectDocument) ->
   typeCharacters "ac", ->
     moveCursor "left", ->

--- a/test/src/system/composition_input_test.coffee
+++ b/test/src/system/composition_input_test.coffee
@@ -1,0 +1,34 @@
+editorModule "Composition input", template: "editor_empty"
+
+editorTest "composing", (expectDocument) ->
+  composeString "abc", ->
+    expectDocument "abc\n"
+
+editorTest "typing and composing", (expectDocument) ->
+  typeCharacters "a", ->
+    composeString "bcd", ->
+      typeCharacters "e", ->
+        expectDocument "abcde\n"
+
+editorTest "pressing return after a canceled composition", (expectDocument) ->
+  typeCharacters "ab", ->
+    triggerEvent document.activeElement, "compositionend", data: "ab"
+    pressKey "return", ->
+      expectDocument "ab\n\n"
+
+editorTest "composing formatted text", (expectDocument) ->
+  typeCharacters "abc", ->
+    clickToolbarButton attribute: "bold", ->
+      composeString "def", ->
+        expectAttributes([0, 3], {})
+        expectAttributes([3, 6], bold: true)
+        expectDocument("abcdef\n")
+
+editorTest "composing away from formatted text", (expectDocument) ->
+    clickToolbarButton attribute: "bold", ->
+      typeCharacters "abc", ->
+        clickToolbarButton attribute: "bold", ->
+          composeString "def", ->
+            expectAttributes([0, 3], bold: true)
+            expectAttributes([3, 6], {})
+            expectDocument("abcdef\n")

--- a/test/src/system/text_formatting_test.coffee
+++ b/test/src/system/text_formatting_test.coffee
@@ -143,3 +143,20 @@ editorTest "key command activates toolbar button", (done) ->
   typeToolbarKeyCommand attribute: "bold", ->
     ok isToolbarButtonActive(attribute: "bold")
     done()
+
+editorTest "composing formatted text", (expectDocument) ->
+  typeCharacters "abc", ->
+    clickToolbarButton attribute: "bold", ->
+      composeString "def", ->
+        expectAttributes([0, 3], {})
+        expectAttributes([3, 6], bold: true)
+        expectDocument("abcdef\n")
+
+editorTest "composing away from formatted text", (expectDocument) ->
+    clickToolbarButton attribute: "bold", ->
+      typeCharacters "abc", ->
+        clickToolbarButton attribute: "bold", ->
+          composeString "def", ->
+            expectAttributes([0, 3], bold: true)
+            expectAttributes([3, 6], {})
+            expectDocument("abcdef\n")

--- a/test/src/system/text_formatting_test.coffee
+++ b/test/src/system/text_formatting_test.coffee
@@ -143,20 +143,3 @@ editorTest "key command activates toolbar button", (done) ->
   typeToolbarKeyCommand attribute: "bold", ->
     ok isToolbarButtonActive(attribute: "bold")
     done()
-
-editorTest "composing formatted text", (expectDocument) ->
-  typeCharacters "abc", ->
-    clickToolbarButton attribute: "bold", ->
-      composeString "def", ->
-        expectAttributes([0, 3], {})
-        expectAttributes([3, 6], bold: true)
-        expectDocument("abcdef\n")
-
-editorTest "composing away from formatted text", (expectDocument) ->
-    clickToolbarButton attribute: "bold", ->
-      typeCharacters "abc", ->
-        clickToolbarButton attribute: "bold", ->
-          composeString "def", ->
-            expectAttributes([0, 3], bold: true)
-            expectAttributes([3, 6], {})
-            expectDocument("abcdef\n")

--- a/test/src/test_helpers/input_helpers.coffee
+++ b/test/src/test_helpers/input_helpers.coffee
@@ -71,7 +71,12 @@ for code, name of Trix.InputController.keyNames
           insertNode(node, callback)
       else
         updated = true
-        compose(string.slice(0, index++), "update", continueComposition)
+        # The cursor doesn't acually move like this during a composition, but
+        # it can move and cause the location range and current attributes to change.
+        # Moving the cursor and then putting it back is enough exercise those changes.
+        moveCursor "left", ->
+          moveCursor "right", ->
+            compose(string.slice(0, index++), "update", continueComposition)
     else
       started = true
       compose(string.slice(0, index++), "start", continueComposition)


### PR DESCRIPTION
* Fixes #39
* Fixes pressing return to cancel a composition on Android