### PR TITLE
Fix handling pastes in browsers that don't support ClipboardEvent.clipboardData

### DIFF
--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -185,10 +185,9 @@ class Trix.InputController extends Trix.BasicObject
 
     paste: (event) ->
       paste = event.clipboardData ? event.testClipboardData
-      return unless paste?
       pasteData = {paste}
 
-      if pasteEventIsCrippledSafariHTMLPaste(event)
+      if not paste? or pasteEventIsCrippledSafariHTMLPaste(event)
         @getPastedHTMLUsingHiddenElement (html) =>
           pasteData.html = html
           @delegate?.inputControllerWillPasteText(pasteData)

--- a/test/src/system/pasting_test.coffee
+++ b/test/src/system/pasting_test.coffee
@@ -1,4 +1,4 @@
-{assert, clickToolbarButton, createFile, defer, expandSelection, moveCursor, pasteContent, pressKey, test, testGroup, typeCharacters} = Trix.TestHelpers
+{assert, clickToolbarButton, createFile, defer, expandSelection, moveCursor, pasteContent, pressKey, test, testGroup, triggerEvent, typeCharacters} = Trix.TestHelpers
 
 testGroup "Pasting", template: "editor_empty", ->
   test "paste plain text", (expectDocument) ->
@@ -174,3 +174,10 @@ testGroup "Pasting", template: "editor_empty", ->
     typeCharacters "a", ->
       pasteContent "Files", (createFile()), ->
         expectDocument "a#{Trix.OBJECT_REPLACEMENT_CHARACTER}\n"
+
+  test "paste event with no clipboardData", (expectDocument) ->
+    typeCharacters "a", ->
+      triggerEvent(document.activeElement, "paste")
+      document.activeElement.insertAdjacentHTML("beforeend", "<span>bc</span>")
+      requestAnimationFrame ->
+        expectDocument("abc\n")


### PR DESCRIPTION
Previously when Trix received a paste event with no `clipboardData`, we'd do nothing and assume the mutation observer would detect the change and cause an HTML re-parse. But because `Trix.MutationObserver` doesn't deeply traverse nodes, the mutation summary it returns could be empty depending on the pasted HTML. With a little logging, you can see this by inserting HTML into the editor:
```js
$("trix-editor").insertAdjacentHTML("beforeend", "hello")
=> mutationSummary = {"textAdded":"hello"}

$("trix-editor").insertAdjacentHTML("beforeend", "<p>hello</p>")
=> mutationSummary = {}
```

Instead of doing nothing, we can capture the paste using `getPastedHTMLUsingHiddenElement`, which a) fixes the problem of nothing pasting at all, and b) allows Trix to format insert the pasted HTML better.

Pasting in IE11 before:
![ie11paste](https://cloud.githubusercontent.com/assets/5355/12429252/31e3114a-beb7-11e5-87f0-377dbc5bf638.gif)

After:
![ie11paste-after](https://cloud.githubusercontent.com/assets/5355/12429259/3a4f73d2-beb7-11e5-8a2b-9cc3a9c2414d.gif)
