### PR TITLE
Headers

### DIFF
--- a/src/trix/config/block_attributes.coffee
+++ b/src/trix/config/block_attributes.coffee
@@ -2,13 +2,6 @@ Trix.config.blockAttributes = attributes =
   default:
     tagName: "div"
     parse: false
-    singleLine: true
-  h1:
-    tagName: "h1"
-    singleLine: true
-  h2:
-    tagName: "h2"
-    singleLine: true
   quote:
     tagName: "blockquote"
     nestable: true

--- a/src/trix/config/block_attributes.coffee
+++ b/src/trix/config/block_attributes.coffee
@@ -2,6 +2,13 @@ Trix.config.blockAttributes = attributes =
   default:
     tagName: "div"
     parse: false
+    singleLine: true
+  h1:
+    tagName: "h1"
+    singleLine: true
+  h2:
+    tagName: "h2"
+    singleLine: true
   quote:
     tagName: "blockquote"
     nestable: true

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -73,6 +73,9 @@ class Trix.Block extends Trix.Object
     return unless config = Trix.config.blockAttributes[attribute]
     if key then config[key] else config
 
+  isSingleLine: ->
+    @getConfig("singleLine")?
+
   isListItem: ->
     @getConfig("listAttribute")?
 

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -145,13 +145,12 @@ class Trix.Block extends Trix.Object
   canBeGroupedWith: (otherBlock, depth) ->
     attributes = @attributes
     otherAttributes = otherBlock.getAttributes()
-    if attributes[depth] is otherAttributes[depth]
+    if attributes[depth] is otherAttributes[depth] and not @isSingleLine()
       if attributes[depth] in ["bullet", "number"] and otherAttributes[depth + 1] not in ["bulletList", "numberList"]
         false
       else
         true
-    else
-      not attributes[depth] in ["h1", "h2"]
+    
 
   # Block breaks
 

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -134,6 +134,9 @@ class Trix.Block extends Trix.Object
     else
       @text.copy()
 
+  offsetIsAtEnd: (offset) ->
+    @getLength() - 1 is offset
+
   # Grouping
 
   canBeGrouped: (depth) ->
@@ -147,6 +150,8 @@ class Trix.Block extends Trix.Object
         false
       else
         true
+    else
+      not attributes[depth] in ["h1", "h2"]
 
   # Block breaks
 

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -71,15 +71,15 @@ class Trix.Composition extends Trix.BasicObject
 
   breakFormattedBlock: ->
     position = @getPosition()
-    range = [position - 1, position]
+    range = [position, position]
 
     document = @document
     {index, offset} = document.locationFromPosition(position)
     block = document.getBlockAtIndex(index)
 
     if block.getBlockBreakPosition() is offset
-      if block.text.getStringAtRange([offset-1, offset]) is "\n"
-        document = document.removeTextAtRange([position-1, position])
+      if block.text.getStringAtRange([offset - 1, offset]) is "\n"
+        document = document.removeTextAtRange([position - 1, position])
       else if offset - 1 isnt 0
         position += 1
     else
@@ -88,11 +88,13 @@ class Trix.Composition extends Trix.BasicObject
       else if offset - 1 isnt 0
         position += 1
 
-    if block.isSingleLine()
-      newDocument = new Trix.Document
+    if block.isSingleLine() and not block.offsetIsAtEnd(offset)
+      @setDocument(document.insertBlockBreakAtRange(range))
     else
+      position += 1
       newDocument = new Trix.Document [block.removeLastAttribute().copyWithoutText()]
-    @setDocument(document.insertDocumentAtRange(newDocument, range))
+      @setDocument(document.insertDocumentAtRange(newDocument, range))
+    
     @setSelection(position)
 
   insertLineBreak: ->
@@ -108,7 +110,6 @@ class Trix.Composition extends Trix.BasicObject
         else
           console.log "breaking singline block"
           @breakFormattedBlock()
-          @removeLastBlockAttribute()
       else if block.isListItem()
         if block.isEmpty()
           @decreaseListLevel()

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -91,7 +91,6 @@ class Trix.Composition extends Trix.BasicObject
     if block.isSingleLine() and not block.offsetIsAtEnd(offset)
       @setDocument(document.insertBlockBreakAtRange(range))
     else
-      position += 1
       newDocument = new Trix.Document [block.removeLastAttribute().copyWithoutText()]
       @setDocument(document.insertDocumentAtRange(newDocument, range))
     

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -108,7 +108,6 @@ class Trix.Composition extends Trix.BasicObject
         if block.isEmpty()
           @removeLastBlockAttribute()
         else
-          console.log "breaking singline block"
           @breakFormattedBlock()
       else if block.isListItem()
         if block.isEmpty()

--- a/src/trix/views/block_view.coffee
+++ b/src/trix/views/block_view.coffee
@@ -22,7 +22,7 @@ class Trix.BlockView extends Trix.ObjectView
     if @attributes.length
       nodes
     else
-      element = makeElement(Trix.config.blockAttributes.default.tagName)
+      element = makeElement(Trix.config.blockAttributes.default)
       element.appendChild(node) for node in nodes
       [element]
 


### PR DESCRIPTION
This work incorporates work from #187, #145, #146 including the workaround by @digitalpbk, and my own work. I'm not sure how to create multi-author commit, but I want to give attribute where it's due.

I still need to write the tests, but thought I would get this code up for review.

If you add a block attribute for any of the h* tags, you can add menu items to toggle them. This implementation depends on the header attributes having the property `singleLine: true`. If there's an official name for HTML elements of this type, I'm game to change the property name and the corresponding methods. I couldn't find one in the 15 minutes I spent searching.

I've also added code to start a default block when you hit <kbd>return</kbd> at the end of a singleLine block.

Here's a little demo demonstrating the code!
![headings](https://cloud.githubusercontent.com/assets/1348928/15266460/4f13fd4e-195a-11e6-9a59-715e9f799404.gif)
