### PR TITLE
Natural white space

### DIFF
--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -1,4 +1,6 @@
 .trix-content {
+  white-space: pre-wrap;
+
   blockquote {
     margin: 0 0 0 5px;
     padding: 0 0 0 10px;
@@ -10,7 +12,6 @@
     font-size: 12px;
     margin: 0;
     padding: 10px;
-    white-space: pre-wrap;
     background-color: #eee;
   }
 

--- a/src/trix/config/block_attributes.coffee
+++ b/src/trix/config/block_attributes.coffee
@@ -7,8 +7,6 @@ Trix.config.blockAttributes = attributes =
     nestable: true
   code:
     tagName: "pre"
-    text:
-      plaintext: true
   bulletList:
     tagName: "ul"
     parse: false

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -61,7 +61,7 @@ class Trix.InputController extends Trix.BasicObject
     unless @inputSummary.composing
       @handleInput ->
         unless @mutationIsExpected(mutationSummary)
-          @responder?.replaceHTML(@element.innerHTML)
+          @responder?.replaceHTML(@element.innerHTML, referenceElement: @element)
 
         @resetInputSummary()
         @requestRender()

--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -38,6 +38,10 @@ Trix.registerElement "trix-editor", do ->
   # Style
 
   defaultCSS: """
+    %t {
+      white-space: pre-wrap;
+    }
+
     %t:empty:not(:focus)::before {
       content: attr(placeholder);
       color: graytext;

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -129,8 +129,8 @@ class Trix.Composition extends Trix.BasicObject
     @setSelection(endPosition)
     @notifyDelegateOfInsertionAtRange([endPosition, endPosition])
 
-  replaceHTML: (html) ->
-    document = Trix.Document.fromHTML(html).copyUsingObjectsFromDocument(@document)
+  replaceHTML: (html, options) ->
+    document = Trix.Document.fromHTML(html, options).copyUsingObjectsFromDocument(@document)
     locationRange = @getLocationRange(strict: false)
     selectedRange = @document.rangeFromLocationRange(locationRange)
     @setDocument(document)

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -51,6 +51,7 @@ class Trix.HTMLParser extends Trix.BasicObject
   processNode: (node) ->
     switch node.nodeType
       when Node.TEXT_NODE
+        @appendBlockForElement(node)
         @processTextNode(node)
       when Node.ELEMENT_NODE
         @appendBlockForElement(node)

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -72,12 +72,12 @@ class Trix.HTMLParser extends Trix.BasicObject
         @currentBlockElement = null
 
   findParentBlockElement: (element) ->
-    {parentElement} = element
-    while parentElement and parentElement isnt @containerElement
-      if @isBlockElement(parentElement) and parentElement in @blockElements
-        return parentElement
+    {parentNode} = element
+    while parentNode and parentNode isnt @containerElement
+      if @isBlockElement(parentNode) and parentNode in @blockElements
+        return parentNode
       else
-        {parentElement} = parentElement
+        {parentNode} = parentNode
     null
 
   isExtraBR: (element) ->

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -51,28 +51,28 @@ class Trix.HTMLParser extends Trix.BasicObject
   processNode: (node) ->
     switch node.nodeType
       when Node.TEXT_NODE
-        @appendBlockForElement(node)
+        @appendBlockForNode(node)
         @processTextNode(node)
       when Node.ELEMENT_NODE
-        @appendBlockForElement(node)
+        @appendBlockForNode(node)
         @processElement(node)
 
-  appendBlockForElement: (element) ->
-    if @isBlockElement(element) and not @isBlockElement(element.firstChild)
-      attributes = @getBlockAttributes(element)
-      unless elementContainsNode(@currentBlockElement, element) and arraysAreEqual(attributes, @currentBlock.attributes)
-        @currentBlock = @appendBlockForAttributesWithElement(attributes, element)
-        @currentBlockElement = element
+  appendBlockForNode: (node) ->
+    if @isBlockElement(node) and not @isBlockElement(node.firstChild)
+      attributes = @getBlockAttributes(node)
+      unless elementContainsNode(@currentBlockElement, node) and arraysAreEqual(attributes, @currentBlock.attributes)
+        @currentBlock = @appendBlockForAttributesWithElement(attributes, node)
+        @currentBlockElement = node
 
-    else if @currentBlockElement and not elementContainsNode(@currentBlockElement, element) and not @isBlockElement(element)
-      if parentBlockElement = @findParentBlockElement(element)
-        @appendBlockForElement(parentBlockElement)
+    else if @currentBlockElement and not elementContainsNode(@currentBlockElement, node) and not @isBlockElement(node)
+      if parentBlockElement = @findParentBlockElement(node)
+        @appendBlockForNode(parentBlockElement)
       else
         @currentBlock = @appendEmptyBlock()
         @currentBlockElement = null
 
-  findParentBlockElement: (element) ->
-    {parentNode} = element
+  findParentBlockElement: (node) ->
+    {parentNode} = node
     while parentNode and parentNode isnt @containerElement
       if @isBlockElement(parentNode) and parentNode in @blockElements
         return parentNode

--- a/src/trix/views/block_view.coffee
+++ b/src/trix/views/block_view.coffee
@@ -14,8 +14,7 @@ class Trix.BlockView extends Trix.ObjectView
     if @block.isEmpty()
       nodes.push(makeElement("br"))
     else
-      textConfig = Trix.config.blockAttributes[@block.getLastAttribute()]?.text
-      textView = @findOrCreateCachedChildView(Trix.TextView, @block.text, {textConfig})
+      textView = @findOrCreateCachedChildView(Trix.TextView, @block.text)
       nodes.push(textView.getNodes()...)
       nodes.push(makeElement("br")) if @shouldAddExtraNewlineElement()
 

--- a/src/trix/views/piece_view.coffee
+++ b/src/trix/views/piece_view.coffee
@@ -8,7 +8,6 @@ class Trix.PieceView extends Trix.ObjectView
     super
     @piece = @object
     @attributes = @piece.getAttributes()
-    {@textConfig} = @options
 
     if @piece.attachment
       @attachment = @piece.attachment
@@ -19,7 +18,7 @@ class Trix.PieceView extends Trix.ObjectView
     nodes = if @attachment
       @createAttachmentNodes()
     else
-      @createStringNodes()
+      [document.createTextNode(@string)]
 
     if element = @createElement()
       innerElement = findInnerElement(element)
@@ -35,21 +34,6 @@ class Trix.PieceView extends Trix.ObjectView
 
     view = @createChildView(constructor, @piece.attachment, {@piece})
     view.getNodes()
-
-  createStringNodes: ->
-    if @textConfig?.plaintext
-      [document.createTextNode(@string)]
-    else
-      nodes = []
-      for substring, index in @string.split("\n")
-        if index > 0
-          element = makeElement("br")
-          nodes.push(element)
-
-        if length = substring.length
-          node = document.createTextNode(preserveSpaces(substring))
-          nodes.push(node)
-      nodes
 
   createElement: ->
     for key of @attributes when config = Trix.config.textAttributes[key]
@@ -79,12 +63,3 @@ class Trix.PieceView extends Trix.ObjectView
         attributes = {}
         attributes[key] = value
         return makeElement(config.groupTagName, attributes)
-
-  preserveSpaces = (string) ->
-    nbsp = Trix.NON_BREAKING_SPACE
-    string
-      .replace(/\ $/, nbsp)
-      .replace(/(\S)\ {3}(\S)/g, "$1 #{nbsp} $2")
-      .replace(/\ {2}/g, "#{nbsp} ")
-      .replace(/\ {2}/g, " #{nbsp}")
-      .replace(/^\ /, nbsp)

--- a/src/trix/views/text_view.coffee
+++ b/src/trix/views/text_view.coffee
@@ -4,13 +4,12 @@ class Trix.TextView extends Trix.ObjectView
   constructor: ->
     super
     @text = @object
-    {@textConfig} = @options
 
   createNodes: ->
     nodes = []
     pieces = (piece for piece in @text.getPieces() when not piece.hasAttribute("blockBreak"))
     objects = Trix.ObjectGroup.groupObjects(pieces)
     for object in objects
-      view = @findOrCreateCachedChildView(Trix.PieceView, object, {@textConfig})
+      view = @findOrCreateCachedChildView(Trix.PieceView, object)
       nodes.push(view.getNodes()...)
     nodes

--- a/test/src/test_helpers/fixtures/fixtures.coffee
+++ b/test/src/test_helpers/fixtures/fixtures.coffee
@@ -17,9 +17,6 @@ cursorTarget = Trix.makeElement(
   data: trixSelection: true, trixCursorTarget: true, trixSerialize: false
 ).outerHTML
 
-removeWhitespace = (string) ->
-  string.replace(/\s/g, "")
-
 @fixtures =
   "bold text":
     document: createDocument(["abc", bold: true])
@@ -32,7 +29,7 @@ removeWhitespace = (string) ->
 
   "text with newline":
     document: createDocument(["ab\nc"])
-    html: "<div>#{blockComment}ab<br>c</div>"
+    html: "<div>#{blockComment}ab\nc</div>"
 
   "text with link":
     document: createDocument(["abc", href: "http://example.com"])
@@ -50,50 +47,6 @@ removeWhitespace = (string) ->
         ]
       ]
     html: """<div>#{blockComment}<a href="http://example.com">ab<em>c</em></a></div>"""
-
-  "spaces 1":
-    document: createDocument([" a"])
-    html: """<div>#{blockComment}&nbsp;a</div>"""
-
-  "spaces 2":
-    document: createDocument(["  a"])
-    html: """<div>#{blockComment}&nbsp; a</div>"""
-
-  "spaces 3":
-    document: createDocument(["   a"])
-    html: """<div>#{blockComment}&nbsp; &nbsp;a</div>"""
-
-  "spaces 4":
-    document: createDocument([" a "])
-    html: """<div>#{blockComment}&nbsp;a&nbsp;</div>"""
-
-  "spaces 5":
-    document: createDocument(["a  b"])
-    html: """<div>#{blockComment}a&nbsp; b</div>"""
-
-  "spaces 6":
-    document: createDocument(["a   b"])
-    html: """<div>#{blockComment}a &nbsp; b</div>"""
-
-  "spaces 7":
-    document: createDocument(["a    b"])
-    html: """<div>#{blockComment}a&nbsp; &nbsp; b</div>"""
-
-  "spaces 8":
-    document: createDocument(["a b "])
-    html: """<div>#{blockComment}a b&nbsp;</div>"""
-
-  "spaces 9":
-    document: createDocument(["a b c"])
-    html: """<div>#{blockComment}a b c</div>"""
-
-  "spaces 10":
-    document: createDocument(["a "])
-    html: """<div>#{blockComment}a&nbsp;</div>"""
-
-  "spaces 11":
-    document: createDocument(["a  "])
-    html: """<div>#{blockComment}a &nbsp;</div>"""
 
   "quote formatted block":
     document: createDocument(["abc", {}, ["quote"]])
@@ -222,8 +175,8 @@ removeWhitespace = (string) ->
 
     text = stringText.appendText(attachmentText)
 
-    html: "<div>#{blockComment}a<br>b#{cursorTarget}#{figure.outerHTML}#{cursorTarget}</div>"
-    serializedHTML: "<div>a<br>b#{serializedFigure.outerHTML}</div>"
+    html: "<div>#{blockComment}a\nb#{cursorTarget}#{figure.outerHTML}#{cursorTarget}</div>"
+    serializedHTML: "<div>a\nb#{serializedFigure.outerHTML}</div>"
     document: new Trix.Document [new Trix.Block text]
 
   "image attachment with edited caption": do ->
@@ -323,44 +276,8 @@ removeWhitespace = (string) ->
       ["\nc\n", {}, ["quote"]],
       ["d", {}, ["quote", "code"]]
     )
-    html: removeWhitespace """
-      <blockquote>
-        #{blockComment}
-        a
-        <br>
-        <br>
-        <pre>
-          #{blockComment}
-          b
-        </pre>
-        #{blockComment}
-        <br>
-        c
-        <br>
-        <br>
-        <pre>
-          #{blockComment}
-          d
-        </pre>
-      </blockquote>
-    """
-    serializedHTML: removeWhitespace """
-      <blockquote>
-        a
-        <br>
-        <br>
-        <pre>
-          b
-        </pre>
-        <br>
-        c
-        <br>
-        <br>
-        <pre>
-          d
-        </pre>
-      </blockquote>
-    """
+    html: "<blockquote>#{blockComment}a\n<br><pre>#{blockComment}b</pre>#{blockComment}\nc\n<br><pre>#{blockComment}d</pre></blockquote>"
+    serializedHTML: "<blockquote>a\n<br><pre>b</pre>\nc\n<br><pre>d</pre></blockquote>"
 
   "nested code, quote, and list in quote":
     document: createDocument(
@@ -371,64 +288,8 @@ removeWhitespace = (string) ->
       ["\ne\n", {}, ["quote"]],
       ["f", {}, ["quote", "bulletList", "bullet"]]
     )
-    html: removeWhitespace """
-     <blockquote>
-      #{blockComment}
-      a
-      <br>
-      <br>
-      <pre>
-        #{blockComment}
-        b
-      </pre>
-      #{blockComment}
-      <br>
-      c
-      <br>
-      <br>
-      <blockquote>
-        #{blockComment}
-        d
-      </blockquote>
-      #{blockComment}
-      <br>
-      e
-      <br>
-      <br>
-      <ul>
-        <li>
-          #{blockComment}
-          f
-        </li>
-      </ul>
-    </blockquote>
-    """
-    serializedHTML: removeWhitespace """
-      <blockquote>
-        a
-        <br>
-        <br>
-        <pre>
-          b
-        </pre>
-        <br>
-        c
-        <br>
-        <br>
-        <blockquote>
-          d
-        </blockquote>
-        <br>
-        e
-        <br>
-        <br>
-        <ul>
-          <li>
-            f
-          </li>
-        </ul>
-      </blockquote>
-    """
+    html: "<blockquote>#{blockComment}a\n<br><pre>#{blockComment}b</pre>#{blockComment}\nc\n<br><blockquote>#{blockComment}d</blockquote>#{blockComment}\ne\n<br><ul><li>#{blockComment}f</li></ul></blockquote>"
+    serializedHTML: "<blockquote>a\n<br><pre>b</pre>\nc\n<br><blockquote>d</blockquote>\ne\n<br><ul><li>f</li></ul></blockquote>"
 
   "nested quote and list":
     document: createDocument(["ab3", {}, ["quote", "bulletList", "bullet"]])
@@ -456,7 +317,7 @@ removeWhitespace = (string) ->
 
   "blocks beginning with newlines":
     document: createDocument(["\na", {}, ["quote"]], ["\nb", {}, []], ["\nc", {}, ["quote"]])
-    html: "<blockquote>#{blockComment}<br>a</blockquote><div>#{blockComment}<br>b</div><blockquote>#{blockComment}<br>c</blockquote>"
+    html: "<blockquote>#{blockComment}\na</blockquote><div>#{blockComment}\nb</div><blockquote>#{blockComment}\nc</blockquote>"
 
   "blocks beginning with formatted text":
     document: createDocument(["a", { bold: true }, ["quote"]], ["b", { italic: true }, []], ["c", { bold: true }, ["quote"]])
@@ -464,7 +325,7 @@ removeWhitespace = (string) ->
 
   "text with newlines before block":
     document: createDocument(["a\nb"], ["c", {}, ["quote"]])
-    html: "<div>#{blockComment}a<br>b</div><blockquote>#{blockComment}c</blockquote>"
+    html: "<div>#{blockComment}a\nb</div><blockquote>#{blockComment}c</blockquote>"
 
 @eachFixture = (callback) ->
   for name, details of @fixtures

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -47,10 +47,22 @@ testGroup "Trix.HTMLParser", ->
     expectedHTML = """<div><!--block-->a</div><div><!--block-->b</div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
+  test "preserves consecutive spaces", ->
+    html = """<div>a   b  c</div>"""
+    expectedHTML = """<div><!--block-->a   b  c</div>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
   test "converts newlines to spaces", ->
     html = "<div>a\nb \nc \n d \n\ne</div><pre>1\n2</pre>"
     expectedHTML = """<div><!--block-->a b c d e</div><pre><!--block-->1\n2</pre>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
+  test "preserves newlines if the reference element can render them", (done) ->
+    html = "<div>a\n\nb</div>"
+    expectedHTML = """<div><!--block-->a\n\nb</div>"""
+    getReferenceElement (referenceElement) ->
+      assert.documentHTMLEqual Trix.HTMLParser.parse(html, {referenceElement}).getDocument(), expectedHTML
+      done()
 
   test "parses entire HTML document", ->
     html = """<html><head><style>.bold {font-weight: bold}</style></head><body><span class="bold">abc</span></body></html>"""

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -2,15 +2,19 @@
 
 testGroup "Trix.HTMLParser", ->
   eachFixture (name, {html, serializedHTML, document}) ->
-    test name, ->
-      parsedDocument = Trix.HTMLParser.parse(html).getDocument()
-      assert.documentHTMLEqual parsedDocument.copyUsingObjectsFromDocument(document), html
+    test name, (done) ->
+      getReferenceElement (referenceElement) ->
+        parsedDocument = Trix.HTMLParser.parse(html, {referenceElement}).getDocument()
+        assert.documentHTMLEqual parsedDocument.copyUsingObjectsFromDocument(document), html
+        done()
 
   eachFixture (name, {html, serializedHTML, document}) ->
     if serializedHTML?
-      test "#{name} (serialized)", ->
-        parsedDocument = Trix.HTMLParser.parse(serializedHTML).getDocument()
-        assert.documentHTMLEqual parsedDocument.copyUsingObjectsFromDocument(document), html
+      test "#{name} (serialized)", (done) ->
+        getReferenceElement (referenceElement) ->
+          parsedDocument = Trix.HTMLParser.parse(serializedHTML, {referenceElement}).getDocument()
+          assert.documentHTMLEqual parsedDocument.copyUsingObjectsFromDocument(document), html
+          done()
 
   test "parses absolute image URLs", ->
     src = "#{getOrigin()}/test_helpers/fixtures/logo.png"
@@ -30,7 +34,7 @@ testGroup "Trix.HTMLParser", ->
 
   test "parses unfamiliar html", ->
     html = """<meta charset="UTF-8"><span style="font-style: italic">abc</span><span>d</span><section style="margin:0"><blink>123</blink><a href="http://example.com">45<b>6</b></a>x<br />y</section><p style="margin:0">9</p>"""
-    expectedHTML = """<div><!--block--><em>abc</em>d</div><div><!--block-->123<a href="http://example.com">45<strong>6</strong></a>x<br>y</div><div><!--block-->9</div>"""
+    expectedHTML = """<div><!--block--><em>abc</em>d</div><div><!--block-->123<a href="http://example.com">45<strong>6</strong></a>x\ny</div><div><!--block-->9</div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
   test "ignores leading whitespace before <meta> tag", ->
@@ -60,12 +64,12 @@ testGroup "Trix.HTMLParser", ->
 
   test "translates tables into plain text", ->
     html = """<table><tr><td>a</td><td>b</td></tr><tr><td>1</td><td><p>2</p></td></tr><table>"""
-    expectedHTML = """<div><!--block-->a | b<br>1 | 2</div>"""
+    expectedHTML = """<div><!--block-->a | b\n1 | 2</div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
   test "translates block element margins to newlines", ->
     html = """<p style="margin: 0 0 1em 0">a</p><p style="margin: 0">b</p><article style="margin: 1em 0 0 0">c</article>"""
-    expectedHTML = """<div><!--block-->a<br><br></div><div><!--block-->b</div><div><!--block--><br>c</div>"""
+    expectedHTML = """<div><!--block-->a\n<br></div><div><!--block-->b</div><div><!--block-->\nc</div>"""
     document = Trix.HTMLParser.parse(html).getDocument()
     assert.documentHTMLEqual document, expectedHTML
 
@@ -86,3 +90,18 @@ testGroup "Trix.HTMLParser", ->
 getOrigin = ->
   {protocol, hostname, port} = window.location
   "#{protocol}//#{hostname}#{if port then ":#{port}" else ""}"
+
+getReferenceElement = (callback) ->
+  if element = document.getElementById("reference_element")
+    callback(element)
+  else
+    element = document.createElement("trix-editor")
+    element.id = "reference_element"
+    element.addEventListener "trix-initialize", -> callback(element)
+
+    container = document.createElement("div")
+    container.style.position = "absolute"
+    container.style.left = "-9999px"
+
+    container.appendChild(element)
+    document.body.appendChild(container)

--- a/test/src/unit/location_mapper_test.coffee
+++ b/test/src/unit/location_mapper_test.coffee
@@ -7,8 +7,7 @@ testGroup "Trix.LocationMapper", ->
       # 0 <div>
       #     0 <!--block-->
       #     1 <strong>
-      #         0 a
-      #         1 <br>
+      #         0 a\n
       #       </strong>
       #     2 <br>
       #   </div>
@@ -46,7 +45,6 @@ testGroup "Trix.LocationMapper", ->
       { location: [0, 0],  container: [0, 1],     offset: 0 }
       { location: [0, 0],  container: [0, 1, 0],  offset: 0 }
       { location: [0, 1],  container: [0, 1, 0],  offset: 1 }
-      { location: [0, 1],  container: [0, 1],     offset: 1 }
       { location: [0, 2],  container: [0, 1],     offset: 2 }
       { location: [0, 2],  container: [0],        offset: 2 }
       { location: [0, 3],  container: [],         offset: 1 }
@@ -113,8 +111,7 @@ testGroup "Trix.LocationMapper", ->
       # 0 <div>
       #     0 <!--block-->
       #     0 <strong>
-      #         0 a
-      #         1 <br>
+      #         0 a\n
       #       </strong>
       #   </div>
       # </trix-document>
@@ -125,7 +122,7 @@ testGroup "Trix.LocationMapper", ->
     ]
 
     location = index: 0, offset: 2
-    container = findContainer([0])
+    container = findContainer([0, 1, 0])
     offset = 2
 
     assert.deepEqual mapper.findContainerAndOffsetFromLocation(location), [container, offset]


### PR DESCRIPTION
This change uses `white-space: pre-wrap;` for rendering newlines and consecutive spaces, and fixes #152. It's fundamentally simpler since we no longer have to render alternating `&nbsp;` to display consecutive spaces or split strings on `\n` and render `<br>`s. Less nodes are required for rendering, which yields a nice performance boost too.

---

Before and after using this document
<img width="177" alt="screen shot 2016-02-26 at 3 06 55 pm" src="https://cloud.githubusercontent.com/assets/5355/13364318/2b8180f4-dc9c-11e5-995f-0038fa3b3af7.png">

Rendered HTML *before*:
```html
<div><strong>hello</strong>&nbsp;world<br><br><em>how</em>&nbsp;&nbsp;<del>are</del>&nbsp; &nbsp;you?<br><br></div>
```

Rendered HTML *after*:
```html
<div><strong>hello</strong> world

<em>how</em>  <del>are</del>   you?
<br></div>
```

Render time *before*:
```
Rendered 10000 times
  Average: 0.131 ms
  Total: 1305.215 ms
```

Render time *after*:
```
Rendered 10000 times
  Average: 0.071 ms
  Total: 707.095 ms
```
(benchmarking setup: https://gist.github.com/javan/61544cded83763660693)

---

A potential downside is the HTML is less portable and requires its container to be styled with `white-space: pre-wrap;`, which I added to `trix.css`. I think the overall simplicity is worth that tradeoff.

/cc @sstephenson 

Trix build of this branch: [trix.zip](https://github.com/basecamp/trix/files/161929/trix.zip)