### PR TITLE
HTML parser improvements

### DIFF
--- a/.blade.yml
+++ b/.blade.yml
@@ -23,7 +23,7 @@ plugins:
     browsers:
       Google Chrome:
         os: Mac, Windows
-        version: -2
+        version: [48, 47]
       Firefox:
         os: Mac, Windows
         version: -2

--- a/src/trix/core/helpers/dom.coffee
+++ b/src/trix/core/helpers/dom.coffee
@@ -43,11 +43,15 @@ Trix.extend
 
   findClosestElementFromNode: (node, {matchingSelector} = {}) ->
     node = node.parentNode until not node? or node.nodeType is Node.ELEMENT_NODE
+    return unless node?
 
     if matchingSelector?
-      while node
-        return node if Trix.elementMatchesSelector(node, matchingSelector)
-        node = node.parentNode
+      if node.closest
+        node.closest(matchingSelector)
+      else
+        while node
+          return node if Trix.elementMatchesSelector(node, matchingSelector)
+          node = node.parentNode
     else
       node
 

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -268,7 +268,7 @@ class Trix.HTMLParser extends Trix.BasicObject
 
   isInsignificantTextNode = (node) ->
     return unless node?.nodeType is Node.TEXT_NODE
-    return unless /^\s*$/.test(node.data)
+    return if /\S/.test(node.data)
     return if elementCanDisplayNewlines(node.parentNode)
     not node.previousSibling or isBlockElement(node.previousSibling) or not node.nextSibling or isBlockElement(node.nextSibling)
 

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -246,10 +246,12 @@ class Trix.HTMLParser extends Trix.BasicObject
       node = walker.currentNode
       switch node.nodeType
         when Node.ELEMENT_NODE
-          element = node
-          for {name} in [element.attributes...]
-            unless name in allowedAttributes or name.indexOf("data-trix") is 0
-              element.removeAttribute(name)
+          if tagName(node) is "script"
+            nodesToRemove.push(node)
+          else
+            for {name} in [node.attributes...]
+              unless name in allowedAttributes or name.indexOf("data-trix") is 0
+                node.removeAttribute(name)
         when Node.COMMENT_NODE
           nodesToRemove.push(node)
 

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -271,7 +271,7 @@ class Trix.HTMLParser extends Trix.BasicObject
     return unless node?.nodeType is Node.TEXT_NODE
     return unless /^\s*$/.test(node.data)
     return if elementCanDisplayNewlines(node.parentNode)
-    isBlockElement(node.previousSibling) and isBlockElement(node.nextSibling)
+    not node.previousSibling or isBlockElement(node.previousSibling) or not node.nextSibling or isBlockElement(node.nextSibling)
 
   isExtraBR = (element) ->
     tagName(element) is "br" and

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -51,10 +51,12 @@ class Trix.HTMLParser extends Trix.BasicObject
   processNode: (node) ->
     switch node.nodeType
       when Node.TEXT_NODE
-        @processTextNode(node)
+        unless isInsignificantTextNode(node)
+          @processTextNode(node)
       when Node.ELEMENT_NODE
-        @appendBlockForElement(node)
-        @processElement(node)
+        unless isInsignificantTextNode(node.firstChild)
+          @appendBlockForElement(node)
+          @processElement(node)
 
   appendBlockForElement: (element) ->
     elementIsBlockElement = isBlockElement(element)
@@ -250,9 +252,6 @@ class Trix.HTMLParser extends Trix.BasicObject
               element.removeAttribute(name)
         when Node.COMMENT_NODE
           nodesToRemove.push(node)
-        when Node.TEXT_NODE
-          if isInsignificantTextNode(node)
-            nodesToRemove.push(node)
 
     for node in nodesToRemove
       node.parentNode.removeChild(node)

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -57,13 +57,16 @@ class Trix.HTMLParser extends Trix.BasicObject
         @processElement(node)
 
   appendBlockForElement: (element) ->
-    if isBlockElement(element) and not isBlockElement(element.firstChild)
+    elementIsBlockElement = isBlockElement(element)
+    currentBlockContainsElement = elementContainsNode(@currentBlockElement, element)
+
+    if elementIsBlockElement and not isBlockElement(element.firstChild)
       attributes = @getBlockAttributes(element)
-      unless elementContainsNode(@currentBlockElement, element) and arraysAreEqual(attributes, @currentBlock.attributes)
+      unless currentBlockContainsElement and arraysAreEqual(attributes, @currentBlock.attributes)
         @currentBlock = @appendBlockForAttributesWithElement(attributes, element)
         @currentBlockElement = element
 
-    else if @currentBlockElement and not elementContainsNode(@currentBlockElement, element) and not isBlockElement(element)
+    else if @currentBlockElement and not currentBlockContainsElement and not elementIsBlockElement
       if parentBlockElement = @findParentBlockElement(element)
         @appendBlockForElement(parentBlockElement)
       else

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -53,6 +53,11 @@ testGroup "Trix.HTMLParser", ->
     expectedHTML = """<div><!--block-->a b c d e f &nbsp; g<br><br>&nbsp;h &nbsp;</div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
+  test "parses block elements with leading whitespace", ->
+    html = """<blockquote> <span>a</span> <blockquote>\n <strong>b</strong> <pre> <span>c</span></pre></blockquote></blockquote>"""
+    expectedHTML = """<blockquote><!--block-->a<blockquote><!--block--><strong>b</strong><pre><!--block--> c</pre></blockquote></blockquote>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
   test "converts newlines to spaces", ->
     html = "<div>a\nb \nc \n d \n\ne</div><pre>1\n2</pre>"
     expectedHTML = """<div><!--block-->a b c d e</div><pre><!--block-->1\n2</pre>"""

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -39,8 +39,8 @@ testGroup "Trix.HTMLParser", ->
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
   test "ignores whitespace between block elements", ->
-    html = """<div>a</div> \n <div>b</div>"""
-    expectedHTML = """<div><!--block-->a</div><div><!--block-->b</div>"""
+    html = """<div>a</div> \n <div>b</div>     <article>c</article>  \n\n <section>d</section> """
+    expectedHTML = """<div><!--block-->a</div><div><!--block-->b</div><div><!--block-->c</div><div><!--block-->d</div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
   test "ingores whitespace between nested block elements", ->

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -53,9 +53,14 @@ testGroup "Trix.HTMLParser", ->
     expectedHTML = """<div><!--block-->a b c d e f &nbsp; g<br><br>&nbsp;h &nbsp;</div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
-  test "parses block elements with leading whitespace", ->
+  test "parses block elements with leading breakable whitespace", ->
     html = """<blockquote> <span>a</span> <blockquote>\n <strong>b</strong> <pre> <span>c</span></pre></blockquote></blockquote>"""
     expectedHTML = """<blockquote><!--block-->a<blockquote><!--block--><strong>b</strong><pre><!--block--> c</pre></blockquote></blockquote>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
+  test "parses block elements with leading non-breaking whitespace", ->
+    html = """<blockquote>&nbsp;<span>a</span></blockquote>"""
+    expectedHTML = """<blockquote><!--block-->&nbsp;a</blockquote>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
   test "converts newlines to spaces", ->

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -43,6 +43,11 @@ testGroup "Trix.HTMLParser", ->
     expectedHTML = """<div><!--block-->a</div><div><!--block-->b</div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
+  test "ingores whitespace between nested block elements", ->
+    html = """<ul> <li>a</li> \n  <li>b</li>  </ul><div>  <div> \n <blockquote>c</blockquote>\n </div>  \n</div>"""
+    expectedHTML = """<ul><li><!--block-->a</li><li><!--block-->b</li></ul><blockquote><!--block-->c</blockquote>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
   test "converts newlines to spaces", ->
     html = "<div>a\nb \nc \n d \n\ne</div><pre>1\n2</pre>"
     expectedHTML = """<div><!--block-->a b c d e</div><pre><!--block-->1\n2</pre>"""

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -85,6 +85,11 @@ testGroup "Trix.HTMLParser", ->
     document = Trix.HTMLParser.parse(html).getDocument()
     assert.documentHTMLEqual document, expectedHTML
 
+  test "ignores text nodes in script elements", ->
+    html = """<div>a<script>alert("b")</script></div>"""
+    expectedHTML = """<div><!--block-->a</div>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
   test "sanitizes unsafe html", (done) ->
     window.unsanitized = []
     Trix.HTMLParser.parse """

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -48,6 +48,11 @@ testGroup "Trix.HTMLParser", ->
     expectedHTML = """<ul><li><!--block-->a</li><li><!--block-->b</li></ul><blockquote><!--block-->c</blockquote>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
+  test "ignores inline whitespace that can't be displayed", ->
+    html = """ a  \n b    <span>c\n</span><span>d  \ne </span> f <span style="white-space: pre">  g\n\n h  </span>"""
+    expectedHTML = """<div><!--block-->a b c d e f &nbsp; g<br><br>&nbsp;h &nbsp;</div>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
   test "converts newlines to spaces", ->
     html = "<div>a\nb \nc \n d \n\ne</div><pre>1\n2</pre>"
     expectedHTML = """<div><!--block-->a b c d e</div><pre><!--block-->1\n2</pre>"""


### PR DESCRIPTION
* Fixes parsing insignificant whitespace-only text nodes between elements (#219)
* Prevents parsing text nodes in `<script>` elements
* Small performance improvements
* Organizes code into logical groups