### PR TITLE
Support composition input of non-Roman characters on QWERTY keyboards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: ruby
 cache: bundler
 script: bin/ci
+branches:
+  only:
+    - master

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -229,6 +229,7 @@ class Trix.InputController extends Trix.BasicObject
 
     compositionstart: (event) ->
       unless @selectionIsExpanded()
+        # Skip placeholder if keypress input was received before the composition started
         unless @inputSummary.eventName is "keypress" and @inputSummary.textAdded
           textAdded = @responder?.insertPlaceholder()
           @setInputSummary({textAdded})

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -59,8 +59,11 @@ class Trix.InputController extends Trix.BasicObject
     @handleInput ->
       unless @mutationIsExpected(mutationSummary)
         @responder?.replaceHTML(@element.innerHTML)
+
+      unless @inputSummary.composing
+        @requestRender()
+
       @resetInputSummary()
-      @requestRender()
       Trix.selectionChangeObserver.reset()
 
   mutationIsExpected: (mutationSummary) ->
@@ -226,9 +229,10 @@ class Trix.InputController extends Trix.BasicObject
 
     compositionstart: (event) ->
       unless @selectionIsExpanded()
-        textAdded = @responder?.insertPlaceholder()
-        @setInputSummary({textAdded})
-        @requestRender()
+        unless @inputSummary.eventName is "keypress" and @inputSummary.textAdded
+          textAdded = @responder?.insertPlaceholder()
+          @setInputSummary({textAdded})
+          @requestRender()
 
       @setInputSummary(composing: true, compositionStart: event.data)
 

--- a/test/src/system/composition_input_test.coffee
+++ b/test/src/system/composition_input_test.coffee
@@ -1,14 +1,18 @@
 editorModule "Composition input", template: "editor_empty"
 
 editorTest "composing", (expectDocument) ->
-  composeString "abc", ->
-    expectDocument "abc\n"
+  startComposition "a", ->
+    updateComposition "ab", ->
+      endComposition "abc", ->
+        expectDocument "abc\n"
 
 editorTest "typing and composing", (expectDocument) ->
   typeCharacters "a", ->
-    composeString "bcd", ->
-      typeCharacters "e", ->
-        expectDocument "abcde\n"
+    startComposition "b", ->
+      updateComposition "bc", ->
+        endComposition "bcd", ->
+          typeCharacters "e", ->
+            expectDocument "abcde\n"
 
 editorTest "pressing return after a canceled composition", (expectDocument) ->
   typeCharacters "ab", ->
@@ -19,16 +23,31 @@ editorTest "pressing return after a canceled composition", (expectDocument) ->
 editorTest "composing formatted text", (expectDocument) ->
   typeCharacters "abc", ->
     clickToolbarButton attribute: "bold", ->
-      composeString "def", ->
-        expectAttributes([0, 3], {})
-        expectAttributes([3, 6], bold: true)
-        expectDocument("abcdef\n")
+      startComposition "d", ->
+        updateComposition "de", ->
+          endComposition "def", ->
+            expectAttributes([0, 3], {})
+            expectAttributes([3, 6], bold: true)
+            expectDocument("abcdef\n")
 
 editorTest "composing away from formatted text", (expectDocument) ->
-    clickToolbarButton attribute: "bold", ->
-      typeCharacters "abc", ->
-        clickToolbarButton attribute: "bold", ->
-          composeString "def", ->
-            expectAttributes([0, 3], bold: true)
-            expectAttributes([3, 6], {})
-            expectDocument("abcdef\n")
+  clickToolbarButton attribute: "bold", ->
+    typeCharacters "abc", ->
+      clickToolbarButton attribute: "bold", ->
+        startComposition "d", ->
+          updateComposition "de", ->
+            endComposition "def", ->
+              expectAttributes([0, 3], bold: true)
+              expectAttributes([3, 6], {})
+              expectDocument("abcdef\n")
+
+editorTest "composing another language using a QWERTY keyboard", (expectDocument) ->
+  element = getEditorElement()
+  keyCodes = x: 120, i: 105
+
+  triggerEvent(element, "keypress", charCode: keyCodes.x, keyCode: keyCodes.x, which: keyCodes.x)
+  startComposition "x", ->
+    triggerEvent(element, "keypress", charCode: keyCodes.i, keyCode: keyCodes.i, which: keyCodes.i)
+    updateComposition "xi", ->
+      endComposition "喜", ->
+        expectDocument "喜\n"

--- a/test/src/test_helpers/selection_helpers.coffee
+++ b/test/src/test_helpers/selection_helpers.coffee
@@ -66,10 +66,13 @@ for code, name of Trix.InputController.keyNames
   rangy.getSelection().isCollapsed
 
 @insertNode = (node, callback) ->
-  deleteSelection()
   selection = rangy.getSelection()
-  selection.getRangeAt(0).insertNode(node)
-  selection.collapse(node, 0)
+  range = selection.getRangeAt(0)
+  range.splitBoundaries()
+  range.insertNode(node)
+  range.setStartAfter(node)
+  range.deleteContents()
+  range.normalizeBoundaries()
   callback?()
 
 @selectNode = (node, callback) ->

--- a/test/src/test_helpers/selection_helpers.coffee
+++ b/test/src/test_helpers/selection_helpers.coffee
@@ -72,6 +72,12 @@ for code, name of Trix.InputController.keyNames
   selection.collapse(node, 0)
   callback?()
 
+@selectNode = (node, callback) ->
+  selection = rangy.getSelection()
+  selection.selectAllChildren(node)
+  Trix.selectionChangeObserver.update()
+  callback?()
+
 getCursorCoordinates = ->
   if rect = window.getSelection().getRangeAt(0).getClientRects()[0]
     clientX: rect.left


### PR DESCRIPTION
Before:
![pinyin-simplified-before](https://cloud.githubusercontent.com/assets/5355/11314094/45f45652-8fb0-11e5-8afc-7416aa493dbe.gif)

After:
![pinyin-simplified-after](https://cloud.githubusercontent.com/assets/5355/11314097/4a92d1a2-8fb0-11e5-9686-3979b4cfe64e.gif)

