### PR TITLE
Paragraphs and figures

### DIFF
--- a/src/trix/config/block_attributes.coffee
+++ b/src/trix/config/block_attributes.coffee
@@ -1,10 +1,12 @@
 Trix.config.blockAttributes = attributes =
   default:
-    tagName: "div"
+    tagName: "p"
     parse: false
   quote:
     tagName: "blockquote"
     nestable: true
+  attachment:
+    singleCharacter: true
   code:
     tagName: "pre"
     text:

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -45,7 +45,7 @@ class Trix.Block extends Trix.Object
     @copyWithAttributes(attributes)
 
   removeAttribute: (attribute) ->
-    {listAttribute} = Trix.config.blockAttributes[attribute]
+    {listAttribute} = Trix.config.blockAttributes[attribute]?
     attributes = removeLastElement(@attributes, attribute)
     attributes = removeLastElement(attributes, listAttribute) if listAttribute?
     @copyWithAttributes(attributes)

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -12,6 +12,9 @@ class Trix.Block extends Trix.Object
     @text = applyBlockBreakToText(text)
     @attributes = attributes
 
+  isSingleCharacter: ->
+    @getConfig("singleCharacter")
+
   isEmpty: ->
     @text.isBlockBreak()
 

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -114,7 +114,13 @@ class Trix.Composition extends Trix.BasicObject
         else
           @insertString("\n")
     else
-      @insertString("\n")
+      if @shouldBreakParagraphsIntoBlocks()
+        @insertBlockBreak()
+      else
+        @insertString("\n")
+
+  shouldBreakParagraphsIntoBlocks: ->
+    Trix.config.blockAttributes.default.tagName is "p"
 
   insertHTML: (html) ->
     startPosition = @getPosition()

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -150,13 +150,17 @@ class Trix.Composition extends Trix.BasicObject
   insertAttachment: (attachment) ->
     if @shouldBreakParagraphsIntoBlocks()
       console.log "should break paragraphs into blocks"
-      @breakFormattedBlock()
-      [startPosition, endPosition] = @getSelectedRange()
-      @setSelection(startPosition + 1)
-      @setBlockAttribute("attachment", true)
+      @createBlockForAttachment()
 
     text = Trix.Text.textForAttachmentWithAttributes(attachment, @currentAttributes)
     @insertText(text)
+
+  createBlockForAttachment: ->
+    @insertBlockBreak()
+    @breakFormattedBlock()
+    [startPosition, endPosition] = @getSelectedRange()
+    @setSelection(startPosition + 1)
+    @setCurrentAttribute("attachment", true)
 
   deleteInDirection: (direction) ->
     range = [startPosition, endPosition] = @getSelectedRange()

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -148,6 +148,13 @@ class Trix.Composition extends Trix.BasicObject
       @insertAttachment(attachment)
 
   insertAttachment: (attachment) ->
+    if @shouldBreakParagraphsIntoBlocks()
+      console.log "should break paragraphs into blocks"
+      @breakFormattedBlock()
+      [startPosition, endPosition] = @getSelectedRange()
+      @setSelection(startPosition + 1)
+      @setBlockAttribute("attachment", true)
+
     text = Trix.Text.textForAttachmentWithAttributes(attachment, @currentAttributes)
     @insertText(text)
 

--- a/src/trix/models/document.coffee
+++ b/src/trix/models/document.coffee
@@ -219,7 +219,7 @@ class Trix.Document extends Trix.Object
   applyBlockAttributeAtRange: (attributeName, value, range) ->
     {document, range} = @expandRangeToLineBreaksAndSplitBlocks(range)
 
-    if Trix.config.blockAttributes[attributeName].listAttribute
+    if Trix.config.blockAttributes[attributeName]?.listAttribute
       document = document.removeLastListAttributeAtRange(range, exceptAttributeName: attributeName)
       {document, range} = document.convertLineBreaksToBlockBreaksInRange(range)
     else

--- a/src/trix/views/object_group_view.coffee
+++ b/src/trix/views/object_group_view.coffee
@@ -12,12 +12,19 @@ class Trix.ObjectGroupView extends Trix.ObjectView
     @childViews
 
   createNodes: ->
-    element = @createContainerElement()
+    if not @blockContainsSingleCharacter()
+      element = @createContainerElement()
 
-    for view in @getChildViews()
-      element.appendChild(node) for node in view.getNodes()
+      for view in @getChildViews()
+        element.appendChild(node) for node in view.getNodes()
 
-    [element]
+      [element]
+    else
+      singleCharacterView = @getChildViews()[0]
+      singleCharacterView.getNodes()
 
   createContainerElement: (depth = @objectGroup.getDepth()) ->
     @getChildViews()[0].createContainerElement(depth)
+
+  blockContainsSingleCharacter: ->
+    @getChildViews()[0].block.isSingleCharacter()


### PR DESCRIPTION
I'm opening this PR to start discussing what needs to be done to move attachments and their corresponding `<figure>` elements outside of the `<p>` when it's the default block (Addressed in #202). The attachment is represented as an `AttachmentPiece` and we need to treat it as a block. 

One way we can do this by adding the block attribute `attachment`:

```coffeescript
Trix.config.blockAttributes = attributes =
    attachment:
        tagName: "trix-attachment"
```

We could create a `<trix-attachment>` element and use it to represent the piece.

``` html
<trix-attachment>
    <span data-trix-selection="true" data-trix-cursor-target="true">&#65279</span>
    <figure class="attachment attachment-preview"><img>
             <figcaption class="caption"></figcaption>
            <progress class="progress" value="0" max="100" data-trix-mutable="true"></progress>
      </figure>
     <span data-trix-selection="true" data-trix-cursor-target="true">&#65279;</span
</trix-attachment>
```

Another option is to render the block without a root element, though I think this will require more modification in the renderer.

@javan, @sstephenson, which do you prefer?