### PR TITLE
BUGFIX: missing openssl to build eventmachine fails.

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -41,6 +41,7 @@ echo "--- Installing Ruby gems"
     fi
   fi
   gem list -i bundler >/dev/null 2>&1 || gem install bundler
+  bundle config build.eventmachine --with-cppflags=-I/usr/local/opt/openssl/include
   bundle check || bundle install
 } >&3 2>&1
 


### PR DESCRIPTION
When install OpenSSL with Homebrew, the share library may not on default
location. So we set bundle build config option for eventmachine so we
can build development environment successful.