### PR TITLE
Move `event.preventDefault()` to under `if target?`

### DIFF
--- a/src/trix/core/helpers/dom.coffee
+++ b/src/trix/core/helpers/dom.coffee
@@ -13,8 +13,9 @@ Trix.extend
     handler = (event) ->
       handler.destroy() if times? and --times is 0
       target = Trix.findClosestElementFromNode(event.target, matchingSelector: selector)
-      withCallback?.call(target, event, target) if target?
-      event.preventDefault() if preventDefault
+      if target?
+        withCallback?.call(target, event, target)
+        event.preventDefault() if preventDefault
 
     handler.destroy = ->
       element.removeEventListener(eventName, handler, useCapture)


### PR DESCRIPTION
Otherwise event.preventDefault() would be invoked, even `target` is undefined.

The issue is explained in #93 