### PR TITLE
Typing formatted text fixes

### DIFF
--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -76,13 +76,20 @@ class Trix.InputController extends Trix.BasicObject
           @requestReparse()
         @reset()
 
-  mutationIsExpected: (mutationSummary) ->
+  mutationIsExpected: ({textAdded, textDeleted}) ->
     if @inputSummary
       if @inputSummary.preferDocument?
         @inputSummary.preferDocument
       else
-        unhandledAddition = mutationSummary.textAdded isnt @inputSummary.textAdded
-        unhandledDeletion = mutationSummary.textDeleted? and not @inputSummary.didDelete
+        unhandledAddition = textAdded isnt @inputSummary.textAdded
+        unhandledDeletion = textDeleted? and not @inputSummary.didDelete
+
+        if textDeleted is "\n" and unhandledDeletion
+          if textAdded and not unhandledAddition
+            if range = @responder?.getSelectedRange()
+              if @responder?.positionIsBlockBreak(range[1] + textAdded.length)
+                unhandledDeletion = false
+
         not (unhandledAddition or unhandledDeletion)
 
   unlessMutationOccurs: (callback) ->

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -86,9 +86,8 @@ class Trix.InputController extends Trix.BasicObject
     # by the extra <br> rendered to represent them.
     if textDeleted is "\n" and unhandledDeletion
       if textAdded and not unhandledAddition
-        Trix.selectionChangeObserver.update()
         if range = @responder?.getSelectedRange()
-          if @responder?.positionIsBlockBreak(range[1])
+          if @responder?.positionIsBlockBreak(range[1] + textAdded.length)
             unhandledDeletion = false
 
     not (unhandledAddition or unhandledDeletion)
@@ -155,9 +154,11 @@ class Trix.InputController extends Trix.BasicObject
       {data} = event
       {textAdded} = @inputSummary
       if textAdded and textAdded isnt data and textAdded.toUpperCase() is data
-        @expandSelectionInDirection("forward")
+        range = @responder?.getSelectedRange()
+        @responder?.setSelectedRange([range[0], range[1] + textAdded.length])
         @responder?.insertString(data)
         @setInputSummary(textAdded: data)
+        @responder?.setSelectedRange(range)
 
     dragenter: (event) ->
       event.preventDefault()

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -77,20 +77,20 @@ class Trix.InputController extends Trix.BasicObject
         @reset()
 
   mutationIsExpected: ({textAdded, textDeleted}) ->
-    if @inputSummary
-      if @inputSummary.preferDocument?
-        @inputSummary.preferDocument
-      else
-        unhandledAddition = textAdded isnt @inputSummary.textAdded
-        unhandledDeletion = textDeleted? and not @inputSummary.didDelete
+    return true if @inputSummary.preferDocument
 
-        if textDeleted is "\n" and unhandledDeletion
-          if textAdded and not unhandledAddition
-            if range = @responder?.getSelectedRange()
-              if @responder?.positionIsBlockBreak(range[1] + textAdded.length)
-                unhandledDeletion = false
+    unhandledAddition = textAdded isnt @inputSummary.textAdded
+    unhandledDeletion = textDeleted? and not @inputSummary.didDelete
 
-        not (unhandledAddition or unhandledDeletion)
+    # Expect newline removal at the end of a block caused
+    # by the extra <br> rendered to represent them.
+    if textDeleted is "\n" and unhandledDeletion
+      if textAdded and not unhandledAddition
+        if range = @responder?.getSelectedRange()
+          if @responder?.positionIsBlockBreak(range[1] + textAdded.length)
+            unhandledDeletion = false
+
+    not (unhandledAddition or unhandledDeletion)
 
   unlessMutationOccurs: (callback) ->
     mutationCount = @mutationCount

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -86,7 +86,7 @@ class Trix.InputController extends Trix.BasicObject
     # by the extra <br> rendered to represent them.
     if textDeleted is "\n" and unhandledDeletion
       if textAdded and not unhandledAddition
-        if range = @responder?.getSelectedRange()
+        if range = @getSelectedRange()
           if @responder?.positionIsBlockBreak(range[1] + textAdded.length)
             unhandledDeletion = false
 
@@ -154,11 +154,11 @@ class Trix.InputController extends Trix.BasicObject
       {data} = event
       {textAdded} = @inputSummary
       if textAdded and textAdded isnt data and textAdded.toUpperCase() is data
-        range = @responder?.getSelectedRange()
-        @responder?.setSelectedRange([range[0], range[1] + textAdded.length])
+        range = @getSelectedRange()
+        @setSelectedRange([range[0], range[1] + textAdded.length])
         @responder?.insertString(data)
         @setInputSummary(textAdded: data)
-        @responder?.setSelectedRange(range)
+        @setSelectedRange(range)
 
     dragenter: (event) ->
       event.preventDefault()
@@ -166,7 +166,7 @@ class Trix.InputController extends Trix.BasicObject
     dragstart: (event) ->
       target = event.target
       @serializeSelectionToDataTransfer(event.dataTransfer)
-      @draggedRange = @responder?.getSelectedRange()
+      @draggedRange = @getSelectedRange()
       @delegate?.inputControllerDidStartDrag?()
 
     dragover: (event) ->
@@ -394,7 +394,7 @@ class Trix.InputController extends Trix.BasicObject
     types["Files"] or types["application/x-trix-document"] or types["text/html"] or types["text/plain"]
 
   getPastedHTMLUsingHiddenElement: (callback) ->
-    selectedRange = @responder?.getSelectedRange()
+    selectedRange = @getSelectedRange()
 
     style =
       position: "absolute"
@@ -409,9 +409,11 @@ class Trix.InputController extends Trix.BasicObject
     requestAnimationFrame =>
       html = element.innerHTML
       document.body.removeChild(element)
-      @responder?.setSelectedRange(selectedRange)
+      @setSelectedRange(selectedRange)
       callback(html)
 
+  @proxyMethod "responder?.getSelectedRange"
+  @proxyMethod "responder?.setSelectedRange"
   @proxyMethod "responder?.expandSelectionInDirection"
   @proxyMethod "responder?.selectionIsInCursorTarget"
   @proxyMethod "responder?.selectionIsExpanded"

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -149,6 +149,15 @@ class Trix.InputController extends Trix.BasicObject
         @responder?.insertString(character)
         @setInputSummary(textAdded: character, didDelete: @selectionIsExpanded())
 
+    textInput: (event) ->
+      # Handle autocapitalization
+      {data} = event
+      {textAdded} = @inputSummary
+      if textAdded and textAdded isnt data and textAdded.toUpperCase() is data
+        @expandSelectionInDirection("forward")
+        @responder?.insertString(data)
+        @setInputSummary(textAdded: data)
+
     dragenter: (event) ->
       event.preventDefault()
 

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -86,8 +86,9 @@ class Trix.InputController extends Trix.BasicObject
     # by the extra <br> rendered to represent them.
     if textDeleted is "\n" and unhandledDeletion
       if textAdded and not unhandledAddition
+        Trix.selectionChangeObserver.update()
         if range = @responder?.getSelectedRange()
-          if @responder?.positionIsBlockBreak(range[1] + textAdded.length)
+          if @responder?.positionIsBlockBreak(range[1])
             unhandledDeletion = false
 
     not (unhandledAddition or unhandledDeletion)

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -402,6 +402,9 @@ class Trix.Composition extends Trix.BasicObject
     if location = @document.locationFromPosition(position)
       @locationIsCursorTarget(location)
 
+  positionIsBlockBreak: (position) ->
+    @document.getPieceAtPosition(position)?.isBlockBreak()
+
   getSelectedDocument: ->
     if selectedRange = @getSelectedRange()
       @document.getDocumentAtRange(selectedRange)

--- a/test/src/system/mutation_input_test.coffee
+++ b/test/src/system/mutation_input_test.coffee
@@ -1,4 +1,4 @@
-{assert, defer, test, testGroup, triggerEvent, typeCharacters} = Trix.TestHelpers
+{assert, defer, test, testGroup, triggerEvent, typeCharacters, clickToolbarButton, isToolbarButtonActive} = Trix.TestHelpers
 
 testGroup "Mutation input", template: "editor_empty", ->
   test "deleting a newline", (expectDocument) ->
@@ -10,3 +10,24 @@ testGroup "Mutation input", template: "editor_empty", ->
     br.parentNode.removeChild(br)
     requestAnimationFrame ->
       expectDocument("a\nb\n")
+
+  test "typing formatted text after a newline at the end of block", (expectDocument) ->
+    element = getEditorElement()
+    element.editor.insertString("a\n")
+
+    clickToolbarButton attribute: "bold", ->
+      # Press B key
+      triggerEvent(element, "keydown", charCode: 0, keyCode: 66, which: 66)
+      triggerEvent(element, "keypress", charCode: 98, keyCode: 98, which: 98)
+
+      node = document.createTextNode("b")
+      extraBR = element.querySelectorAll("br")[1]
+      extraBR.parentNode.insertBefore(node, extraBR)
+      extraBR.parentNode.removeChild(extraBR)
+
+      requestAnimationFrame ->
+        assert.ok isToolbarButtonActive(attribute: "bold")
+        assert.textAttributes([0, 2], {})
+        assert.textAttributes([2, 3], bold: true)
+        assert.textAttributes([3, 4], blockBreak: true)
+        expectDocument("a\nb\n")

--- a/test/src/system/mutation_input_test.coffee
+++ b/test/src/system/mutation_input_test.coffee
@@ -1,4 +1,4 @@
-{assert, defer, test, testGroup, triggerEvent, typeCharacters, clickToolbarButton, isToolbarButtonActive} = Trix.TestHelpers
+{assert, defer, test, testGroup, triggerEvent, typeCharacters, clickToolbarButton, isToolbarButtonActive, insertNode} = Trix.TestHelpers
 
 testGroup "Mutation input", template: "editor_empty", ->
   test "deleting a newline", (expectDocument) ->
@@ -31,3 +31,17 @@ testGroup "Mutation input", template: "editor_empty", ->
         assert.textAttributes([2, 3], bold: true)
         assert.textAttributes([3, 4], blockBreak: true)
         expectDocument("a\nb\n")
+
+  test "typing formatted text with autocapitalization on", (expectDocument) ->
+    element = getEditorElement()
+
+    clickToolbarButton attribute: "bold", ->
+      # Type "b", autocapitalize to "B"
+      triggerEvent(element, "keydown", charCode: 0, keyCode: 66, which: 66)
+      triggerEvent(element, "keypress", charCode: 98, keyCode: 98, which: 98)
+      triggerEvent(element, "textInput", data: "B")
+
+      insertNode document.createTextNode("B"), ->
+        assert.ok isToolbarButtonActive(attribute: "bold")
+        assert.textAttributes([0, 1], bold: true)
+        expectDocument("B\n")


### PR DESCRIPTION
contenteditable naturally types over `<br>`s at the end of a block element, and we need to account for their removal now that we’re correctly summarizing `<br>` mutations (1497f52). Discovered by @zachwaugh.

Before:
![lost-formatting](https://cloud.githubusercontent.com/assets/5355/15443950/2ca1ac06-1eba-11e6-835b-f25e5ef017e2.gif)

After:
![lost-formatting-after](https://cloud.githubusercontent.com/assets/5355/15443955/31b930d8-1eba-11e6-93ac-580daf224657.gif)

---

Also accounts for mutations that occur on systems (like iOS) that perform auto-capitalization as you type.

Before:
![capitalize-before](https://cloud.githubusercontent.com/assets/5355/16127123/13d83a22-33c9-11e6-8770-e8854a206e41.gif)

After:
![capitalize-after](https://cloud.githubusercontent.com/assets/5355/16127126/17b6ab06-33c9-11e6-8048-12d7274c11d7.gif)

