### PR TITLE
Avoid creating unnecessary non-breaking spaces

### DIFF
--- a/src/trix/views/piece_view.coffee
+++ b/src/trix/views/piece_view.coffee
@@ -8,7 +8,7 @@ class Trix.PieceView extends Trix.ObjectView
     super
     @piece = @object
     @attributes = @piece.getAttributes()
-    {@textConfig} = @options
+    {@textConfig, @context} = @options
 
     if @piece.attachment
       @attachment = @piece.attachment
@@ -47,7 +47,7 @@ class Trix.PieceView extends Trix.ObjectView
           nodes.push(element)
 
         if length = substring.length
-          node = document.createTextNode(preserveSpaces(substring))
+          node = document.createTextNode(@preserveSpaces(substring))
           nodes.push(node)
       nodes
 
@@ -80,11 +80,18 @@ class Trix.PieceView extends Trix.ObjectView
         attributes[key] = value
         return makeElement(config.groupTagName, attributes)
 
-  preserveSpaces = (string) ->
-    nbsp = Trix.NON_BREAKING_SPACE
-    string
-      .replace(/\ $/, nbsp)
+  nbsp = Trix.NON_BREAKING_SPACE
+
+  preserveSpaces: (string) ->
+    if @context.isLast
+      string = string.replace(/\ $/, nbsp)
+
+    string = string
       .replace(/(\S)\ {3}(\S)/g, "$1 #{nbsp} $2")
       .replace(/\ {2}/g, "#{nbsp} ")
       .replace(/\ {2}/g, " #{nbsp}")
-      .replace(/^\ /, nbsp)
+
+    if @context.isFirst or @context.followsWhitespace
+      string = string.replace(/^\ /, nbsp)
+
+    string

--- a/src/trix/views/text_view.coffee
+++ b/src/trix/views/text_view.coffee
@@ -8,9 +8,23 @@ class Trix.TextView extends Trix.ObjectView
 
   createNodes: ->
     nodes = []
-    pieces = (piece for piece in @text.getPieces() when not piece.hasAttribute("blockBreak"))
-    objects = Trix.ObjectGroup.groupObjects(pieces)
-    for object in objects
-      view = @findOrCreateCachedChildView(Trix.PieceView, object, {@textConfig})
+    pieces = Trix.ObjectGroup.groupObjects(@getPieces())
+    lastIndex = pieces.length - 1
+
+    for piece, index in pieces
+      context = {}
+      context.isFirst = true if index is 0
+      context.isLast = true if index is lastIndex
+      context.followsWhitespace = true if endsWithWhitespace(previousPiece)
+
+      view = @findOrCreateCachedChildView(Trix.PieceView, piece, {@textConfig, context})
       nodes.push(view.getNodes()...)
+
+      previousPiece = piece
     nodes
+
+  getPieces: ->
+    piece for piece in @text.getPieces() when not piece.hasAttribute("blockBreak")
+
+  endsWithWhitespace = (piece) ->
+    /\s$/.test(piece?.toString())

--- a/test/src/test_helpers/fixtures/fixtures.coffee
+++ b/test/src/test_helpers/fixtures/fixtures.coffee
@@ -95,6 +95,20 @@ removeWhitespace = (string) ->
     document: createDocument(["a  "])
     html: """<div>#{blockComment}a &nbsp;</div>"""
 
+  "spaces and formatting":
+    document: new Trix.Document [
+      new Trix.Block new Trix.Text [
+          new Trix.StringPiece " a "
+          new Trix.StringPiece "b", href: "http://b.com"
+          new Trix.StringPiece " "
+          new Trix.StringPiece "c", bold: true
+          new Trix.StringPiece " d"
+          new Trix.StringPiece " e ", italic: true
+          new Trix.StringPiece " f  "
+        ]
+      ]
+    html: """<div>#{blockComment}&nbsp;a <a href="http://b.com">b</a> <strong>c</strong> d<em> e </em>&nbsp;f &nbsp;</div>"""
+
   "quote formatted block":
     document: createDocument(["abc", {}, ["quote"]])
     html: "<blockquote>#{blockComment}abc</blockquote>"

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -80,13 +80,13 @@ testGroup "Trix.HTMLParser", ->
 
   test "parses whitespace-only text nodes without a containing block element", ->
     html = """a <strong>b</strong> <em>c</em>"""
-    expectedHTML = """<div><!--block-->a&nbsp;<strong>b</strong>&nbsp;<em>c</em></div>"""
+    expectedHTML = """<div><!--block-->a <strong>b</strong> <em>c</em></div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
   test "parses spanned text elements that don't have a parser function", ->
     assert.notOk Trix.config.textAttributes.strike.parser
     html = """<del>a <strong>b</strong></del>"""
-    expectedHTML = """<div><!--block--><del>a&nbsp;</del><strong><del>b</del></strong></div>"""
+    expectedHTML = """<div><!--block--><del>a </del><strong><del>b</del></strong></div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
   test "translates tables into plain text", ->


### PR DESCRIPTION
Alternative to #192 that avoids rendering single space pieces as `&nbsp;` (fixes #152), and generally improves how Trix renders consecutive spaces.