### PR TITLE
Fix selection error when clicking some input elements. Fixes #209

### DIFF
--- a/src/trix/core/helpers/selection.coffee
+++ b/src/trix/core/helpers/selection.coffee
@@ -4,10 +4,22 @@ Trix.extend
     selection if selection.rangeCount > 0
 
   getDOMRange: ->
-    Trix.getDOMSelection()?.getRangeAt(0)
+    if domRange = Trix.getDOMSelection()?.getRangeAt(0)
+      unless domRangeIsPrivate(domRange)
+        domRange
 
   setDOMRange: (domRange) ->
     selection = window.getSelection()
     selection.removeAllRanges()
     selection.addRange(domRange)
     Trix.selectionChangeObserver.update()
+
+# In Firefox, clicking certain <input> elements changes the selection to a
+# private element used to draw its UI. Attempting to access properties of those
+# elements throws an error.
+# https://bugzilla.mozilla.org/show_bug.cgi?id=208427
+domRangeIsPrivate = (domRange) ->
+  nodeIsPrivate(domRange.startContainer) or nodeIsPrivate(domRange.endContainer)
+
+nodeIsPrivate = (node) ->
+  not Object.getPrototypeOf(node)

--- a/src/trix/observers/selection_change_observer.coffee
+++ b/src/trix/observers/selection_change_observer.coffee
@@ -1,3 +1,5 @@
+{getDOMRange} = Trix
+
 class Trix.SelectionChangeObserver extends Trix.BasicObject
   constructor: ->
     @selectionManagers = []
@@ -44,10 +46,6 @@ class Trix.SelectionChangeObserver extends Trix.BasicObject
     if @started
       @update()
       requestAnimationFrame(@run)
-
-  getDOMRange = ->
-    selection = window.getSelection()
-    selection.getRangeAt(0) if selection.rangeCount > 0
 
   domRangesAreEqual = (left, right) ->
     left?.startContainer is right?.startContainer and


### PR DESCRIPTION
Alternate to #214

Avoids this 13 year old Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=208427

<img width="439" alt="screen shot 2016-03-22 at 10 29 34 am" src="https://cloud.githubusercontent.com/assets/5355/13954948/349172d6-f019-11e5-9faa-778d52424ab1.png">
