### PR TITLE
Extract Trix.LineBreakInsertion

### DIFF
--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -1,4 +1,5 @@
 #= require trix/models/document
+#= require trix/models/line_break_insertion
 
 {normalizeRange, rangesAreEqual, objectsAreEqual, summarizeArrayChange, getAllAttributeNames, extend} = Trix
 
@@ -69,50 +70,8 @@ class Trix.Composition extends Trix.BasicObject
     @setSelection(endPosition)
     @notifyDelegateOfInsertionAtRange([startPosition, endPosition])
 
-  breakFormattedBlock: ->
-    position = @getPosition()
-    range = [position - 1, position]
-
-    document = @document
-    {index, offset} = document.locationFromPosition(position)
-    block = document.getBlockAtIndex(index)
-    previousCharacter = block.text.getStringAtPosition(offset - 1)
-    nextCharacter = block.text.getStringAtPosition(offset)
-
-    if block.getBlockBreakPosition() is offset
-      if block.getConfig("breakOnReturn")
-        position += 1
-        range = [position - 1, position]
-      document = document.removeTextAtRange([position - 1, position])
-    else
-      if nextCharacter is "\n"
-        range = [position - 1, position + 1]
-      else if offset - 1 isnt 0
-        position += 1
-
-    newDocument = new Trix.Document [block.removeLastAttribute().copyWithoutText()]
-    @setDocument( document.insertDocumentAtRange(newDocument, range))
-    @setSelection(position)
-
   insertLineBreak: ->
-    [startPosition, endPosition] = @getSelectedRange()
-    endLocation = @document.locationFromPosition(endPosition)
-    block = @document.getBlockAtIndex(endLocation.index)
-
-    if @returnShouldDecreaseListLevel()
-      @decreaseListLevel()
-      @setSelection(startPosition)
-    else if @returnShouldPrependListItem()
-      document = new Trix.Document [block.copyWithoutText()]
-      @insertDocument(document)
-    else if @returnShouldInsertBlockBreak()
-      @insertBlockBreak()
-    else if @returnShouldRemoveLastBlockAttribute()
-      @removeLastBlockAttribute()
-    else if @returnShouldBreakFormattedBlock()
-      @breakFormattedBlock()
-    else
-      @insertString("\n")
+    Trix.LineBreakInsertion.perform(this)
 
   insertHTML: (html) ->
     startPosition = @getPosition()
@@ -502,57 +461,3 @@ class Trix.Composition extends Trix.BasicObject
     utf16string = @document.toUTF16String()
     utf16position = utf16string.offsetFromUCS2Offset(position)
     utf16string.offsetToUCS2Offset(utf16position + offset)
-
-  returnShouldInsertBlockBreak: ->
-    [startPosition, endPosition] = @getSelectedRange()
-    startLocation = @document.locationFromPosition(startPosition)
-    endLocation = @document.locationFromPosition(endPosition)
-    block = @document.getBlockAtIndex(endLocation.index)
-    breaksOnReturn = block.breaksOnReturn()
-    previousCharacter = block.text.getStringAtPosition(endLocation.offset - 1)
-    nextCharacter = block.text.getStringAtPosition(endLocation.offset)
-
-    if block.hasAttributes() and block.isListItem()
-      unless block.isEmpty()
-        return startLocation.offset isnt 0
-
-    breaksOnReturn and nextCharacter isnt "\n"
-
-  returnShouldBreakFormattedBlock: ->
-    [startPosition, endPosition] = @getSelectedRange()
-    endLocation = @document.locationFromPosition(endPosition)
-    block = @document.getBlockAtIndex(endLocation.index)
-    breaksOnReturn = block.breaksOnReturn()
-    previousCharacter = block.text.getStringAtPosition(endLocation.offset - 1)
-    nextCharacter = block.text.getStringAtPosition(endLocation.offset)
-
-    if block.hasAttributes()
-      unless block.isListItem()
-        (breaksOnReturn and nextCharacter is "\n") or previousCharacter is "\n"
-
-  returnShouldDecreaseListLevel: ->
-    [startPosition, endPosition] = @getSelectedRange()
-    endLocation = @document.locationFromPosition(endPosition)
-    block = @document.getBlockAtIndex(endLocation.index)
-    breaksOnReturn = block.breaksOnReturn()
-
-    block.hasAttributes() and block.isListItem() and block.isEmpty()
-
-  returnShouldPrependListItem: ->
-    [startPosition, endPosition] = @getSelectedRange()
-    startLocation = @document.locationFromPosition(startPosition)
-    endLocation = @document.locationFromPosition(endPosition)
-    block = @document.getBlockAtIndex(endLocation.index)
-
-    if block.hasAttributes() and block.isListItem()
-      unless block.isEmpty()
-        startLocation.offset is 0
-
-  returnShouldRemoveLastBlockAttribute: ->
-    [startPosition, endPosition] = @getSelectedRange()
-    endLocation = @document.locationFromPosition(endPosition)
-    block = @document.getBlockAtIndex(endLocation.index)
-
-    if block.hasAttributes()
-      unless block.isListItem()
-        block.isEmpty()

--- a/src/trix/models/line_break_insertion.coffee
+++ b/src/trix/models/line_break_insertion.coffee
@@ -1,0 +1,75 @@
+class Trix.LineBreakInsertion
+  @perform: (composition) ->
+    insertion = new this composition
+    insertion.perform()
+
+  constructor: (@composition) ->
+    {@document} = @composition
+
+    [@startPosition, @endPosition] = @composition.getSelectedRange()
+    @startLocation = @document.locationFromPosition(@startPosition)
+    @endLocation = @document.locationFromPosition(@endPosition)
+
+    @block = @document.getBlockAtIndex(@endLocation.index)
+    @breaksOnReturn = @block.breaksOnReturn()
+    @previousCharacter = @block.text.getStringAtPosition(@endLocation.offset - 1)
+    @nextCharacter = @block.text.getStringAtPosition(@endLocation.offset)
+
+  perform: ->
+    switch
+      when @shouldDecreaseListLevel()
+        @composition.decreaseListLevel()
+        @composition.setSelection(@startPosition)
+      when @shouldPrependListItem()
+        document = new Trix.Document [@block.copyWithoutText()]
+        @composition.insertDocument(document)
+      when @shouldInsertBlockBreak()
+        @composition.insertBlockBreak()
+      when @shouldRemoveLastBlockAttribute()
+        @composition.removeLastBlockAttribute()
+      when @shouldBreakFormattedBlock()
+        @breakFormattedBlock()
+      else
+        @composition.insertString("\n")
+
+  # Private
+
+  breakFormattedBlock: ->
+    document = @document
+    position = @startPosition
+    {offset} = @startLocation
+    range = [position - 1, position]
+
+    if @block.getBlockBreakPosition() is offset
+      if @block.getConfig("breakOnReturn")
+        position += 1
+        range = [position - 1, position]
+      document = document.removeTextAtRange([position - 1, position])
+    else
+      if @nextCharacter is "\n"
+        range = [position - 1, position + 1]
+      else if offset - 1 isnt 0
+        position += 1
+
+    newDocument = new Trix.Document [@block.removeLastAttribute().copyWithoutText()]
+    @composition.setDocument(document.insertDocumentAtRange(newDocument, range))
+    @composition.setSelection(position)
+
+  shouldInsertBlockBreak: ->
+    if @block.hasAttributes() and @block.isListItem() and not @block.isEmpty()
+      @startLocation.offset isnt 0
+    else
+      @breaksOnReturn and @nextCharacter isnt "\n"
+
+  shouldBreakFormattedBlock: ->
+    @block.hasAttributes() and not @block.isListItem() and
+      (@breaksOnReturn and @nextCharacter is "\n") or @previousCharacter is "\n"
+
+  shouldDecreaseListLevel: ->
+    @block.hasAttributes() and @block.isListItem() and @block.isEmpty()
+
+  shouldPrependListItem: ->
+    @block.isListItem() and @startLocation.offset is 0 and not @block.isEmpty()
+
+  shouldRemoveLastBlockAttribute: ->
+    @block.hasAttributes() and not @block.isListItem() and @block.isEmpty()


### PR DESCRIPTION
Hey @drewrygh, 81d868c2ec121f130f7ca3d8c7a042cbf7c7c663 is a great change that definitely improves readability. I noticed that all of the [added `returnShould*` methods](https://github.com/basecamp/trix/commit/81d868c2ec121f130f7ca3d8c7a042cbf7c7c663#diff-e3e9bbb9b78653d0126d51aa52f0ee96R520) mostly work with a common set of data so I extracted them all to a new model (`Trix.LineBreakInsertion`), which sets that data up once and makes the new methods private to the line insertion operation.