### PR TITLE
Fix pasting URLs on iOS

### DIFF
--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -211,6 +211,14 @@ class Trix.InputController extends Trix.BasicObject
         @requestRender()
         @delegate?.inputControllerDidPaste(pasteData)
 
+      else if href = paste.getData("URL")
+        pasteData.string = href
+        @setInputSummary(textAdded: href, didDelete: @selectionIsExpanded())
+        @delegate?.inputControllerWillPasteText(pasteData)
+        @responder?.insertText(Trix.Text.textForStringWithAttributes(href, {href}))
+        @requestRender()
+        @delegate?.inputControllerDidPaste(pasteData)
+
       else if string = paste.getData("text/plain")
         pasteData.string = string
         @setInputSummary(textAdded: string, didDelete: @selectionIsExpanded())

--- a/test/src/system/pasting_test.coffee
+++ b/test/src/system/pasting_test.coffee
@@ -19,6 +19,12 @@ testGroup "Pasting", template: "editor_empty", ->
         pasteContent "text/html", "<div>Hello world<br></div><div>This is a test</div>", ->
           expectDocument "abHello world\nThis is a test\nc\n"
 
+  test "paste URL", (expectDocument) ->
+    typeCharacters "a", ->
+      pasteContent "URL", "http://example.com", ->
+        assert.textAttributes([1, 18], href: "http://example.com")
+        expectDocument "ahttp://example.com\n"
+
   test "paste complex html into formatted block", (done) ->
     typeCharacters "abc", ->
       clickToolbarButton attribute: "quote", ->


### PR DESCRIPTION
Pasting a URL on iOS is currently broken with Trix. You can reproduce by using the action sheet in mobile Safari and selecting "Copy", which copies the URL to the clipboard, and then paste into the editor on http://trix-editor.org. It appears iOS/WebKit doesn’t put a text/plain representation of the URL on the clipboard, but only a text/uri-list:

```
> clipboardData.types.forEach(function(type){ console.log(type, clipboardData.getData(type)); })
[Log] apple web archive pasteboard type – ""
[Log] com.apple.rtfd – ""
[Log] public.rtf – ""
[Log] public.html – ""
[Log] public.png – ""
[Log] public.tiff – ""
[Log] public.jpeg – ""
[Log] com.compuserve.gif – ""
[Log] text/uri-list – "http://example.com/"
[Log] text/plain – ""
```

This fixes that by using the [*URL* type](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Recommended_Drag_Types#link) which is a shortcut for retrieving the first URL found in a `text/uri-list`

```
> clipboardData.getData("URL")
< "http://example.com/"
```

In addition to fixing iOS, it improves handling of URLs on all platforms that support the `URL` type by inserting a link instead of plain text.