### PR TITLE
Fix parsing whitespace-only text nodes

### DIFF
--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -79,11 +79,6 @@ class Trix.HTMLParser extends Trix.BasicObject
         {parentElement} = parentElement
     null
 
-  isExtraBR: (element) ->
-    tagName(element) is "br" and
-      isBlockElement(element.parentNode) and
-      element.parentNode.lastChild is element
-
   processTextNode: (node) ->
     if string = normalizeSpaces(node.data)
       unless elementCanDisplayNewlines(node.parentNode)
@@ -102,7 +97,7 @@ class Trix.HTMLParser extends Trix.BasicObject
     else
       switch tagName(element)
         when "br"
-          unless @isExtraBR(element) or isBlockElement(element.nextSibling)
+          unless isExtraBR(element) or isBlockElement(element.nextSibling)
             @appendStringWithAttributes("\n", @getTextAttributes(element))
           @processedElements.push(element)
         when "img"
@@ -274,6 +269,11 @@ class Trix.HTMLParser extends Trix.BasicObject
     return unless /^\s*$/.test(node.data)
     return if elementCanDisplayNewlines(node.parentNode)
     isBlockElement(node.previousSibling) and isBlockElement(node.nextSibling)
+
+  isExtraBR = (element) ->
+    tagName(element) is "br" and
+      isBlockElement(element.parentNode) and
+      element.parentNode.lastChild is element
 
   elementCanDisplayNewlines = (element) ->
     {whiteSpace} = window.getComputedStyle(element)

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -232,7 +232,6 @@ class Trix.HTMLParser extends Trix.BasicObject
     JSON.parse(element.dataset.trixAttachment)
 
   sanitizeHTML = (html) ->
-    html = removeInsignificantWhitespace(html)
     doc = document.implementation.createHTMLDocument("")
     doc.documentElement.innerHTML = html
     {body, head} = doc
@@ -261,11 +260,6 @@ class Trix.HTMLParser extends Trix.BasicObject
       node.parentNode.removeChild(node)
 
     body.innerHTML
-
-  removeInsignificantWhitespace = (html) ->
-    html
-      .replace(/>\n+</g, "><")
-      .replace(/>\ +</g, "> <")
 
   convertNewlinesToSpaces = (string) ->
     string.replace(/\s?\n\s?/g, " ")

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -57,13 +57,13 @@ class Trix.HTMLParser extends Trix.BasicObject
         @processElement(node)
 
   appendBlockForElement: (element) ->
-    if @isBlockElement(element) and not @isBlockElement(element.firstChild)
+    if isBlockElement(element) and not isBlockElement(element.firstChild)
       attributes = @getBlockAttributes(element)
       unless elementContainsNode(@currentBlockElement, element) and arraysAreEqual(attributes, @currentBlock.attributes)
         @currentBlock = @appendBlockForAttributesWithElement(attributes, element)
         @currentBlockElement = element
 
-    else if @currentBlockElement and not elementContainsNode(@currentBlockElement, element) and not @isBlockElement(element)
+    else if @currentBlockElement and not elementContainsNode(@currentBlockElement, element) and not isBlockElement(element)
       if parentBlockElement = @findParentBlockElement(element)
         @appendBlockForElement(parentBlockElement)
       else
@@ -73,7 +73,7 @@ class Trix.HTMLParser extends Trix.BasicObject
   findParentBlockElement: (element) ->
     {parentElement} = element
     while parentElement and parentElement isnt @containerElement
-      if @isBlockElement(parentElement) and parentElement in @blockElements
+      if isBlockElement(parentElement) and parentElement in @blockElements
         return parentElement
       else
         {parentElement} = parentElement
@@ -81,13 +81,8 @@ class Trix.HTMLParser extends Trix.BasicObject
 
   isExtraBR: (element) ->
     tagName(element) is "br" and
-      @isBlockElement(element.parentNode) and
+      isBlockElement(element.parentNode) and
       element.parentNode.lastChild is element
-
-  isBlockElement: (element) ->
-    return unless element?.nodeType is Node.ELEMENT_NODE
-    return if findClosestElementFromNode(element, matchingSelector: "td")
-    tagName(element) in getBlockTagNames() or window.getComputedStyle(element).display is "block"
 
   processTextNode: (node) ->
     if string = normalizeSpaces(node.data)
@@ -107,7 +102,7 @@ class Trix.HTMLParser extends Trix.BasicObject
     else
       switch tagName(element)
         when "br"
-          unless @isExtraBR(element) or @isBlockElement(element.nextSibling)
+          unless @isExtraBR(element) or isBlockElement(element.nextSibling)
             @appendStringWithAttributes("\n", @getTextAttributes(element))
           @processedElements.push(element)
         when "img"
@@ -259,7 +254,7 @@ class Trix.HTMLParser extends Trix.BasicObject
         when Node.COMMENT_NODE
           nodesToRemove.push(node)
         when Node.TEXT_NODE
-          if node.data.match(/^\s*$/) and node.parentNode is body
+          if isInsignificantTextNode(node)
             nodesToRemove.push(node)
 
     for node in nodesToRemove
@@ -274,6 +269,17 @@ class Trix.HTMLParser extends Trix.BasicObject
 
   convertNewlinesToSpaces = (string) ->
     string.replace(/\s?\n\s?/g, " ")
+
+  isBlockElement = (element) ->
+    return unless element?.nodeType is Node.ELEMENT_NODE
+    return if findClosestElementFromNode(element, matchingSelector: "td")
+    tagName(element) in getBlockTagNames() or window.getComputedStyle(element).display is "block"
+
+  isInsignificantTextNode = (node) ->
+    return unless node?.nodeType is Node.TEXT_NODE
+    return unless /^\s*$/.test(node.data)
+    return if elementCanDisplayNewlines(node.parentNode)
+    isBlockElement(node.previousSibling) and isBlockElement(node.nextSibling)
 
   elementCanDisplayNewlines = (element) ->
     {whiteSpace} = window.getComputedStyle(element)

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -58,6 +58,11 @@ testGroup "Trix.HTMLParser", ->
     expectedHTML = """<blockquote><!--block-->abc</blockquote><div><!--block--><strong>123</strong></div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
+  test "parses whitespace-only text nodes without a containing block element", ->
+    html = """a <strong>b</strong> <em>c</em>"""
+    expectedHTML = """<div><!--block-->a&nbsp;<strong>b</strong>&nbsp;<em>c</em></div>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
   test "translates tables into plain text", ->
     html = """<table><tr><td>a</td><td>b</td></tr><tr><td>1</td><td><p>2</p></td></tr><table>"""
     expectedHTML = """<div><!--block-->a | b<br>1 | 2</div>"""


### PR DESCRIPTION
Fix for #208. This issue only occurred when parsing HTML without a containing block element. Text nodes containing only whitespace characters were incorrectly identified as insignificant space between elements and ignored.

Before:
```js
Trix.HTMLParser.parse("<em>a</em> <strong>b</strong> <em>c</em>").getDocument().toString()
=> "abc\n"
```

After:
```js
Trix.HTMLParser.parse("<em>a</em> <strong>b</strong> <em>c</em>").getDocument().toString()
=> "a b c\n"
```
Build of this branch: [trix.zip](https://github.com/basecamp/trix/files/180149/trix.zip)