### PR TITLE
CSS clean-up

### DIFF
--- a/assets/trix/stylesheets/attachments.scss
+++ b/assets/trix/stylesheets/attachments.scss
@@ -49,9 +49,9 @@ trix-editor {
           margin: 0;
           padding: 0;
           font-size: 13px;
-          line-height: 13px;
+          line-height: 1;
           text-align: center;
-          border: none;
+          border: 0;
           outline: none;
           -webkit-appearance: none;
           -moz-appearance: none;

--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -57,7 +57,7 @@
 
     .caption {
       display: block;
-      margin: 4px auto 0 auto;
+      margin: 4px auto 0;
       padding: 0;
       text-align: center;
 

--- a/assets/trix/stylesheets/toolbar.scss
+++ b/assets/trix/stylesheets/toolbar.scss
@@ -81,7 +81,6 @@ trix-toolbar {
         width: auto;
         opacity: .6;
         -webkit-appearance: none;
-        -webkit-border-radius: 0;
       }
 
       input[type=url], input[type=text] {

--- a/assets/trix/stylesheets/toolbar.scss
+++ b/assets/trix/stylesheets/toolbar.scss
@@ -24,7 +24,7 @@ trix-toolbar {
       height: 28px;
       width: 40px;
       background: #fff;
-      border: none;
+      border: 0;
       border-bottom: 1px solid #ddd;
 
       &::before {
@@ -77,8 +77,7 @@ trix-toolbar {
       input[type=button] {
         font-size: 12px;
         height: 24px;
-        width: 50px;
-        padding: 1px 8px 0 8px;
+        padding: 1px 8px 0;
         width: auto;
         opacity: .6;
         -webkit-appearance: none;
@@ -100,7 +99,7 @@ trix-toolbar {
         -moz-appearance: none;
 
         &.validate:invalid {
-          box-shadow: #F00 0px 0px 1.5px 1px;
+          box-shadow: #F00 0 0 1.5px 1px;
         }
       }
 


### PR DESCRIPTION
I found a few minor aspects of the CSS that could be improved—no-brainers I hope—namely:
- A duplicated `width` declaration
- Some units being used unnecessarily
- `border: none` instead of `0`
- Shorthand declarations which could be a little shorter

---

Then there's some other more aesthetic formatting choices I could implement if anyone wants, but they'd probably be difficult to maintain in the long term unless a CI or something was actively linting for them:
- Comma separated selectors on their own lines (makes for better diffing and error reporting, I reckon)
- Double-quoted or single-quoted strings (mixed now, I prefer double)
- Leading 0 on decimal property values (more readable I think)
- All lower-case hex colour values `¯\_(ツ)_/¯`

Also happy to add an [scss-lint](https://github.com/brigade/scss-lint) config for these conventions, if that's wanted.
