### PR TITLE
Preserve image src attribute

### DIFF
--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -105,7 +105,7 @@ class Trix.HTMLParser extends Trix.BasicObject
             @appendStringWithAttributes("\n", getTextAttributes(element))
           @processedElements.push(element)
         when "img"
-          attributes = url: element.src, contentType: "image"
+          attributes = url: element.attributes.src.value, contentType: "image"
           attributes[key] = value for key, value of getImageDimensions(element)
           @appendAttachmentWithAttributes(attributes, getTextAttributes(element))
           @processedElements.push(element)

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -47,6 +47,10 @@ test "translates block element margins to newlines", ->
   document = Trix.HTMLParser.parse(html).getDocument()
   expectHTML document, expectedHTML
 
+test "preserves img's src", ->
+  html = """<img src="/test.jpg">"""
+  equal Trix.DocumentView.render(Trix.HTMLParser.parse(html).getDocument()).querySelector("img").attributes.src.value, "/test.jpg"
+
 asyncTest "sanitizes unsafe html", ->
   window.unsanitized = []
   Trix.HTMLParser.parse """


### PR DESCRIPTION
`element.src` converts a relative path to the absolute one, but `element.attributes.src.value` preserves the original value. 

This is for #102 