### PR TITLE
Leaf option for blocks

### DIFF
--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -241,6 +241,7 @@ class Trix.Composition extends Trix.BasicObject
       @setDocument(@document.addAttributeAtRange(attributeName, value, selectedRange))
 
   setBlockAttribute: (attributeName, value) ->
+    @removeLastBlockAttribute() if @getBlock()?.getConfig("leaf")
     return unless selectedRange = @getSelectedRange()
     @setDocument(@document.applyBlockAttributeAtRange(attributeName, value, selectedRange))
     @setSelection(selectedRange)


### PR DESCRIPTION
Adds the option to set a block attribute as a leaf. Leaf blocks cannot contain other nested blocks. 

Useful for stuff like headings. When the current block is an H1 and i press H2 I would expect the H1 to be replaced by an H2, not nested in it.
Fixes https://github.com/basecamp/trix/issues/133#issuecomment-166155477
