### PR TITLE
Fix triggering "trix-focus" event when autofocusing

### DIFF
--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -139,10 +139,10 @@ Trix.registerElement "trix-editor", do ->
 
   attachedCallback: ->
     unless @hasAttribute("data-trix-internal")
-      autofocus(this)
       @editorController ?= new Trix.EditorController(editorElement: this, html: @defaultValue = @value)
       @editorController.registerSelectionManager()
       @registerResetListener()
+      autofocus(this)
       requestAnimationFrame => @notify("initialize")
 
   detachedCallback: ->

--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -10,11 +10,6 @@ Trix.registerElement "trix-editor", do ->
 
   # Contenteditable support helpers
 
-  autofocus = (element) ->
-    unless document.querySelector(":focus")
-      if element.hasAttribute("autofocus") and document.querySelector("[autofocus]") is element
-        element.focus()
-
   makeEditable = (element) ->
     return if element.hasAttribute("contenteditable")
     element.setAttribute("contenteditable", "")
@@ -142,12 +137,22 @@ Trix.registerElement "trix-editor", do ->
       @editorController ?= new Trix.EditorController(editorElement: this, html: @defaultValue = @value)
       @editorController.registerSelectionManager()
       @registerResetListener()
-      autofocus(this)
+      @autofocus()
       requestAnimationFrame => @notify("initialize")
 
   detachedCallback: ->
     @editorController?.unregisterSelectionManager()
     @unregisterResetListener()
+
+  # Autofocus support
+
+  autofocus: ->
+    unless document.querySelector(":focus")
+      if @hasAttribute("autofocus") and document.querySelector("[autofocus]") is this
+        focusTriggered = false
+        handleEventOnce("focus", onElement: this, withCallback: -> focusTriggered = true)
+        @focus()
+        triggerEvent("focus", onElement: this) unless focusTriggered
 
   # Form reset support
 

--- a/test/src/system/custom_element_test.coffee
+++ b/test/src/system/custom_element_test.coffee
@@ -202,6 +202,21 @@ testGroup "Custom element API", template: "editor_empty", ->
                 assert.equal focusEventCount, 1
                 done()
 
+  test "element triggers custom focus event when autofocusing", (done) ->
+    element = document.createElement("trix-editor")
+    element.setAttribute("autofocus", "")
+
+    focusEventCount = 0
+    element.addEventListener "trix-focus", -> focusEventCount++
+
+    container = document.getElementById("trix-container")
+    container.innerHTML = ""
+    container.appendChild(element)
+
+    element.addEventListener "trix-initialize", ->
+      assert.equal focusEventCount, 1
+      done()
+
   test "editor resets to its original value on form reset", (expectDocument) ->
     element = getEditorElement()
     form = element.inputElement.form


### PR DESCRIPTION
Applies autofocus *after* `EditorController` is installed. Otherwise we miss the initial `focus` event.