### PR TITLE
Fix parsing whitespace after unserialized attachment HTML

### DIFF
--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -75,7 +75,7 @@ class Trix.HTMLParser extends Trix.BasicObject
 
   elementIsRemovable = (element) ->
     return unless element?.nodeType is Node.ELEMENT_NODE
-    tagName(element) is "script" or element.dataset.trixSerialize is "false"
+    tagName(element) is "script" or element.getAttribute("data-trix-serialize") is "false"
 
   nodeFilter = (node) ->
     if tagName(node) is "style"

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -59,7 +59,7 @@ class Trix.HTMLParser extends Trix.BasicObject
       node = walker.currentNode
       switch node.nodeType
         when Node.ELEMENT_NODE
-          if tagName(node) is "script"
+          if elementIsRemovable(node)
             nodesToRemove.push(node)
           else
             for {name} in [node.attributes...]
@@ -72,6 +72,10 @@ class Trix.HTMLParser extends Trix.BasicObject
       node.parentNode.removeChild(node)
 
     body.innerHTML
+
+  elementIsRemovable = (element) ->
+    return unless element?.nodeType is Node.ELEMENT_NODE
+    tagName(element) is "script" or element.dataset.trixSerialize is "false"
 
   nodeFilter = (node) ->
     if tagName(node) is "style"

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -83,6 +83,12 @@ testGroup "Trix.HTMLParser", ->
     expectedHTML = """<div><!--block-->a <strong>b</strong> <em>c</em></div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
+  test "parses spaces around cursor targets", ->
+    cursorTarget = Trix.selectionElements.create("cursorTarget").outerHTML
+    html = """<div>a #{cursorTarget}<span>b</span>#{cursorTarget} c</div>"""
+    expectedHTML = """<div><!--block-->a b c</div>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
   test "parses spanned text elements that don't have a parser function", ->
     assert.notOk Trix.config.textAttributes.strike.parser
     html = """<del>a <strong>b</strong></del>"""


### PR DESCRIPTION
New test failing before this change:
```
Trix.HTMLParser: parses spaces around cursor targets
  Expected: "<div><!--block-->a b c</div>"
  Result: "<div><!--block-->a bc</div>"
```