### PR TITLE
Avoid inheriting text attributes from parent block elements

### DIFF
--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -198,7 +198,7 @@ class Trix.HTMLParser extends Trix.BasicObject
     while element and element isnt @containerElement
       if tagName(element) in getBlockTagNames()
         ancestors.push(element)
-      element = element.parentElement
+      element = element.parentNode
     ancestors
 
   getMarginOfBlockElementAtIndex: (index) ->

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -167,7 +167,13 @@ class Trix.HTMLParser extends Trix.BasicObject
         attributes[attribute] = true
       else if config.parser
         if value = config.parser(element)
-          attributes[attribute] = value
+          attributeInheritedFromBlock = false
+          for blockElement in @findBlockElementAncestors(element.firstChild)
+            if config.parser(blockElement) is value
+              attributeInheritedFromBlock = true
+              break
+          unless attributeInheritedFromBlock
+            attributes[attribute] = value
 
     if nodeIsAttachmentElement(element)
       if json = element.dataset.trixAttributes
@@ -186,6 +192,14 @@ class Trix.HTMLParser extends Trix.BasicObject
             attributes.push(config.listAttribute) if config.listAttribute
       element = element.parentNode
     attributes.reverse()
+
+  findBlockElementAncestors: (element) ->
+    ancestors = []
+    while element and element isnt @containerElement
+      if tagName(element) in getBlockTagNames()
+        ancestors.push(element)
+      element = element.parentElement
+    ancestors
 
   getMarginOfBlockElementAtIndex: (index) ->
     if element = @blockElements[index]

--- a/test/src/system/html_loading_test.coffee
+++ b/test/src/system/html_loading_test.coffee
@@ -32,3 +32,18 @@ testGroup "HTML loading", ->
       getEditor().loadHTML("<article>a</article>")
       assert.textAttributes([0, 1], bold: true)
       expectDocument("a\n")
+
+  testGroup "styled block elements", template: "editor_with_block_styles", ->
+    test "<em> in <blockquote> with font-style: italic", (expectDocument) ->
+      getEditor().loadHTML("<blockquote>a<em>b</em></blockquote>")
+      assert.textAttributes([0, 1], {})
+      assert.textAttributes([1, 2], italic: true)
+      assert.blockAttributes([0, 2], ["quote"])
+      expectDocument("ab\n")
+
+    test "<strong> in <li> with font-weight: bold", (expectDocument) ->
+      getEditor().loadHTML("<ul><li>a<strong>b</strong></li></ul>")
+      assert.textAttributes([0, 1], {})
+      assert.textAttributes([1, 2], bold: true)
+      assert.blockAttributes([0, 2], ["bulletList","bullet"])
+      expectDocument("ab\n")

--- a/test/src/test_helpers/fixtures/editor_with_block_styles.jst.eco
+++ b/test/src/test_helpers/fixtures/editor_with_block_styles.jst.eco
@@ -1,0 +1,6 @@
+<style type="text/css">
+  blockquote { font-style: italic; }
+  li { font-weight: bold; }
+</style>
+
+<trix-editor class="trix-content"></trix-editor>


### PR DESCRIPTION
Fixes scenario where a block's styles match those of a text attribute. If the HTML was reparsed, the block's text would receive those attributes.

For example, if a page has italic styles for quotes:
```css
blockquote {
  font-style: italic;
}
```
This would happen on reparse:
![block-styles-before](https://cloud.githubusercontent.com/assets/5355/12434408/7a458216-bed4-11e5-8997-e7401782ded4.gif)
---
After this change:
![block-styles-after](https://cloud.githubusercontent.com/assets/5355/12434426/8a54fbe6-bed4-11e5-8b2f-215ab55a4480.gif)
