### PR TITLE
Move Trix explicitly on to the `window` object

### DIFF
--- a/src/trix/index.coffee.erb
+++ b/src/trix/index.coffee.erb
@@ -3,7 +3,7 @@
 #= require trix/config
 #= require trix/elements/trix_editor_element
 
-@Trix =
+window.Trix =
   VERSION: "<%= render_asset("trix/VERSION").chomp %>"
 
   ZERO_WIDTH_SPACE: "\uFEFF"


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/basecamp/trix/issues/119), Trix currently does not work at all with node module loaders. The solution proposed in that PR specifically solved the issue for Webpack, but not for any bundler that wraps Trix in an IIFE (as most do). This is because the index file adds `Trix` to `this`, which is assumed to be `window`, and all other bundled files (themselves executed in IIFEs) assume the ability to access Trix somewhere in scope (which works when the original `this` was `window`, but not when it is anything else).

At Shopify, we're using a custom JavaScript bundle to be able to use npm packages. The only solution for us with Trix right now is to vendor it and make these changes manually.

Anyhow, this PR somewhat improves the situation by attaching Trix to `window` explicitly. This is far from ideal — it would be much better to use a UMD wrapper so that it can be brought into a project using AMD, CJS, or globals. However, this is a smaller change that isn't too much of a departure from what's currently there.

cc/ @javan 