### PR TITLE
Create a new block when the user presses return

### DIFF
--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -114,7 +114,7 @@ class Trix.Composition extends Trix.BasicObject
         else
           @insertString("\n")
     else
-      @insertString("\n")
+      @insertBlockBreak()
 
   insertHTML: (html) ->
     startPosition = @getPosition()

--- a/test/src/system/composition_input_test.coffee
+++ b/test/src/system/composition_input_test.coffee
@@ -21,6 +21,13 @@ testGroup "Composition input", template: "editor_empty", ->
       pressKey "return", ->
         expectDocument "ab\n\n"
 
+  test "pressing return creates new block", (expectDocument) ->
+    typeCharacters "ab", ->
+      pressKey "return", ->
+        document = getDocument()
+        assert.equal document.getBlockCount(), 2
+        expectDocument "ab\n\n"
+
   test "composing formatted text", (expectDocument) ->
     typeCharacters "abc", ->
       clickToolbarButton attribute: "bold", ->


### PR DESCRIPTION
With this change a new block is created when the user presses the return key.

This makes it possible to use `Trix.config.blockAttributes.default.tagName = "p"` to use `<p>` tags instead of `<div>` tags and have a new paragraph created by pressing return (see #117).
Pressing shift + return creates just a newline.
