### PR TITLE
Improve composition event handling

### DIFF
--- a/src/trix/controllers/composition_input_controller.coffee
+++ b/src/trix/controllers/composition_input_controller.coffee
@@ -47,10 +47,10 @@ class Trix.CompositionInputController extends Trix.BasicObject
   # it's likely there won't be another mutation (and subsequent render + selection change).
   # In that case, collapse the selection and request a render.
   setFinalSelection: ->
-    if  @data.end? and @data.end is @data.update
+    if @data.end? and @data.end is @data.update
       @unlessMutationOccurs =>
         if @selectionIsExpanded()
-          @responder?.setSelection(@range[1])
+          @responder?.setSelection(@range[0] + @data.end.length)
           @requestRender()
 
   @proxyMethod "inputController.setInputSummary"

--- a/src/trix/controllers/composition_input_controller.coffee
+++ b/src/trix/controllers/composition_input_controller.coffee
@@ -1,0 +1,63 @@
+class Trix.CompositionInputController extends Trix.BasicObject
+  constructor: (@inputController) ->
+    {@responder, @delegate, @inputSummary} = @inputController
+    @data = {}
+
+  start: (data) ->
+    @data.start = data
+
+    if @inputSummary.eventName is "keypress" and @inputSummary.textAdded
+      @responder?.deleteInDirection("left")
+
+    unless @selectionIsExpanded()
+      @insertPlaceholder()
+      @requestRender()
+
+    @range = @responder?.getSelectedRange()
+
+  update: (data) ->
+    @data.update = data
+
+    if range = @selectPlaceholder()
+      @forgetPlaceholder()
+      @range = range
+
+  end: (data) ->
+    @data.end = data
+    @forgetPlaceholder()
+
+    if @canApplyToDocument()
+      @delegate?.inputControllerWillPerformTyping()
+      @responder?.setSelectedRange(@range)
+      @responder?.insertString(@data.end)
+      @setInputSummary(preferDocument: true)
+      @setFinalSelection()
+
+    else if @data.start? or @data.update?
+      @requestReparse()
+      @inputController.reset()
+
+  # Private
+
+  canApplyToDocument: ->
+    @data.start?.length is 0 and @data.end?.length > 0 and @range?
+
+  # Fix for compositions remaining selected in Firefox:
+  # If the last composition update is the same as the final composition then
+  # it's likely there won't be another mutation (and subsequent render + selection change).
+  # In that case, collapse the selection and request a render.
+  setFinalSelection: ->
+    if  @data.end? and @data.end is @data.update
+      @unlessMutationOccurs =>
+        if @selectionIsExpanded()
+          @responder?.setSelection(@range[1])
+          @requestRender()
+
+  @proxyMethod "inputController.setInputSummary"
+  @proxyMethod "inputController.requestRender"
+  @proxyMethod "inputController.requestReparse"
+  @proxyMethod "inputController.unlessMutationOccurs"
+  @proxyMethod "responder?.selectionIsExpanded"
+  @proxyMethod "responder?.insertPlaceholder"
+  @proxyMethod "responder?.selectPlaceholder"
+  @proxyMethod "responder?.forgetPlaceholder"

--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -167,6 +167,9 @@ class Trix.EditorController extends Trix.Controller
       @requestedRender = false
       @render()
 
+  inputControllerDidRequestReparse: ->
+    @reparse()
+
   inputControllerWillPerformTyping: ->
     @recordTypingUndoEntry()
 

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -1,5 +1,6 @@
 #= require trix/observers/mutation_observer
 #= require trix/operations/file_verification_operation
+#= require trix/controllers/composition_input_controller
 
 {handleEvent, findClosestElementFromNode, findElementFromContainerAndOffset,
   defer, makeElement, innerElementIsActive, summarizeStringChange, objectsAreEqual} = Trix
@@ -66,7 +67,7 @@ class Trix.InputController extends Trix.BasicObject
 
   elementDidMutate: (mutationSummary) ->
     @mutationCount++
-    unless @inputSummary.composing
+    unless @isComposing()
       @handleInput ->
         if @mutationIsExpected(mutationSummary)
           @requestRender()
@@ -103,7 +104,7 @@ class Trix.InputController extends Trix.BasicObject
 
   events:
     keydown: (event) ->
-      @resetInputSummary() unless @inputSummary.composing
+      @resetInputSummary() unless @isComposing()
 
       if keyName = @constructor.keyNames[event.keyCode]
         context = @keys
@@ -247,49 +248,17 @@ class Trix.InputController extends Trix.BasicObject
       event.preventDefault()
 
     compositionstart: (event) ->
-      if @inputSummary.eventName is "keypress" and @inputSummary.textAdded
-        @responder?.deleteInDirection("left")
-
-      unless @selectionIsExpanded()
-        @responder?.insertPlaceholder()
-        @requestRender()
-
-      compositionRange = @responder?.getSelectedRange()
-      @setInputSummary({compositionRange, compositionStart: event.data, composing: true})
+      @compositionInputController = new Trix.CompositionInputController this
+      @compositionInputController.start(event.data)
 
     compositionupdate: (event) ->
-      if compositionRange = @responder?.selectPlaceholder()
-        @setInputSummary({compositionRange})
-        @responder?.forgetPlaceholder()
-
-      @setInputSummary(compositionUpdate: event.data)
+      @compositionInputController ?= new Trix.CompositionInputController this
+      @compositionInputController.update(event.data)
 
     compositionend: (event) ->
-      compositionEnd = event.data
-      {compositionStart, compositionUpdate, compositionRange} = @inputSummary
-
-      @responder?.forgetPlaceholder()
-      @setInputSummary(composing: false)
-
-      if compositionStart?.length is 0 and compositionEnd.length > 0 and compositionRange?
-        @delegate?.inputControllerWillPerformTyping()
-        @responder?.setSelectedRange(compositionRange)
-        @responder?.insertString(compositionEnd)
-        @setInputSummary(preferDocument: true)
-
-        # Fix for compositions remaining selected in Firefox:
-        # If the last composition update is the same as the final composition then
-        # it's likely there won't be another mutation (and subsequent render + selection change).
-        # In that case, collapse the selection and request a render.
-        if compositionEnd is compositionUpdate
-          @unlessMutationOccurs =>
-            if @selectionIsExpanded()
-              @responder?.setSelection(compositionRange[1])
-              @requestRender()
-
-      else if compositionStart? or compositionUpdate?
-        @requestReparse()
-        @reset()
+      @compositionInputController ?= new Trix.CompositionInputController this
+      @compositionInputController.end(event.data)
+      @compositionInputController = null
 
     input: (event) ->
       event.stopPropagation()
@@ -378,6 +347,9 @@ class Trix.InputController extends Trix.BasicObject
       callback.call(this)
     finally
       @delegate?.inputControllerDidHandleInput()
+
+  isComposing: ->
+    @compositionInputController?
 
   deleteInDirection: (direction, event) ->
     if @responder?.deleteInDirection(direction) is false

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -271,7 +271,7 @@ class Trix.InputController extends Trix.BasicObject
       @responder?.forgetPlaceholder()
       @setInputSummary(composing: false)
 
-      if compositionStart?.length is 0 and compositionRange?
+      if compositionStart?.length is 0 and compositionEnd.length > 0 and compositionRange?
         @delegate?.inputControllerWillPerformTyping()
         @responder?.setSelectedRange(compositionRange)
         @responder?.insertString(compositionEnd)

--- a/test/src/system/composition_input_test.coffee
+++ b/test/src/system/composition_input_test.coffee
@@ -84,6 +84,24 @@ testGroup "Composition input", template: "editor_empty", ->
       insertNode document.createTextNode("r"), ->
         expectDocument("car\n")
 
+  # Simulates the sequence of events when typing on Android and then tapping elsewhere
+  test "leaving a composition", (expectDocument) ->
+    element = getEditorElement()
+
+    triggerEvent(element, "keydown", charCode: 0, keyCode: 229, which: 229)
+    triggerEvent(element, "compositionstart", data: "")
+    triggerEvent(element, "compositionupdate", data: "c")
+    node = document.createTextNode("c")
+    insertNode(node)
+    defer ->
+      triggerEvent(element, "keydown", charCode: 0, keyCode: 229, which: 229)
+      triggerEvent(element, "compositionupdate", data: "ca")
+      node.data = "ca"
+      defer ->
+        triggerEvent(element, "compositionend", data: "")
+        defer ->
+          expectDocument("ca\n")
+
   # Simulates compositions in Firefox where the final composition data is
   # dispatched as both compositionupdate and compositionend.
   test "composition ending with same data as last update", (expectDocument) ->

--- a/test/src/system/composition_input_test.coffee
+++ b/test/src/system/composition_input_test.coffee
@@ -68,6 +68,22 @@ testGroup "Composition input", template: "editor_empty", ->
         pressKey "backspace", ->
           expectDocument "a \n"
 
+  # Simulates the sequence of events when pressing backspace at the end of a
+  # word and updating it on Android (running older versions of System WebView)
+  test "updating a composition", (expectDocument) ->
+    element = getEditorElement()
+    element.editor.insertString("cat")
+
+    triggerEvent(element, "keydown", charCode: 0, keyCode: 229, which: 229)
+    triggerEvent(element, "compositionstart", data: "cat")
+    triggerEvent(element, "compositionupdate", data: "cat")
+    removeCharacters -1, ->
+      triggerEvent(element, "keydown", charCode: 0, keyCode: 229, which: 229)
+      triggerEvent(element, "compositionupdate", data: "car")
+      triggerEvent(element, "compositionend", data: "car")
+      insertNode document.createTextNode("r"), ->
+        expectDocument("car\n")
+
   # Simulates compositions in Firefox where the final composition data is
   # dispatched as both compositionupdate and compositionend.
   test "composition ending with same data as last update", (expectDocument) ->

--- a/test/src/system/composition_input_test.coffee
+++ b/test/src/system/composition_input_test.coffee
@@ -116,10 +116,13 @@ testGroup "Composition input", template: "editor_empty", ->
       triggerEvent(element, "compositionupdate", data: "é")
       node.data = "é"
       defer ->
-        triggerEvent(element, "compositionend", data: "é")
+        triggerEvent(element, "compositionupdate", data: "éé")
+        node.data = "éé"
         defer ->
-          assert.locationRange(index: 0, offset: 1)
-          expectDocument("é\n")
+          triggerEvent(element, "compositionend", data: "éé")
+          defer ->
+            assert.locationRange(index: 0, offset: 2)
+            expectDocument("éé\n")
 
 removeCharacters = (direction, callback) ->
   selection = rangy.getSelection()

--- a/test/src/system/mutation_input_test.coffee
+++ b/test/src/system/mutation_input_test.coffee
@@ -1,0 +1,12 @@
+{assert, defer, test, testGroup, triggerEvent, typeCharacters} = Trix.TestHelpers
+
+testGroup "Mutation input", template: "editor_empty", ->
+  test "deleting a newline", (expectDocument) ->
+    element = getEditorElement()
+    element.editor.insertString("a\n\nb")
+
+    triggerEvent(element, "keydown", charCode: 0, keyCode: 229, which: 229)
+    br = element.querySelectorAll("br")[1]
+    br.parentNode.removeChild(br)
+    defer ->
+      expectDocument("a\nb\n")

--- a/test/src/system/mutation_input_test.coffee
+++ b/test/src/system/mutation_input_test.coffee
@@ -8,5 +8,5 @@ testGroup "Mutation input", template: "editor_empty", ->
     triggerEvent(element, "keydown", charCode: 0, keyCode: 229, which: 229)
     br = element.querySelectorAll("br")[1]
     br.parentNode.removeChild(br)
-    defer ->
+    requestAnimationFrame ->
       expectDocument("a\nb\n")


### PR DESCRIPTION
* Fixes that deleted text would reappear, duplicate, or some combination of the two on Android devices running earlier versions of System WebView
* Fixes deleting empty lines on newer versions of Android System WebView
* Fixes incorrect cursor position after multi-character compositions in Firefox
* Extracts composition event handling into `Trix.CompositionInputController`