### PR TITLE
Fuzzy location mapping

### DIFF
--- a/src/trix/config/selection_elements.coffee
+++ b/src/trix/config/selection_elements.coffee
@@ -1,14 +1,6 @@
 {makeElement, defer} = Trix
 
 prototypes =
-  cursorPoint:
-    makeElement
-      tagName: "span"
-      data:
-        trixSelection: true
-        trixMutable: true
-        trixSerialize: false
-
   cursorTarget:
     makeElement
       tagName: "span"
@@ -31,10 +23,3 @@ Trix.extend
 
     create: (name) ->
       prototypes[name].cloneNode(true)
-
-    remove: (element) ->
-      {parentElement} = element
-      parentElement.dataset.trixMutable = true
-      parentElement.removeChild(element)
-      defer ->
-        delete parentElement.dataset.trixMutable

--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -84,10 +84,10 @@ class Trix.EditorController extends Trix.Controller
     @compositionController.uninstallAttachmentEditor()
     @attachmentLocationRange = null
 
-  compositionDidRequestChangingSelection: (requestedSelection) ->
+  compositionDidRequestChangingSelectionToLocationRange: (locationRange) ->
     return if @loadingSnapshot and not @isFocused()
-    @requestedSelection = requestedSelection
-    @documentWhenSelectionRequested = @composition.document
+    @requestedLocationRange = locationRange
+    @documentWhenLocationRangeRequested = @composition.document
     @render() unless @handlingInput
 
   compositionWillLoadSnapshot: ->
@@ -123,17 +123,13 @@ class Trix.EditorController extends Trix.Controller
     @editorElement.notify("sync")
 
   compositionControllerDidRender: ->
-    if @requestedSelection?
-      if @documentWhenSelectionRequested.isEqualTo(@composition.document)
-        {locationRange, pointRange} = @requestedSelection
-        if locationRange
-          @selectionManager.setLocationRange(locationRange)
-        else if pointRange
-          @selectionManager.setLocationRangeFromPointRange(pointRange)
+    if @requestedLocationRange?
+      if @documentWhenLocationRangeRequested.isEqualTo(@composition.document)
+        @selectionManager.setLocationRange(@requestedLocationRange)
 
       @composition.updateCurrentAttributes()
-      @requestedSelection = null
-      @documentWhenSelectionRequested = null
+      @requestedLocationRange = null
+      @documentWhenLocationRangeRequested = null
     @editorElement.notify("render")
 
   compositionControllerDidFocus: ->

--- a/src/trix/core/helpers/dom.coffee
+++ b/src/trix/core/helpers/dom.coffee
@@ -159,7 +159,8 @@ Trix.extend
     if strict
       Trix.nodeIsBlockStartComment(node)
     else
-      Trix.nodeProbablyIsBlockContainer(node)
+      Trix.nodeIsBlockStartComment(node) or
+        (not Trix.nodeIsBlockStartComment(node.firstChild) and Trix.nodeProbablyIsBlockContainer(node))
 
   nodeIsBlockStartComment: (node) ->
     Trix.nodeIsCommentNode(node) and node?.data is "block"

--- a/src/trix/core/helpers/dom.coffee
+++ b/src/trix/core/helpers/dom.coffee
@@ -145,8 +145,21 @@ Trix.extend
     fragment.appendChild(node) while node = container.firstChild
     fragment
 
+  getBlockTagNames: ->
+    Trix.blockTagNames ?= (value.tagName for key, value of Trix.config.blockAttributes)
+
   nodeIsBlockContainer: (node) ->
     Trix.nodeIsBlockStartComment(node?.firstChild)
+
+  nodeProbablyIsBlockContainer: (node) ->
+    Trix.tagName(node) in Trix.getBlockTagNames() and
+      Trix.tagName(node.firstChild) not in Trix.getBlockTagNames()
+
+  nodeIsBlockStart: (node, {strict} = strict: true) ->
+    if strict
+      Trix.nodeIsBlockStartComment(node)
+    else
+      Trix.nodeProbablyIsBlockContainer(node)
 
   nodeIsBlockStartComment: (node) ->
     Trix.nodeIsCommentNode(node) and node?.data is "block"

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -131,9 +131,10 @@ class Trix.Composition extends Trix.BasicObject
 
   replaceHTML: (html) ->
     document = Trix.Document.fromHTML(html).copyUsingObjectsFromDocument(@document)
-    pointRange = @getPointRange()
+    locationRange = @getLocationRange(strict: false)
+    selectedRange = @document.rangeFromLocationRange(locationRange)
     @setDocument(document)
-    @setSelectionPointRange(pointRange)
+    @setSelection(selectedRange)
 
   insertFile: (file) ->
     if @delegate?.compositionShouldAcceptFile(file)
@@ -333,10 +334,7 @@ class Trix.Composition extends Trix.BasicObject
 
   setSelection: (selectedRange) ->
     locationRange = @document.locationRangeFromRange(selectedRange)
-    @delegate?.compositionDidRequestChangingSelection({locationRange})
-
-  setSelectionPointRange: (pointRange) ->
-    @delegate?.compositionDidRequestChangingSelection({pointRange})
+    @delegate?.compositionDidRequestChangingSelectionToLocationRange(locationRange)
 
   getSelectedRange: ->
     if locationRange = @getLocationRange()
@@ -350,8 +348,8 @@ class Trix.Composition extends Trix.BasicObject
     if locationRange = @getLocationRange()
       @document.positionFromLocation(locationRange[0])
 
-  getLocationRange: ->
-    @getSelectionManager().getLocationRange() ? normalizeRange(index: 0, offset: 0)
+  getLocationRange: (options) ->
+    @getSelectionManager().getLocationRange(options) ? normalizeRange(index: 0, offset: 0)
 
   getExpandedRangeInDirection: (direction) ->
     [startPosition, endPosition] = @getSelectedRange()

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -1,4 +1,4 @@
-{arraysAreEqual, normalizeSpaces, makeElement, tagName, walkTree,
+{arraysAreEqual, normalizeSpaces, makeElement, tagName, getBlockTagNames, walkTree,
  findClosestElementFromNode, elementContainsNode, nodeIsAttachmentElement} = Trix
 
 class Trix.HTMLParser extends Trix.BasicObject
@@ -87,10 +87,7 @@ class Trix.HTMLParser extends Trix.BasicObject
   isBlockElement: (element) ->
     return unless element?.nodeType is Node.ELEMENT_NODE
     return if findClosestElementFromNode(element, matchingSelector: "td")
-    tagName(element) in @getBlockTagNames() or window.getComputedStyle(element).display is "block"
-
-  getBlockTagNames: ->
-    @blockTagNames ?= (value.tagName for key, value of Trix.config.blockAttributes)
+    tagName(element) in getBlockTagNames() or window.getComputedStyle(element).display is "block"
 
   processTextNode: (node) ->
     if string = normalizeSpaces(node.data)
@@ -193,7 +190,7 @@ class Trix.HTMLParser extends Trix.BasicObject
 
   getMarginOfBlockElementAtIndex: (index) ->
     if element = @blockElements[index]
-      unless tagName(element) in @getBlockTagNames() or element in @processedElements
+      unless tagName(element) in getBlockTagNames() or element in @processedElements
         getBlockElementMargin(element)
 
   getMarginOfDefaultBlockElement: ->

--- a/src/trix/models/location_mapper.coffee
+++ b/src/trix/models/location_mapper.coffee
@@ -1,12 +1,11 @@
-{elementContainsNode, findChildIndexOfNode, findClosestElementFromNode,
- findNodeFromContainerAndOffset, nodeIsBlockStartComment, nodeIsBlockContainer,
- nodeIsCursorTarget, nodeIsEmptyTextNode, nodeIsTextNode, nodeIsAttachmentElement,
- tagName, walkTree} = Trix
+{elementContainsNode, findChildIndexOfNode, findClosestElementFromNode, findNodeFromContainerAndOffset,
+ nodeIsBlockStart, nodeIsBlockStartComment, nodeIsBlockContainer, nodeIsCursorTarget,
+ nodeIsEmptyTextNode, nodeIsTextNode, nodeIsAttachmentElement, tagName, walkTree} = Trix
 
 class Trix.LocationMapper
   constructor: (@element) ->
 
-  findLocationFromContainerAndOffset: (container, offset) ->
+  findLocationFromContainerAndOffset: (container, offset, {strict} = strict: true) ->
     childIndex = 0
     foundBlock = false
     location = index: 0, offset: 0
@@ -31,7 +30,7 @@ class Trix.LocationMapper
         else unless elementContainsNode(container, node)
           break if childIndex > 0
 
-        if nodeIsBlockStartComment(node)
+        if nodeIsBlockStart(node, {strict})
           location.index++ if foundBlock
           location.offset = 0
           foundBlock = true

--- a/src/trix/models/point_mapper.coffee
+++ b/src/trix/models/point_mapper.coffee
@@ -1,17 +1,6 @@
-{getDOMRange, setDOMRange, findNodeFromContainerAndOffset,
- tagName, selectionElements, normalizeRange, defer} = Trix
+{getDOMRange, setDOMRange} = Trix
 
 class Trix.PointMapper
-  findPointRangeFromDOMRange: (domRange) ->
-    end = @findPointFromDOMRangeAtIndex(domRange, 1)
-    points = [end]
-
-    unless domRange.collapsed
-      start = @findPointFromDOMRangeAtIndex(domRange, 0)
-      points.unshift(start)
-
-    normalizeRange(points)
-
   createDOMRangeFromPoint: ({x, y}) ->
     if document.caretPositionFromPoint
       {offsetNode, offset} = document.caretPositionFromPoint(x, y)
@@ -37,38 +26,3 @@ class Trix.PointMapper
   getClientRectsForDOMRange: (domRange) ->
     [start, ..., end] = [domRange.getClientRects()...]
     [start, end]
-
-  # Private
-
-  findPointFromDOMRangeAtIndex: (domRange, index) ->
-    domRange = domRange.cloneRange()
-    side = if index is 0 then "start" else "end"
-    element = findNodeFromContainerAndOffset(domRange["#{side}Container"], domRange["#{side}Offset"])
-
-    if tagName(element) is "br"
-      rect = getClientRectForElement(element)
-      rect ?= @getClientRectsForDOMRange(domRange)[index]
-      if rect
-        x = rect.left
-        y = rect.bottom
-    else
-      element = selectionElements.create("cursorPoint")
-      domRange.collapse(false) if side is "end"
-      domRange.insertNode(element)
-      rect = element.getBoundingClientRect()
-      selectionElements.remove(element)
-      x = rect.left - index
-      y = rect.top + 1
-
-    if x? and y?
-      {x, y}
-
-  getClientRectForElement = (element) ->
-    rect = element.getBoundingClientRect()
-    rect if clientRectIsValid(rect)
-
-  # Android creates an empty bounding rect for
-  # BR elements where all values are 0.
-  clientRectIsValid = (rect) ->
-    return true for key, value of rect when Math.abs(value)
-    false

--- a/src/trix/models/selection_manager.coffee
+++ b/src/trix/models/selection_manager.coffee
@@ -14,10 +14,13 @@ class Trix.SelectionManager extends Trix.BasicObject
     handleEvent("mousedown", onElement: @element, withCallback: @didMouseDown)
 
   getLocationRange: (options = {}) ->
-    locationRange = if options.ignoreLock
-      @currentLocationRange
-    else
-      @lockedLocationRange ? @currentLocationRange
+    locationRange =
+      if options.strict is false
+        @createLocationRangeFromDOMRange(getDOMRange(), strict: false)
+      else if options.ignoreLock
+        @currentLocationRange
+      else
+        @lockedLocationRange ? @currentLocationRange
 
   setLocationRange: (locationRange) ->
     return if @lockedLocationRange
@@ -25,10 +28,6 @@ class Trix.SelectionManager extends Trix.BasicObject
     if domRange = @createDOMRangeFromLocationRange(locationRange)
       setDOMRange(domRange)
       @updateCurrentLocationRange(locationRange)
-
-  getPointRange: ->
-    if domRange = getDOMRange()
-      @findPointRangeFromDOMRange(domRange)
 
   setLocationRangeFromPointRange: (pointRange) ->
     pointRange = normalizeRange(pointRange)
@@ -69,7 +68,6 @@ class Trix.SelectionManager extends Trix.BasicObject
   @proxyMethod "locationMapper.findLocationFromContainerAndOffset"
   @proxyMethod "locationMapper.findContainerAndOffsetFromLocation"
   @proxyMethod "locationMapper.findNodeAndOffsetFromLocation"
-  @proxyMethod "pointMapper.findPointRangeFromDOMRange"
   @proxyMethod "pointMapper.createDOMRangeFromPoint"
   @proxyMethod "pointMapper.getClientRectsForDOMRange"
 
@@ -114,10 +112,10 @@ class Trix.SelectionManager extends Trix.BasicObject
       domRange.setEnd(rangeEnd...)
       domRange
 
-  createLocationRangeFromDOMRange: (domRange) ->
+  createLocationRangeFromDOMRange: (domRange, options) ->
     return unless domRange? and @domRangeWithinElement(domRange)
-    return unless start = @findLocationFromContainerAndOffset(domRange.startContainer, domRange.startOffset)
-    end = @findLocationFromContainerAndOffset(domRange.endContainer, domRange.endOffset) unless domRange.collapsed
+    return unless start = @findLocationFromContainerAndOffset(domRange.startContainer, domRange.startOffset, options)
+    end = @findLocationFromContainerAndOffset(domRange.endContainer, domRange.endOffset, options) unless domRange.collapsed
     normalizeRange([start, end])
 
   getLocationAtPoint: (point) ->

--- a/src/trix/observers/mutation_observer.coffee
+++ b/src/trix/observers/mutation_observer.coffee
@@ -42,7 +42,7 @@ class Trix.MutationObserver extends Trix.BasicObject
     false
 
   nodeIsSignificant: (node) ->
-    node? and node isnt @element and not @nodeIsMutable(node) and not nodeIsEmptyTextNode(node)
+    node isnt @element and not @nodeIsMutable(node) and not nodeIsEmptyTextNode(node)
 
   nodeIsMutable: (node) ->
     findClosestElementFromNode(node, matchingSelector: mutableSelector)

--- a/test/src/system/html_replacement_test.coffee
+++ b/test/src/system/html_replacement_test.coffee
@@ -1,60 +1,74 @@
-{assert, test, testGroup} = Trix.TestHelpers
+{assert, clickToolbarButton, collapseSelection, defer, moveCursor, selectNode, typeCharacters, test, testGroup, triggerEvent} = Trix.TestHelpers
 
-testGroup "HTML replacement", template: "editor_empty", ->
-  copyWith = (object, properties = {}) ->
-    result = {}
-    result[key] = value for key, value of object
-    result[key] = value for key, value of properties
-    result
+testGroup "HTML replacement", ->
+  testGroup "deleting with command+backspace", template: "editor_empty", ->
+    test "from the end of a line", (expectDocument) ->
+      getEditor().loadHTML("<div>a</div><blockquote>b</blockquote><div>c</div>")
+      getSelectionManager().setLocationRange(index: 1, offset: 1)
+      pressCommandBackspace replaceText: "b", ->
+        assert.locationRange(index: 1, offset: 0)
+        assert.blockAttributes [0, 2], []
+        assert.blockAttributes [2, 3], ["quote"]
+        assert.blockAttributes [3, 5], []
+        expectDocument("a\n\nc\n")
 
-  testCases =
-    "single character":
-      document: [{"text":[{"type":"string","attributes":{},"string":"a"},{"type":"string","attributes":{"blockBreak":true},"string":"\n"}],"attributes":[]}]
-      selections: [ 0, 1, [0,1] ]
+    test "in the first block", (expectDocument) ->
+      getEditor().loadHTML("<div>a</div><blockquote>b</blockquote>")
+      getSelectionManager().setLocationRange(index: 0, offset: 1)
+      pressCommandBackspace replaceText: "a", ->
+        assert.locationRange(index: 0, offset: 0)
+        assert.blockAttributes [0, 1], []
+        assert.blockAttributes [1, 3], ["quote"]
+        expectDocument("\nb\n")
 
-    "character and newline":
-      document: [{"text":[{"type":"string","attributes":{},"string":"a\n"},{"type":"string","attributes":{"blockBreak":true},"string":"\n"}],"attributes":[]}]
-      selections: [ 0, 1, 2, [0,1], [0,2] ]
+    test "from the middle of a line", (expectDocument) ->
+      getEditor().loadHTML("<div>a</div><blockquote>bc</blockquote><div>d</div>")
+      getSelectionManager().setLocationRange(index: 1, offset: 1)
+      pressCommandBackspace replaceText: "b", ->
+        assert.locationRange(index: 1, offset: 0)
+        assert.blockAttributes [0, 2], []
+        assert.blockAttributes [2, 4], ["quote"]
+        assert.blockAttributes [4, 6], []
+        expectDocument("a\nc\nd\n")
 
-    "bullets":
-      document: [{"text":[{"type":"string","attributes":{},"string":"a"},{"type":"string","attributes":{"blockBreak":true},"string":"\n"}],"attributes":["bulletList","bullet"]},{"text":[{"type":"string","attributes":{},"string":"b"},{"type":"string","attributes":{"blockBreak":true},"string":"\n"}],"attributes":["bulletList","bullet"]}]
-      selections: [ 0, 1, 2, 3, [0,1], [0,3], [2,3] ]
+    test "from the middle of a line in a multi-line block", (expectDocument) ->
+      getEditor().loadHTML("<div>a</div><blockquote>bc<br>d</blockquote><div>e</div>")
+      getSelectionManager().setLocationRange(index: 1, offset: 1)
+      pressCommandBackspace replaceText: "b", ->
+        assert.locationRange(index: 1, offset: 0)
+        assert.blockAttributes([0, 2], [])
+        assert.blockAttributes([2, 6], ["quote"])
+        expectDocument("a\nc\nd\ne\n")
 
-  for name, testCase of testCases
-    testCase.document = Trix.Document.fromJSON(testCase.document)
-    testCase.documentString = testCase.document.toString()
-    testCase.selections = testCase.selections.map (selection) -> Trix.normalizeRange(selection)
+    test "from the end of a list item", (expectDocument) ->
+      getEditor().loadHTML("<ul><li>a</li><li>b</li></ul>")
+      getSelectionManager().setLocationRange(index: 1, offset: 1)
+      pressCommandBackspace replaceText: "b", ->
+        assert.locationRange(index: 1, offset: 0)
+        assert.blockAttributes([0, 2], ["bulletList", "bullet"])
+        assert.blockAttributes([2, 4], ["bulletList", "bullet"])
+        expectDocument("a\n\n")
 
-  testStyles = [
-    {}
-    { textRendering: "optimizeSpeed" }
-    { textRendering: "optimizeLegibility" }
-    { textRendering: "geometricPrecision" }
-  ]
 
-  testStyleVariants = [
-    { padding: "3px" }
-  ]
+pressCommandBackspace = ({replaceText}, callback) ->
+  triggerEvent(document.activeElement, "keydown", charCode: 0, keyCode: 8, which: 8, metaKey: true)
 
-  for styles in testStyles
-    for variant in testStyleVariants
-      testStyles.push(copyWith(styles, variant))
+  range = rangy.getSelection().getRangeAt(0)
+  range.findText(replaceText, direction: "backward")
+  range.splitBoundaries()
 
-  for styles in testStyles
-    for name, testCase of testCases
-      for range in testCase.selections
-        do (styles, name, testCase, range) ->
-          test "#{name} with selected range #{JSON.stringify(range)} and styles #{JSON.stringify(styles)}", (expectDocument) ->
-            {document, documentString} = testCase
+  node = range.getNodes()[0]
+  {previousSibling, parentNode} = node
 
-            applyStyles(styles)
-            getEditor().loadDocument(document)
-            getEditor().setSelectedRange(range)
-            getComposition().replaceHTML(getEditorElement().innerHTML)
+  if previousSibling?.nodeType is Node.COMMENT_NODE
+    parentNode.removeChild(previousSibling)
 
-            assert.deepEqual getEditor().getSelectedRange(), range
-            expectDocument documentString
+  parentNode.removeChild(node)
 
-  applyStyles = (styles) ->
-    element = getEditorElement()
-    element.style[key] = value for key, value of styles
+  unless parentNode.hasChildNodes()
+    parentNode.appendChild(document.createElement("br"))
+
+  range.collapseBefore(parentNode.firstChild)
+  range.select()
+
+  requestAnimationFrame(callback)

--- a/test/src/test_helpers/test_stubs.coffee
+++ b/test/src/test_helpers/test_stubs.coffee
@@ -1,11 +1,8 @@
 {normalizeRange, rangeIsCollapsed} = Trix
 
 class Trix.TestCompositionDelegate
-  compositionDidRequestChangingSelection: ({locationRange, pointRange}) ->
-    if locationRange
-      @getSelectionManager().setLocationRange(locationRange)
-    else if pointRange
-      @getSelectionManager().setLocationRangeFromPointRange(pointRange)
+  compositionDidRequestChangingSelectionToLocationRange: ->
+    @getSelectionManager().setLocationRange(arguments...)
 
   getSelectionManager: ->
     @selectionManager ?= new Trix.TestSelectionManager


### PR DESCRIPTION
When re-parsing the editor's HTML, we create a location range using points because the unknown input may have removed Trix's block comment nodes. Calculating a location range from HTML with missing comment nodes would often result in the wrong cursor position after rendering. Usually off by 1, at the end of the preceding block. See #116 and #131.

Using points works well most of the time, but occasionally fails in conditions that are difficult to reproduce. This change removes the use of points, and goes back to using `LocationMapper`, but with a new `strict: false` mode that uses the containing elements to make an assumption about where a block starts. `getLocationRange(strict: false)` is only used by `Composition#replaceHTML` so all other `getLocationRange` calls continue to work as normal (looking for `<!--block-->` nodes to mark a block's start).