### PR TITLE
Nestable block attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ element.editor.setSelectedRange([0, 4])
 element.editor.deleteInDirection("forward")
 ```
 
-## Working With Attributes and Indentation
+## Working With Attributes and Nesting
 
 Trix represents formatting as sets of _attributes_ applied across ranges of a document.
 
@@ -288,14 +288,14 @@ element.editor.activateAttribute("italic")
 element.editor.insertString("This is italic")
 ```
 
-### Adjusting the Indentation Level
+### Adjusting the Nesting Level
 
-To adjust the indentation level of block-level attributes, call the `editor.increaseIndentationLevel` and `editor.decreaseIndentationLevel` methods.
+To adjust the nesting level of quotes, bulleted lists, or numbered lists, call the `editor.increaseNestingLevel` and `editor.decreaseNestingLevel` methods.
 
 ```js
 element.editor.activateAttribute("quote")
-element.editor.increaseIndentationLevel()
-element.editor.decreaseIndentationLevel()
+element.editor.increaseNestingLevel()
+element.editor.decreaseNestingLevel()
 ```
 
 ## Using Undo and Redo

--- a/assets/trix/stylesheets/icons.scss.erb
+++ b/assets/trix/stylesheets/icons.scss.erb
@@ -22,8 +22,12 @@ trix-toolbar .button_group button {
   &.code::before { background-image: url(<%= svgo_data_uri('trix/images/code.svg', precision: 1) %>); }
   &.bullets::before { background-image: url(<%= svgo_data_uri('trix/images/bullets.svg', precision: 0) %>); }
   &.numbers::before { background-image: url(<%= svgo_data_uri('trix/images/numbers.svg', precision: 1) %>); }
-  &.block-level.decrease::before { background-image: url(<%= svgo_data_uri('trix/images/block_level_decrease.svg', precision: 1) %>); }
-  &.block-level.increase::before { background-image: url(<%= svgo_data_uri('trix/images/block_level_increase.svg', precision: 1) %>); }
+  &.indentation-level, &.block-level {
+    &.decrease::before { background-image: url(<%= svgo_data_uri('trix/images/block_level_decrease.svg', precision: 1) %>); }
+  }
+  &.indentation-level, &.block-level {
+    &.increase::before { background-image: url(<%= svgo_data_uri('trix/images/block_level_increase.svg', precision: 1) %>); }
+  }
   &.undo::before { background-image: url(<%= svgo_data_uri('trix/images/undo.svg', precision: 1) %>); }
   &.redo::before { background-image: url(<%= svgo_data_uri('trix/images/redo.svg', precision: 1) %>); }
 }

--- a/src/trix/config/block_attributes.coffee
+++ b/src/trix/config/block_attributes.coffee
@@ -4,7 +4,7 @@ Trix.config.blockAttributes = attributes =
     parse: false
   quote:
     tagName: "blockquote"
-    indentable: true
+    nestable: true
   heading1:
     tagName: "h1"
     terminal: true
@@ -21,7 +21,7 @@ Trix.config.blockAttributes = attributes =
     tagName: "li"
     listAttribute: "bulletList"
     group: false
-    indentable: true
+    nestable: true
     test: (element) ->
       Trix.tagName(element.parentNode) is attributes[@listAttribute].tagName
   numberList:
@@ -31,6 +31,6 @@ Trix.config.blockAttributes = attributes =
     tagName: "li"
     listAttribute: "numberList"
     group: false
-    indentable: true
+    nestable: true
     test: (element) ->
       Trix.tagName(element.parentNode) is attributes[@listAttribute].tagName

--- a/src/trix/config/block_attributes.coffee
+++ b/src/trix/config/block_attributes.coffee
@@ -4,7 +4,7 @@ Trix.config.blockAttributes = attributes =
     parse: false
   quote:
     tagName: "blockquote"
-    nestable: true
+    indentable: true
   heading1:
     tagName: "h1"
     terminal: true
@@ -21,6 +21,7 @@ Trix.config.blockAttributes = attributes =
     tagName: "li"
     listAttribute: "bulletList"
     group: false
+    indentable: true
     test: (element) ->
       Trix.tagName(element.parentNode) is attributes[@listAttribute].tagName
   numberList:
@@ -30,5 +31,6 @@ Trix.config.blockAttributes = attributes =
     tagName: "li"
     listAttribute: "numberList"
     group: false
+    indentable: true
     test: (element) ->
       Trix.tagName(element.parentNode) is attributes[@listAttribute].tagName

--- a/src/trix/config/toolbar.coffee
+++ b/src/trix/config/toolbar.coffee
@@ -17,8 +17,8 @@ Trix.config.toolbar =
         <button type="button" class="code" data-trix-attribute="code" title="#{lang.code}">#{lang.code}</button>
         <button type="button" class="list bullets" data-trix-attribute="bullet" title="#{lang.bullets}">#{lang.bullets}</button>
         <button type="button" class="list numbers" data-trix-attribute="number" title="#{lang.numbers}">#{lang.numbers}</button>
-        <button type="button" class="block-level decrease" data-trix-action="decreaseBlockLevel" title="#{lang.outdent}">#{lang.outdent}</button>
-        <button type="button" class="block-level increase" data-trix-action="increaseBlockLevel" title="#{lang.indent}">#{lang.indent}</button>
+        <button type="button" class="indentation-level decrease" data-trix-action="decreaseIndentationLevel" title="#{lang.outdent}">#{lang.outdent}</button>
+        <button type="button" class="indentation-level increase" data-trix-action="increaseIndentationLevel" title="#{lang.indent}">#{lang.indent}</button>
       </span>
 
       <span class="button_group history_tools">

--- a/src/trix/config/toolbar.coffee
+++ b/src/trix/config/toolbar.coffee
@@ -17,8 +17,8 @@ Trix.config.toolbar =
         <button type="button" class="code" data-trix-attribute="code" title="#{lang.code}">#{lang.code}</button>
         <button type="button" class="list bullets" data-trix-attribute="bullet" title="#{lang.bullets}">#{lang.bullets}</button>
         <button type="button" class="list numbers" data-trix-attribute="number" title="#{lang.numbers}">#{lang.numbers}</button>
-        <button type="button" class="indentation-level decrease" data-trix-action="decreaseIndentationLevel" title="#{lang.outdent}">#{lang.outdent}</button>
-        <button type="button" class="indentation-level increase" data-trix-action="increaseIndentationLevel" title="#{lang.indent}">#{lang.indent}</button>
+        <button type="button" class="indentation-level decrease" data-trix-action="decreaseNestingLevel" title="#{lang.outdent}">#{lang.outdent}</button>
+        <button type="button" class="indentation-level increase" data-trix-action="increaseNestingLevel" title="#{lang.indent}">#{lang.indent}</button>
       </span>
 
       <span class="button_group history_tools">

--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -281,10 +281,16 @@ class Trix.EditorController extends Trix.Controller
       perform: -> @editor.redo()
     link:
       test: -> @editor.canActivateAttribute("href")
-    increaseBlockLevel:
+    increaseIndentationLevel:
       test: -> @editor.canIncreaseIndentationLevel()
       perform: -> @editor.increaseIndentationLevel() and @render()
-    decreaseBlockLevel:
+    decreaseIndentationLevel:
+      test: -> @editor.canDecreaseIndentationLevel()
+      perform: -> @editor.decreaseIndentationLevel() and @render()
+    increaseBlockLevel: # deprecated in favor of increaseIndentationLevel
+      test: -> @editor.canIncreaseIndentationLevel()
+      perform: -> @editor.increaseIndentationLevel() and @render()
+    decreaseBlockLevel: # deprecated in favor of decreaseIndentationLevel
       test: -> @editor.canDecreaseIndentationLevel()
       perform: -> @editor.decreaseIndentationLevel() and @render()
 

--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -281,18 +281,18 @@ class Trix.EditorController extends Trix.Controller
       perform: -> @editor.redo()
     link:
       test: -> @editor.canActivateAttribute("href")
-    increaseIndentationLevel:
-      test: -> @editor.canIncreaseIndentationLevel()
-      perform: -> @editor.increaseIndentationLevel() and @render()
-    decreaseIndentationLevel:
-      test: -> @editor.canDecreaseIndentationLevel()
-      perform: -> @editor.decreaseIndentationLevel() and @render()
-    increaseBlockLevel: # deprecated in favor of increaseIndentationLevel
-      test: -> @editor.canIncreaseIndentationLevel()
-      perform: -> @editor.increaseIndentationLevel() and @render()
-    decreaseBlockLevel: # deprecated in favor of decreaseIndentationLevel
-      test: -> @editor.canDecreaseIndentationLevel()
-      perform: -> @editor.decreaseIndentationLevel() and @render()
+    increaseNestingLevel:
+      test: -> @editor.canIncreaseNestingLevel()
+      perform: -> @editor.increaseNestingLevel() and @render()
+    decreaseNestingLevel:
+      test: -> @editor.canDecreaseNestingLevel()
+      perform: -> @editor.decreaseNestingLevel() and @render()
+    increaseBlockLevel: # deprecated in favor of increaseNestingLevel
+      test: -> @editor.canIncreaseNestingLevel()
+      perform: -> @editor.increaseNestingLevel() and @render()
+    decreaseBlockLevel: # deprecated in favor of decreaseNestingLevel
+      test: -> @editor.canDecreaseNestingLevel()
+      perform: -> @editor.decreaseNestingLevel() and @render()
 
   canInvokeAction: (actionName) ->
     if @actionIsExternal(actionName)

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -300,8 +300,8 @@ class Trix.InputController extends Trix.BasicObject
       @responder?.insertLineBreak()
 
     tab: (event) ->
-      if @responder?.canIncreaseBlockAttributeLevel()
-        @responder?.increaseBlockAttributeLevel()
+      if @responder?.canIncreaseIndentationLevel()
+        @responder?.increaseIndentationLevel()
         @requestRender()
         event.preventDefault()
 
@@ -336,8 +336,8 @@ class Trix.InputController extends Trix.BasicObject
         @responder?.insertString("\n")
 
       tab: (event) ->
-        if @responder?.canDecreaseBlockAttributeLevel()
-          @responder?.decreaseBlockAttributeLevel()
+        if @responder?.canDecreaseIndentationLevel()
+          @responder?.decreaseIndentationLevel()
           @requestRender()
           event.preventDefault()
 

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -300,8 +300,8 @@ class Trix.InputController extends Trix.BasicObject
       @responder?.insertLineBreak()
 
     tab: (event) ->
-      if @responder?.canIncreaseIndentationLevel()
-        @responder?.increaseIndentationLevel()
+      if @responder?.canIncreaseNestingLevel()
+        @responder?.increaseNestingLevel()
         @requestRender()
         event.preventDefault()
 
@@ -336,8 +336,8 @@ class Trix.InputController extends Trix.BasicObject
         @responder?.insertString("\n")
 
       tab: (event) ->
-        if @responder?.canDecreaseIndentationLevel()
-          @responder?.decreaseIndentationLevel()
+        if @responder?.canDecreaseNestingLevel()
+          @responder?.decreaseNestingLevel()
           @requestRender()
           event.preventDefault()
 

--- a/src/trix/core/helpers/arrays.coffee
+++ b/src/trix/core/helpers/arrays.coffee
@@ -8,6 +8,11 @@ Trix.extend
   arrayStartsWith: (a = [], b = []) ->
     Trix.arraysAreEqual(a.slice(0, b.length), b)
 
+  spliceArray: (array, args...) ->
+    result = array.slice(0)
+    result.splice(args...)
+    result
+
   summarizeArrayChange: (oldArray = [], newArray = []) ->
     added = []
     removed = []

--- a/src/trix/core/helpers/collections.coffee
+++ b/src/trix/core/helpers/collections.coffee
@@ -5,6 +5,9 @@ Trix.extend
       return false unless value is b[index]
     true
 
+  arrayStartsWith: (a = [], b = []) ->
+    Trix.arraysAreEqual(a.slice(0, b.length), b)
+
   summarizeArrayChange: (oldArray = [], newArray = []) ->
     added = []
     removed = []

--- a/src/trix/core/helpers/index.coffee
+++ b/src/trix/core/helpers/index.coffee
@@ -2,7 +2,7 @@
 #= require trix/core/helpers/functions
 #= require trix/core/helpers/strings
 #= require trix/core/helpers/objects
-#= require trix/core/helpers/collections
+#= require trix/core/helpers/arrays
 #= require trix/core/helpers/config
 #= require trix/core/helpers/dom
 #= require trix/core/helpers/ranges

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -63,23 +63,23 @@ class Trix.Block extends Trix.Object
   hasAttributes: ->
     @getAttributeLevel() > 0
 
-  getLastIndentableAttribute: ->
-    getLastElement(@getIndentableAttributes())
+  getLastNestableAttribute: ->
+    getLastElement(@getNestableAttributes())
 
-  getIndentableAttributes: ->
-    attribute for attribute in @attributes when getBlockConfig(attribute).indentable
+  getNestableAttributes: ->
+    attribute for attribute in @attributes when getBlockConfig(attribute).nestable
 
-  getIndentationLevel: ->
-    @getIndentableAttributes().length
+  getNestingLevel: ->
+    @getNestableAttributes().length
 
-  decreaseIndentationLevel: ->
-    if attribute = @getLastIndentableAttribute()
+  decreaseNestingLevel: ->
+    if attribute = @getLastNestableAttribute()
       @removeAttribute(attribute)
     else
       this
 
-  increaseIndentationLevel: ->
-    if attribute = @getLastIndentableAttribute()
+  increaseNestingLevel: ->
+    if attribute = @getLastNestableAttribute()
       index = @attributes.lastIndexOf(attribute)
       attributes = spliceArray(@attributes, index + 1, 0, expandAttribute(attribute)...)
       @copyWithAttributes(attributes)

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -37,11 +37,7 @@ class Trix.Block extends Trix.Object
       @copyWithText(@text.copyUsingObjectMap(objectMap))
 
   addAttribute: (attribute) ->
-    {listAttribute} = getBlockConfig(attribute)
-    attributes = if listAttribute
-      @attributes.concat([listAttribute, attribute])
-    else
-      @attributes.concat([attribute])
+    attributes = @attributes.concat(expandAttribute(attribute))
     @copyWithAttributes(attributes)
 
   removeAttribute: (attribute) ->
@@ -75,6 +71,20 @@ class Trix.Block extends Trix.Object
 
   getIndentationLevel: ->
     @getIndentableAttributes().length
+
+  decreaseIndentationLevel: ->
+    if attribute = @getLastIndentableAttribute()
+      @removeAttribute(attribute)
+    else
+      this
+
+  increaseIndentationLevel: ->
+    if attribute = @getLastIndentableAttribute()
+      index = @attributes.lastIndexOf(attribute)
+      attributes = splice(@attributes, index + 1, 0, expandAttribute(attribute)...)
+      @copyWithAttributes(attributes)
+    else
+      this
 
   getListItemAttributes: ->
     attribute for attribute in @attributes when getBlockConfig(attribute).listAttribute
@@ -201,6 +211,15 @@ class Trix.Block extends Trix.Object
   unmarkBlockBreakPiece = (piece) ->
     piece.copyWithoutAttribute("blockBreak")
 
+  # Attributes
+
+  expandAttribute = (attribute) ->
+    {listAttribute} = getBlockConfig(attribute)
+    if listAttribute?
+      [listAttribute, attribute]
+    else
+      [attribute]
+
   # Array helpers
 
   getLastElement = (array) ->
@@ -212,3 +231,8 @@ class Trix.Block extends Trix.Object
       array
     else
       array.slice(0, index).concat(array.slice(index + 1))
+
+  splice = (array, args...) ->
+    result = array.slice(0)
+    result.splice(args...)
+    result

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -83,7 +83,7 @@ class Trix.Block extends Trix.Object
     @getListItemAttributes().length
 
   isListItem: ->
-    @getListLevel() > 0
+    getBlockConfig(@getLastAttribute())?.listAttribute
 
   isTerminalBlock: ->
     getBlockConfig(@getLastAttribute())?.terminal

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -89,9 +89,6 @@ class Trix.Block extends Trix.Object
   getListItemAttributes: ->
     attribute for attribute in @attributes when getBlockConfig(attribute).listAttribute
 
-  getListLevel: ->
-    @getListItemAttributes().length
-
   isListItem: ->
     getBlockConfig(@getLastAttribute())?.listAttribute
 

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -68,19 +68,29 @@ class Trix.Block extends Trix.Object
   hasAttributes: ->
     @getAttributeLevel() > 0
 
-  getConfig: (key) ->
-    return unless attribute = @getLastAttribute()
-    return unless config = getBlockConfig(attribute)
-    if key then config[key] else config
+  getLastIndentableAttribute: ->
+    getLastElement(@getIndentableAttributes())
+
+  getIndentableAttributes: ->
+    attribute for attribute in @attributes when getBlockConfig(attribute).indentable
+
+  getIndentationLevel: ->
+    @getIndentableAttributes().length
+
+  getListItemAttributes: ->
+    attribute for attribute in @attributes when getBlockConfig(attribute).listAttribute
+
+  getListLevel: ->
+    @getListItemAttributes().length
 
   isListItem: ->
-    @getConfig("listAttribute")?
+    @getListLevel() > 0
 
   isTerminalBlock: ->
-    @getConfig("terminal")?
+    getBlockConfig(@getLastAttribute())?.terminal
 
   breaksOnReturn: ->
-    @getConfig("breakOnReturn")?
+    getBlockConfig(@getLastAttribute())?.breakOnReturn
 
   findLineBreakInDirectionFromPosition: (direction, position) ->
     string = @toString()

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -46,8 +46,7 @@ class Trix.Block extends Trix.Object
 
   removeAttribute: (attribute) ->
     {listAttribute} = getBlockConfig(attribute)
-    attributes = removeLastElement(@attributes, attribute)
-    attributes = removeLastElement(attributes, listAttribute) if listAttribute?
+    attributes = removeLastValue(removeLastValue(@attributes, attribute), listAttribute)
     @copyWithAttributes(attributes)
 
   removeLastAttribute: ->
@@ -204,11 +203,12 @@ class Trix.Block extends Trix.Object
 
   # Array helpers
 
-  removeLastElement = (array, element) ->
-    if getLastElement(array) is element
-      array.slice(0, -1)
-    else
-      array
-
   getLastElement = (array) ->
     array.slice(-1)[0]
+
+  removeLastValue = (array, value) ->
+    index = array.lastIndexOf(value)
+    if index is -1
+      array
+    else
+      array.slice(0, index).concat(array.slice(index + 1))

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -230,7 +230,7 @@ class Trix.Block extends Trix.Object
     if index is -1
       array
     else
-      array.slice(0, index).concat(array.slice(index + 1))
+      splice(array, index, 1)
 
   splice = (array, args...) ->
     result = array.slice(0)

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -1,6 +1,6 @@
 #= require trix/models/text
 
-{arraysAreEqual, getBlockConfig, getBlockAttributeNames, getListAttributeNames} = Trix
+{arraysAreEqual, spliceArray, getBlockConfig, getBlockAttributeNames, getListAttributeNames} = Trix
 
 class Trix.Block extends Trix.Object
   @fromJSON: (blockJSON) ->
@@ -81,7 +81,7 @@ class Trix.Block extends Trix.Object
   increaseIndentationLevel: ->
     if attribute = @getLastIndentableAttribute()
       index = @attributes.lastIndexOf(attribute)
-      attributes = splice(@attributes, index + 1, 0, expandAttribute(attribute)...)
+      attributes = spliceArray(@attributes, index + 1, 0, expandAttribute(attribute)...)
       @copyWithAttributes(attributes)
     else
       this
@@ -227,9 +227,4 @@ class Trix.Block extends Trix.Object
     if index is -1
       array
     else
-      splice(array, index, 1)
-
-  splice = (array, args...) ->
-    result = array.slice(0)
-    result.splice(args...)
-    result
+      spliceArray(array, index, 1)

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -252,7 +252,7 @@ class Trix.Composition extends Trix.BasicObject
 
   canIncreaseIndentationLevel: ->
     return unless block = @getBlock()
-    if block.getListLevel() > 0
+    if getBlockConfig(block.getLastIndentableAttribute())?.listAttribute
       if previousBlock = @getPreviousBlock()
         block.getListLevel() <= previousBlock.getListLevel()
     else

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -1,7 +1,7 @@
 #= require trix/models/document
 #= require trix/models/line_break_insertion
 
-{normalizeRange, rangesAreEqual, objectsAreEqual, summarizeArrayChange, getAllAttributeNames, getBlockConfig, getTextConfig, extend} = Trix
+{normalizeRange, rangesAreEqual, objectsAreEqual, arrayStartsWith, summarizeArrayChange, getAllAttributeNames, getBlockConfig, getTextConfig, extend} = Trix
 
 class Trix.Composition extends Trix.BasicObject
   constructor: ->
@@ -254,7 +254,7 @@ class Trix.Composition extends Trix.BasicObject
     return unless block = @getBlock()
     if getBlockConfig(block.getLastIndentableAttribute())?.listAttribute
       if previousBlock = @getPreviousBlock()
-        block.getListLevel() <= previousBlock.getListLevel()
+        arrayStartsWith(previousBlock.getListItemAttributes(), block.getListItemAttributes())
     else
       block.getIndentationLevel() > 0
 

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -247,9 +247,28 @@ class Trix.Composition extends Trix.BasicObject
     return unless selectedRange = @getSelectedRange()
     @setDocument(@document.removeAttributeAtRange(attributeName, selectedRange))
 
-  increaseBlockAttributeLevel: ->
-    if attribute = @getBlock()?.getLastAttribute()
+  canDecreaseIndentationLevel: ->
+    @getBlock()?.getIndentationLevel() > 0
+
+  canIncreaseIndentationLevel: ->
+    return unless block = @getBlock()
+    if block.isListItem()
+      if previousBlock = @getPreviousBlock()
+        block.getListLevel() is previousBlock.getListLevel()
+    else
+      block.getIndentationLevel() > 0
+
+  decreaseIndentationLevel: ->
+    if attribute = @getBlock()?.getLastIndentableAttribute()
+      console.log "removing current attribute", attribute
+      @removeCurrentAttribute(attribute)
+
+  increaseIndentationLevel: ->
+    if attribute = @getBlock()?.getLastIndentableAttribute()
       @setCurrentAttribute(attribute)
+
+  canDecreaseBlockAttributeLevel: ->
+    @getBlock()?.getAttributeLevel() > 0
 
   decreaseBlockAttributeLevel: ->
     if attribute = @getBlock()?.getLastAttribute()
@@ -268,19 +287,6 @@ class Trix.Composition extends Trix.BasicObject
     startPosition = @document.positionFromLocation(index: index, offset: 0)
     endPosition = @document.positionFromLocation(index: endIndex, offset: 0)
     @setDocument(@document.removeLastListAttributeAtRange([startPosition, endPosition]))
-
-  canIncreaseBlockAttributeLevel: ->
-    return unless block = @getBlock()
-    nestable = block.getConfig("nestable")
-    if nestable?
-      nestable
-    else if block.isListItem()
-      if previousBlock = @getPreviousBlock()
-        level = block.getAttributeLevel()
-        previousBlock.getAttributeAtLevel(level) is block.getAttributeAtLevel(level)
-
-  canDecreaseBlockAttributeLevel: ->
-    @getBlock()?.getAttributeLevel() > 0
 
   updateCurrentAttributes: ->
     if selectedRange = @getSelectedRange(ignoreLock: true)

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -260,7 +260,6 @@ class Trix.Composition extends Trix.BasicObject
 
   decreaseIndentationLevel: ->
     if attribute = @getBlock()?.getLastIndentableAttribute()
-      console.log "removing current attribute", attribute
       @removeCurrentAttribute(attribute)
 
   increaseIndentationLevel: ->

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -247,24 +247,24 @@ class Trix.Composition extends Trix.BasicObject
     return unless selectedRange = @getSelectedRange()
     @setDocument(@document.removeAttributeAtRange(attributeName, selectedRange))
 
-  canDecreaseIndentationLevel: ->
-    @getBlock()?.getIndentationLevel() > 0
+  canDecreaseNestingLevel: ->
+    @getBlock()?.getNestingLevel() > 0
 
-  canIncreaseIndentationLevel: ->
+  canIncreaseNestingLevel: ->
     return unless block = @getBlock()
-    if getBlockConfig(block.getLastIndentableAttribute())?.listAttribute
+    if getBlockConfig(block.getLastNestableAttribute())?.listAttribute
       if previousBlock = @getPreviousBlock()
         arrayStartsWith(previousBlock.getListItemAttributes(), block.getListItemAttributes())
     else
-      block.getIndentationLevel() > 0
+      block.getNestingLevel() > 0
 
-  decreaseIndentationLevel: ->
+  decreaseNestingLevel: ->
     return unless block = @getBlock()
-    @setDocument(@document.replaceBlock(block, block.decreaseIndentationLevel()))
+    @setDocument(@document.replaceBlock(block, block.decreaseNestingLevel()))
 
-  increaseIndentationLevel: ->
+  increaseNestingLevel: ->
     return unless block = @getBlock()
-    @setDocument(@document.replaceBlock(block, block.increaseIndentationLevel()))
+    @setDocument(@document.replaceBlock(block, block.increaseNestingLevel()))
 
   canDecreaseBlockAttributeLevel: ->
     @getBlock()?.getAttributeLevel() > 0

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -252,19 +252,19 @@ class Trix.Composition extends Trix.BasicObject
 
   canIncreaseIndentationLevel: ->
     return unless block = @getBlock()
-    if block.isListItem()
+    if block.getListLevel() > 0
       if previousBlock = @getPreviousBlock()
-        block.getListLevel() is previousBlock.getListLevel()
+        block.getListLevel() <= previousBlock.getListLevel()
     else
       block.getIndentationLevel() > 0
 
   decreaseIndentationLevel: ->
-    if attribute = @getBlock()?.getLastIndentableAttribute()
-      @removeCurrentAttribute(attribute)
+    return unless block = @getBlock()
+    @setDocument(@document.replaceBlock(block, block.decreaseIndentationLevel()))
 
   increaseIndentationLevel: ->
-    if attribute = @getBlock()?.getLastIndentableAttribute()
-      @setCurrentAttribute(attribute)
+    return unless block = @getBlock()
+    @setDocument(@document.replaceBlock(block, block.increaseIndentationLevel()))
 
   canDecreaseBlockAttributeLevel: ->
     @getBlock()?.getAttributeLevel() > 0

--- a/src/trix/models/document.coffee
+++ b/src/trix/models/document.coffee
@@ -56,10 +56,9 @@ class Trix.Document extends Trix.Object
     new @constructor blocks
 
   replaceBlock: (oldBlock, newBlock) ->
-    index = @blockList.toArray().indexOf(oldBlock)
+    index = @blockList.indexOf(oldBlock)
     return this if index is -1
     new @constructor @blockList.replaceObjectAtIndex(newBlock, index)
-
 
   insertDocumentAtRange: (document, range) ->
     {blockList} = document
@@ -140,7 +139,7 @@ class Trix.Document extends Trix.Object
 
     blocks = @blockList.toArray()
     affectedBlockCount = rightIndex + 1 - leftIndex
-    blocks.splice(leftIndex, affectedBlockCount, block)
+    blocks = @blockList.splice(leftIndex, affectedBlockCount, block)
 
     new @constructor blocks
 

--- a/src/trix/models/document.coffee
+++ b/src/trix/models/document.coffee
@@ -55,6 +55,11 @@ class Trix.Document extends Trix.Object
       block.copyWithAttributes(attributes)
     new @constructor blocks
 
+  replaceBlock: (oldBlock, newBlock) ->
+    index = @blockList.toArray().indexOf(oldBlock)
+    return this if index is -1
+    new @constructor @blockList.replaceObjectAtIndex(newBlock, index)
+
 
   insertDocumentAtRange: (document, range) ->
     {blockList} = document

--- a/src/trix/models/editor.coffee
+++ b/src/trix/models/editor.coffee
@@ -94,18 +94,18 @@ class Trix.Editor
   # Indentation level
 
   canDecreaseIndentationLevel: ->
-    @composition.canDecreaseBlockAttributeLevel()
+    @composition.canDecreaseIndentationLevel()
 
   canIncreaseIndentationLevel: ->
-    @composition.canIncreaseBlockAttributeLevel()
+    @composition.canIncreaseIndentationLevel()
 
   decreaseIndentationLevel: ->
     if @canDecreaseIndentationLevel()
-      @composition.decreaseBlockAttributeLevel()
+      @composition.decreaseIndentationLevel()
 
   increaseIndentationLevel: ->
     if @canIncreaseIndentationLevel()
-      @composition.increaseBlockAttributeLevel()
+      @composition.increaseIndentationLevel()
 
   # Undo/redo
 

--- a/src/trix/models/editor.coffee
+++ b/src/trix/models/editor.coffee
@@ -91,21 +91,35 @@ class Trix.Editor
   deactivateAttribute: (name) ->
     @composition.removeCurrentAttribute(name)
 
-  # Indentation level
+  # Nesting level
+
+  canDecreaseNestingLevel: ->
+    @composition.canDecreaseNestingLevel()
+
+  canIncreaseNestingLevel: ->
+    @composition.canIncreaseNestingLevel()
+
+  decreaseNestingLevel: ->
+    if @canDecreaseNestingLevel()
+      @composition.decreaseNestingLevel()
+
+  increaseNestingLevel: ->
+    if @canIncreaseNestingLevel()
+      @composition.increaseNestingLevel()
+
+  # Indentation level (deprecated aliases to be removed in v1.0)
 
   canDecreaseIndentationLevel: ->
-    @composition.canDecreaseIndentationLevel()
+    @canDecreaseNestingLevel()
 
   canIncreaseIndentationLevel: ->
-    @composition.canIncreaseIndentationLevel()
+    @canIncreaseNestingLevel()
 
   decreaseIndentationLevel: ->
-    if @canDecreaseIndentationLevel()
-      @composition.decreaseIndentationLevel()
+    @decreaseNestingLevel()
 
   increaseIndentationLevel: ->
-    if @canIncreaseIndentationLevel()
-      @composition.increaseIndentationLevel()
+    @increaseNestingLevel()
 
   # Undo/redo
 

--- a/src/trix/models/splittable_list.coffee
+++ b/src/trix/models/splittable_list.coffee
@@ -1,3 +1,5 @@
+{spliceArray} = Trix
+
 class Trix.SplittableList extends Trix.Object
   @box: (objects) ->
     if objects instanceof this
@@ -10,18 +12,20 @@ class Trix.SplittableList extends Trix.Object
     @objects = objects.slice(0)
     @length = @objects.length
 
+  indexOf: (object) ->
+    @objects.indexOf(object)
+
+  splice: (args...) ->
+    new @constructor spliceArray(@objects, args...)
+
   eachObject: (callback) ->
     callback(object, index) for object, index in @objects
 
   insertObjectAtIndex: (object, index) ->
-    objects = @objects.slice(0)
-    objects.splice(index, 0, object)
-    new @constructor objects
+    @splice(index, 0, object)
 
   insertSplittableListAtIndex: (splittableList, index) ->
-    objects = @objects.slice(0)
-    objects.splice(index, 0, splittableList.objects...)
-    new @constructor objects
+    @splice(index, 0, splittableList.objects...)
 
   insertSplittableListAtPosition: (splittableList, position) ->
     [objects, index] = @splitObjectAtPosition(position)
@@ -31,14 +35,10 @@ class Trix.SplittableList extends Trix.Object
     @replaceObjectAtIndex(callback(@objects[index]), index)
 
   replaceObjectAtIndex: (object, index) ->
-    objects = @objects.slice(0)
-    objects.splice(index, 1, object)
-    new @constructor objects
+    @splice(index, 1, object)
 
   removeObjectAtIndex: (index) ->
-    objects = @objects.slice(0)
-    objects.splice(index, 1)
-    new @constructor objects
+    @splice(index, 1)
 
   getObjectAtIndex: (index) ->
     @objects[index]
@@ -53,8 +53,7 @@ class Trix.SplittableList extends Trix.Object
 
   removeObjectsInRange: (range) ->
     [objects, leftIndex, rightIndex] = @splitObjectsAtRange(range)
-    objects.splice(leftIndex, rightIndex - leftIndex + 1)
-    new @constructor objects
+    @splice(leftIndex, rightIndex - leftIndex + 1)
 
   transformObjectsInRange: (range, transform) ->
     [objects, leftIndex, rightIndex] = @splitObjectsAtRange(range)
@@ -113,8 +112,7 @@ class Trix.SplittableList extends Trix.Object
     objects = @objects.slice(0)
     objectsInRange = objects.slice(startIndex, endIndex + 1)
     consolidatedInRange = new @constructor(objectsInRange).consolidate().toArray()
-    objects.splice(startIndex, objectsInRange.length, consolidatedInRange...)
-    new @constructor objects
+    @splice(startIndex, objectsInRange.length, consolidatedInRange...)
 
   findIndexAndOffsetAtPosition: (position) ->
     currentPosition = 0

--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -507,3 +507,14 @@ testGroup "Block formatting", template: "editor_empty", ->
           assert.equal document.getBlockCount(), 1
           assert.blockAttributes([0, 1], ["bulletList", "bullet", "quote", "quote"])
           expectDocument("\n")
+
+  test "list indentation constraints consider the list type", (expectDocument) ->
+    clickToolbarButton attribute: "bullet", ->
+      typeCharacters "a\n\n", ->
+        clickToolbarButton attribute: "number", ->
+          clickToolbarButton action: "increaseBlockLevel", ->
+            document = getDocument()
+            assert.equal document.getBlockCount(), 2
+            assert.blockAttributes([0, 1], ["bulletList", "bullet"])
+            assert.blockAttributes([2, 3], ["numberList", "number"])
+            expectDocument("a\n\n")

--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -216,7 +216,7 @@ testGroup "Block formatting", template: "editor_empty", ->
 
   test "backspacing a nested quote", (done) ->
     clickToolbarButton attribute: "quote", ->
-      clickToolbarButton action: "increaseIndentationLevel", ->
+      clickToolbarButton action: "increaseNestingLevel", ->
         assert.blockAttributes([0, 1], ["quote", "quote"])
         pressKey "backspace", ->
           assert.blockAttributes([0, 1], ["quote"])
@@ -234,7 +234,7 @@ testGroup "Block formatting", template: "editor_empty", ->
   test "backspacing a nested list item", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       typeCharacters "a\n", ->
-        clickToolbarButton action: "increaseIndentationLevel", ->
+        clickToolbarButton action: "increaseNestingLevel", ->
           assert.blockAttributes([2, 3], ["bulletList", "bullet", "bulletList", "bullet"])
           pressKey "backspace", ->
             assert.blockAttributes([2, 3], ["bulletList", "bullet"])
@@ -253,7 +253,7 @@ testGroup "Block formatting", template: "editor_empty", ->
   test "backspacing selected nested list items", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       typeCharacters "a\n", ->
-        clickToolbarButton action: "increaseIndentationLevel", ->
+        clickToolbarButton action: "increaseNestingLevel", ->
           typeCharacters "b", ->
             getSelectionManager().setLocationRange([{index: 0, offset: 0}, {index: 1, offset: 1}])
             pressKey "backspace", ->
@@ -281,18 +281,18 @@ testGroup "Block formatting", template: "editor_empty", ->
             expectDocument("d\n")
 
   test "increasing list level", (done) ->
-    assert.ok isToolbarButtonDisabled(action: "increaseIndentationLevel")
-    assert.ok isToolbarButtonDisabled(action: "decreaseIndentationLevel")
+    assert.ok isToolbarButtonDisabled(action: "increaseNestingLevel")
+    assert.ok isToolbarButtonDisabled(action: "decreaseNestingLevel")
     clickToolbarButton attribute: "bullet", ->
-      assert.ok isToolbarButtonDisabled(action: "increaseIndentationLevel")
-      assert.notOk isToolbarButtonDisabled(action: "decreaseIndentationLevel")
+      assert.ok isToolbarButtonDisabled(action: "increaseNestingLevel")
+      assert.notOk isToolbarButtonDisabled(action: "decreaseNestingLevel")
       typeCharacters "a\n", ->
-        assert.notOk isToolbarButtonDisabled(action: "increaseIndentationLevel")
-        assert.notOk isToolbarButtonDisabled(action: "decreaseIndentationLevel")
-        clickToolbarButton action: "increaseIndentationLevel", ->
+        assert.notOk isToolbarButtonDisabled(action: "increaseNestingLevel")
+        assert.notOk isToolbarButtonDisabled(action: "decreaseNestingLevel")
+        clickToolbarButton action: "increaseNestingLevel", ->
           typeCharacters "b", ->
-            assert.ok isToolbarButtonDisabled(action: "increaseIndentationLevel")
-            assert.notOk isToolbarButtonDisabled(action: "decreaseIndentationLevel")
+            assert.ok isToolbarButtonDisabled(action: "increaseNestingLevel")
+            assert.notOk isToolbarButtonDisabled(action: "decreaseNestingLevel")
             assert.blockAttributes([0, 2], ["bulletList", "bullet"])
             assert.blockAttributes([2, 4], ["bulletList", "bullet", "bulletList", "bullet"])
             done()
@@ -473,14 +473,14 @@ testGroup "Block formatting", template: "editor_empty", ->
 
   test "code blocks are not indentable", (done) ->
     clickToolbarButton attribute: "code", ->
-      assert.notOk isToolbarButtonActive(action: "increaseIndentationLevel")
+      assert.notOk isToolbarButtonActive(action: "increaseNestingLevel")
       done()
 
   test "unindenting a code block inside a bullet", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       clickToolbarButton attribute: "code", ->
         typeCharacters "a", ->
-          clickToolbarButton action: "decreaseIndentationLevel", ->
+          clickToolbarButton action: "decreaseNestingLevel", ->
             document = getDocument()
             assert.equal document.getBlockCount(), 1
             assert.blockAttributes([0, 1], ["code"])
@@ -492,7 +492,7 @@ testGroup "Block formatting", template: "editor_empty", ->
         typeCharacters "\n", ->
           clickToolbarButton attribute: "heading1", ->
             typeCharacters "b", ->
-              clickToolbarButton action: "increaseIndentationLevel", ->
+              clickToolbarButton action: "increaseNestingLevel", ->
                 document = getDocument()
                 assert.equal document.getBlockCount(), 2
                 assert.blockAttributes([0, 1], ["bulletList", "bullet"])
@@ -502,7 +502,7 @@ testGroup "Block formatting", template: "editor_empty", ->
   test "indenting a quote inside a bullet", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       clickToolbarButton attribute: "quote", ->
-        clickToolbarButton action: "increaseIndentationLevel", ->
+        clickToolbarButton action: "increaseNestingLevel", ->
           document = getDocument()
           assert.equal document.getBlockCount(), 1
           assert.blockAttributes([0, 1], ["bulletList", "bullet", "quote", "quote"])
@@ -512,7 +512,7 @@ testGroup "Block formatting", template: "editor_empty", ->
     clickToolbarButton attribute: "bullet", ->
       typeCharacters "a\n\n", ->
         clickToolbarButton attribute: "number", ->
-          clickToolbarButton action: "increaseIndentationLevel", ->
+          clickToolbarButton action: "increaseNestingLevel", ->
             document = getDocument()
             assert.equal document.getBlockCount(), 2
             assert.blockAttributes([0, 1], ["bulletList", "bullet"])

--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -498,3 +498,12 @@ testGroup "Block formatting", template: "editor_empty", ->
                 assert.blockAttributes([0, 1], ["bulletList", "bullet"])
                 assert.blockAttributes([2, 3], ["bulletList", "bullet", "bulletList", "bullet", "heading1"])
                 expectDocument("a\nb\n")
+
+  test "indenting a quote inside a bullet", (expectDocument) ->
+    clickToolbarButton attribute: "bullet", ->
+      clickToolbarButton attribute: "quote", ->
+        clickToolbarButton action: "increaseBlockLevel", ->
+          document = getDocument()
+          assert.equal document.getBlockCount(), 1
+          assert.blockAttributes([0, 1], ["bulletList", "bullet", "quote", "quote"])
+          expectDocument("\n")

--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -216,7 +216,7 @@ testGroup "Block formatting", template: "editor_empty", ->
 
   test "backspacing a nested quote", (done) ->
     clickToolbarButton attribute: "quote", ->
-      clickToolbarButton action: "increaseBlockLevel", ->
+      clickToolbarButton action: "increaseIndentationLevel", ->
         assert.blockAttributes([0, 1], ["quote", "quote"])
         pressKey "backspace", ->
           assert.blockAttributes([0, 1], ["quote"])
@@ -234,7 +234,7 @@ testGroup "Block formatting", template: "editor_empty", ->
   test "backspacing a nested list item", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       typeCharacters "a\n", ->
-        clickToolbarButton action: "increaseBlockLevel", ->
+        clickToolbarButton action: "increaseIndentationLevel", ->
           assert.blockAttributes([2, 3], ["bulletList", "bullet", "bulletList", "bullet"])
           pressKey "backspace", ->
             assert.blockAttributes([2, 3], ["bulletList", "bullet"])
@@ -253,7 +253,7 @@ testGroup "Block formatting", template: "editor_empty", ->
   test "backspacing selected nested list items", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       typeCharacters "a\n", ->
-        clickToolbarButton action: "increaseBlockLevel", ->
+        clickToolbarButton action: "increaseIndentationLevel", ->
           typeCharacters "b", ->
             getSelectionManager().setLocationRange([{index: 0, offset: 0}, {index: 1, offset: 1}])
             pressKey "backspace", ->
@@ -281,18 +281,18 @@ testGroup "Block formatting", template: "editor_empty", ->
             expectDocument("d\n")
 
   test "increasing list level", (done) ->
-    assert.ok isToolbarButtonDisabled(action: "increaseBlockLevel")
-    assert.ok isToolbarButtonDisabled(action: "decreaseBlockLevel")
+    assert.ok isToolbarButtonDisabled(action: "increaseIndentationLevel")
+    assert.ok isToolbarButtonDisabled(action: "decreaseIndentationLevel")
     clickToolbarButton attribute: "bullet", ->
-      assert.ok isToolbarButtonDisabled(action: "increaseBlockLevel")
-      assert.notOk isToolbarButtonDisabled(action: "decreaseBlockLevel")
+      assert.ok isToolbarButtonDisabled(action: "increaseIndentationLevel")
+      assert.notOk isToolbarButtonDisabled(action: "decreaseIndentationLevel")
       typeCharacters "a\n", ->
-        assert.notOk isToolbarButtonDisabled(action: "increaseBlockLevel")
-        assert.notOk isToolbarButtonDisabled(action: "decreaseBlockLevel")
-        clickToolbarButton action: "increaseBlockLevel", ->
+        assert.notOk isToolbarButtonDisabled(action: "increaseIndentationLevel")
+        assert.notOk isToolbarButtonDisabled(action: "decreaseIndentationLevel")
+        clickToolbarButton action: "increaseIndentationLevel", ->
           typeCharacters "b", ->
-            assert.ok isToolbarButtonDisabled(action: "increaseBlockLevel")
-            assert.notOk isToolbarButtonDisabled(action: "decreaseBlockLevel")
+            assert.ok isToolbarButtonDisabled(action: "increaseIndentationLevel")
+            assert.notOk isToolbarButtonDisabled(action: "decreaseIndentationLevel")
             assert.blockAttributes([0, 2], ["bulletList", "bullet"])
             assert.blockAttributes([2, 4], ["bulletList", "bullet", "bulletList", "bullet"])
             done()
@@ -473,14 +473,14 @@ testGroup "Block formatting", template: "editor_empty", ->
 
   test "code blocks are not indentable", (done) ->
     clickToolbarButton attribute: "code", ->
-      assert.notOk isToolbarButtonActive(action: "increaseBlockLevel")
+      assert.notOk isToolbarButtonActive(action: "increaseIndentationLevel")
       done()
 
   test "unindenting a code block inside a bullet", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       clickToolbarButton attribute: "code", ->
         typeCharacters "a", ->
-          clickToolbarButton action: "decreaseBlockLevel", ->
+          clickToolbarButton action: "decreaseIndentationLevel", ->
             document = getDocument()
             assert.equal document.getBlockCount(), 1
             assert.blockAttributes([0, 1], ["code"])
@@ -492,7 +492,7 @@ testGroup "Block formatting", template: "editor_empty", ->
         typeCharacters "\n", ->
           clickToolbarButton attribute: "heading1", ->
             typeCharacters "b", ->
-              clickToolbarButton action: "increaseBlockLevel", ->
+              clickToolbarButton action: "increaseIndentationLevel", ->
                 document = getDocument()
                 assert.equal document.getBlockCount(), 2
                 assert.blockAttributes([0, 1], ["bulletList", "bullet"])
@@ -502,7 +502,7 @@ testGroup "Block formatting", template: "editor_empty", ->
   test "indenting a quote inside a bullet", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       clickToolbarButton attribute: "quote", ->
-        clickToolbarButton action: "increaseBlockLevel", ->
+        clickToolbarButton action: "increaseIndentationLevel", ->
           document = getDocument()
           assert.equal document.getBlockCount(), 1
           assert.blockAttributes([0, 1], ["bulletList", "bullet", "quote", "quote"])
@@ -512,7 +512,7 @@ testGroup "Block formatting", template: "editor_empty", ->
     clickToolbarButton attribute: "bullet", ->
       typeCharacters "a\n\n", ->
         clickToolbarButton attribute: "number", ->
-          clickToolbarButton action: "increaseBlockLevel", ->
+          clickToolbarButton action: "increaseIndentationLevel", ->
             document = getDocument()
             assert.equal document.getBlockCount(), 2
             assert.blockAttributes([0, 1], ["bulletList", "bullet"])

--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -470,3 +470,18 @@ testGroup "Block formatting", template: "editor_empty", ->
         assert.blockAttributes([2, 3], ["heading1"])
         assert.blockAttributes([4, 5], ["heading1"])
         expectDocument("a\nb\nc\n")
+
+  test "code blocks are not indentable", (done) ->
+    clickToolbarButton attribute: "code", ->
+      assert.notOk isToolbarButtonActive(action: "increaseBlockLevel")
+      done()
+
+  test "unindenting a code block inside a bullet", (expectDocument) ->
+    clickToolbarButton attribute: "bullet", ->
+      clickToolbarButton attribute: "code", ->
+        typeCharacters "a", ->
+          clickToolbarButton action: "decreaseBlockLevel", ->
+            document = getDocument()
+            assert.equal document.getBlockCount(), 1
+            assert.blockAttributes([0, 1], ["code"])
+            expectDocument("a\n")

--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -485,3 +485,16 @@ testGroup "Block formatting", template: "editor_empty", ->
             assert.equal document.getBlockCount(), 1
             assert.blockAttributes([0, 1], ["code"])
             expectDocument("a\n")
+
+  test "indenting a heading inside a bullet", (expectDocument) ->
+    clickToolbarButton attribute: "bullet", ->
+      typeCharacters "a", ->
+        typeCharacters "\n", ->
+          clickToolbarButton attribute: "heading1", ->
+            typeCharacters "b", ->
+              clickToolbarButton action: "increaseBlockLevel", ->
+                document = getDocument()
+                assert.equal document.getBlockCount(), 2
+                assert.blockAttributes([0, 1], ["bulletList", "bullet"])
+                assert.blockAttributes([2, 3], ["bulletList", "bullet", "bulletList", "bullet", "heading1"])
+                expectDocument("a\nb\n")

--- a/test/src/system/custom_element_test.coffee
+++ b/test/src/system/custom_element_test.coffee
@@ -170,8 +170,8 @@ testGroup "Custom element API", template: "editor_empty", ->
       assert.equal eventCount, 0
       clickToolbarButton attribute: "bullet", ->
         assert.equal eventCount, 1
-        assert.equal actions.decreaseBlockLevel, true
-        assert.equal actions.increaseBlockLevel, false
+        assert.equal actions.decreaseIndentationLevel, true
+        assert.equal actions.increaseIndentationLevel, false
         done()
 
   test "element triggers custom focus and blur events", (done) ->

--- a/test/src/system/custom_element_test.coffee
+++ b/test/src/system/custom_element_test.coffee
@@ -170,8 +170,8 @@ testGroup "Custom element API", template: "editor_empty", ->
       assert.equal eventCount, 0
       clickToolbarButton attribute: "bullet", ->
         assert.equal eventCount, 1
-        assert.equal actions.decreaseIndentationLevel, true
-        assert.equal actions.increaseIndentationLevel, false
+        assert.equal actions.decreaseNestingLevel, true
+        assert.equal actions.increaseNestingLevel, false
         done()
 
   test "element triggers custom focus and blur events", (done) ->

--- a/test/src/system/list_formatting_test.coffee
+++ b/test/src/system/list_formatting_test.coffee
@@ -31,9 +31,9 @@ testGroup "List formatting", template: "editor_empty", ->
   test "pressing delete at the beginning of a non-empty nested list item", (expectDocument) ->
       clickToolbarButton attribute: "bullet", ->
         typeCharacters "a\n", ->
-          clickToolbarButton action: "increaseBlockLevel", ->
+          clickToolbarButton action: "increaseIndentationLevel", ->
             typeCharacters "b\n", ->
-              clickToolbarButton action: "increaseBlockLevel", ->
+              clickToolbarButton action: "increaseIndentationLevel", ->
                 typeCharacters "c", ->
                   getSelectionManager().setLocationRange(index: 1, offset: 0)
                   getComposition().deleteInDirection("backward")
@@ -46,9 +46,9 @@ testGroup "List formatting", template: "editor_empty", ->
   test "decreasing list item's level decreases its nested items level too", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       typeCharacters "a\n", ->
-        clickToolbarButton action: "increaseBlockLevel", ->
+        clickToolbarButton action: "increaseIndentationLevel", ->
           typeCharacters "b\n", ->
-            clickToolbarButton action: "increaseBlockLevel", ->
+            clickToolbarButton action: "increaseIndentationLevel", ->
               typeCharacters "c", ->
                 getSelectionManager().setLocationRange(index: 1, offset: 1)
 

--- a/test/src/system/list_formatting_test.coffee
+++ b/test/src/system/list_formatting_test.coffee
@@ -31,9 +31,9 @@ testGroup "List formatting", template: "editor_empty", ->
   test "pressing delete at the beginning of a non-empty nested list item", (expectDocument) ->
       clickToolbarButton attribute: "bullet", ->
         typeCharacters "a\n", ->
-          clickToolbarButton action: "increaseIndentationLevel", ->
+          clickToolbarButton action: "increaseNestingLevel", ->
             typeCharacters "b\n", ->
-              clickToolbarButton action: "increaseIndentationLevel", ->
+              clickToolbarButton action: "increaseNestingLevel", ->
                 typeCharacters "c", ->
                   getSelectionManager().setLocationRange(index: 1, offset: 0)
                   getComposition().deleteInDirection("backward")
@@ -46,9 +46,9 @@ testGroup "List formatting", template: "editor_empty", ->
   test "decreasing list item's level decreases its nested items level too", (expectDocument) ->
     clickToolbarButton attribute: "bullet", ->
       typeCharacters "a\n", ->
-        clickToolbarButton action: "increaseIndentationLevel", ->
+        clickToolbarButton action: "increaseNestingLevel", ->
           typeCharacters "b\n", ->
-            clickToolbarButton action: "increaseIndentationLevel", ->
+            clickToolbarButton action: "increaseNestingLevel", ->
               typeCharacters "c", ->
                 getSelectionManager().setLocationRange(index: 1, offset: 1)
 


### PR DESCRIPTION
* Redefines the `nestable` block attribute configuration to encode the nesting behavior of quotes, bullets, and numbers. 
* Introduces the concept of a _nesting level_ separate from the block attribute level.
* Changes the indentation buttons in the toolbar to increase and decrease the nesting level, not the block attribute level.
* Renames the following Editor methods, leaving the old methods as deprecated aliases:
   * `canDecreaseIndentationLevel` -> `canDecreaseNestingLevel`
   * `canIncreaseIndentationLevel` -> `canIncreaseNestingLevel`
   * `decreaseIndentationLevel` -> `decreaseNestingLevel`
   * `increaseIndentationLevel` -> `increaseNestingLevel`
* Renames the following toolbar actions, leaving the old actions as deprecated aliases:
   * `decreaseBlockLevel` -> `decreaseNestingLevel`
   * `increaseBlockLevel` -> `increaseNestingLevel`