### PR TITLE
Fix inserting multiple newlines before formatted block

### DIFF
--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -470,7 +470,7 @@ class Trix.Composition extends Trix.BasicObject
       else
         range = [position, position + 1]
         position += 1
-    else if insertion.endPosition - 1 isnt 0
+    else if insertion.offset - 1 isnt 0
       position += 1
 
     newDocument = new Trix.Document [block.removeLastAttribute().copyWithoutText()]

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -458,7 +458,7 @@ class Trix.Composition extends Trix.BasicObject
     position = insertion.startPosition
     range = [position - 1, position]
 
-    if block.getBlockBreakPosition() is insertion.offset
+    if block.getBlockBreakPosition() is insertion.startLocation.offset
       if block.breaksOnReturn() and insertion.nextCharacter is "\n"
         position += 1
       else
@@ -470,7 +470,7 @@ class Trix.Composition extends Trix.BasicObject
       else
         range = [position, position + 1]
         position += 1
-    else if insertion.offset - 1 isnt 0
+    else if insertion.startLocation.offset - 1 isnt 0
       position += 1
 
     newDocument = new Trix.Document [block.removeLastAttribute().copyWithoutText()]

--- a/src/trix/models/line_break_insertion.coffee
+++ b/src/trix/models/line_break_insertion.coffee
@@ -3,7 +3,6 @@ class Trix.LineBreakInsertion
     {@document} = @composition
 
     [@startPosition, @endPosition] = @composition.getSelectedRange()
-    {@index, @offset} = @document.locationFromPosition(@startPosition)
     @startLocation = @document.locationFromPosition(@startPosition)
     @endLocation = @document.locationFromPosition(@endPosition)
 

--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -427,6 +427,24 @@ testGroup "Block formatting", template: "editor_empty", ->
       assert.equal block.toString(), "abc\n"
       done()
 
+  test "inserting multiple newlines before formatted block", (expectDocument) ->
+    document = new Trix.Document [
+        new Trix.Block(Trix.Text.textForStringWithAttributes("\n"), [])
+        new Trix.Block(Trix.Text.textForStringWithAttributes("abc"), ["quote"])
+      ]
+
+    replaceDocument(document)
+    getEditor().setSelectedRange(1)
+
+    typeCharacters "\n\n", ->
+      document = getDocument()
+      assert.equal document.getBlockCount(), 2
+      assert.blockAttributes([0, 1], [])
+      assert.blockAttributes([2, 3], [])
+      assert.blockAttributes([4, 6], ["quote"])
+      assert.locationRange(index: 0, offset: 3)
+      expectDocument("\n\n\n\nabc\n")
+
   test "inserting newline after heading with text in following block", (expectDocument) ->
     document = new Trix.Document [
         new Trix.Block(Trix.Text.textForStringWithAttributes("ab"), ["heading1"])


### PR DESCRIPTION
Before:

![master](https://cloud.githubusercontent.com/assets/2018508/17948252/9ed5ba5a-6a15-11e6-845a-ec75060109f8.gif)

After:
![098](https://cloud.githubusercontent.com/assets/2018508/17948391/55041dbc-6a16-11e6-8f16-e0111c149183.gif)
