### PR TITLE
Improve behavior when backspacing into a formatted block from a block with a leading newline

### DIFF
--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -479,6 +479,22 @@ testGroup "Block formatting", template: "editor_empty", ->
       assert.blockAttributes([2, 3], ["heading1"])
       expectDocument("abc\nd\n")
 
+  test "backspacing a newline at beginning of non-formatted block", (expectDocument) ->
+     document = new Trix.Document [
+         new Trix.Block(Trix.Text.textForStringWithAttributes("ab"), ["heading1"])
+         new Trix.Block(Trix.Text.textForStringWithAttributes("\ncd"), [])
+       ]
+
+     replaceDocument(document)
+     getEditor().setSelectedRange(3)
+
+     pressKey "backspace", ->
+       document = getDocument()
+       assert.equal document.getBlockCount(), 2
+       assert.blockAttributes([0, 2], ["heading1"])
+       assert.blockAttributes([3, 5], [])
+       expectDocument("ab\ncd\n")
+
   test "inserting newline after single character header", (expectDocument) ->
     clickToolbarButton attribute: "heading1", ->
       typeCharacters "a", ->

--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -462,6 +462,23 @@ testGroup "Block formatting", template: "editor_empty", ->
       assert.blockAttributes([5, 6], [])
       expectDocument("ab\n\ncd\n")
 
+  test "backspacing a newline in an empty block with adjacent formatted blocks", (expectDocument) ->
+    document = new Trix.Document [
+        new Trix.Block(Trix.Text.textForStringWithAttributes("abc"), ["heading1"])
+        new Trix.Block
+        new Trix.Block(Trix.Text.textForStringWithAttributes("d"), ["heading1"])
+      ]
+
+    replaceDocument(document)
+    getEditor().setSelectedRange(4)
+
+    pressKey "backspace", ->
+      document = getDocument()
+      assert.equal document.getBlockCount(), 2
+      assert.blockAttributes([0, 1], ["heading1"])
+      assert.blockAttributes([2, 3], ["heading1"])
+      expectDocument("abc\nd\n")
+
   test "inserting newline after single character header", (expectDocument) ->
     clickToolbarButton attribute: "heading1", ->
       typeCharacters "a", ->

--- a/test/src/system/text_formatting_test.coffee
+++ b/test/src/system/text_formatting_test.coffee
@@ -1,4 +1,4 @@
-{assert, clickToolbarButton, clickToolbarDialogButton, collapseSelection, expandSelection, insertString, insertText, isToolbarButtonActive, isToolbarButtonDisabled, isToolbarDialogActive, moveCursor, test, testGroup, typeCharacters, typeInToolbarDialog, typeToolbarKeyCommand} = Trix.TestHelpers
+{assert, clickToolbarButton, clickToolbarDialogButton, collapseSelection, expandSelection, insertString, insertText, isToolbarButtonActive, isToolbarButtonDisabled, isToolbarDialogActive, moveCursor, pressKey, test, testGroup, typeCharacters, typeInToolbarDialog, typeToolbarKeyCommand} = Trix.TestHelpers
 
 testGroup "Text formatting", template: "editor_empty", ->
   test "applying attributes to text", (done) ->
@@ -144,3 +144,8 @@ testGroup "Text formatting", template: "editor_empty", ->
     typeToolbarKeyCommand attribute: "bold", ->
       assert.ok isToolbarButtonActive(attribute: "bold")
       done()
+
+  test "backspacing newline after text", (expectDocument) ->
+    typeCharacters "a\n", ->
+      pressKey "backspace", ->
+        expectDocument("a\n")


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/5355/17948131/7c3e612e-6a1d-11e6-9e31-ff29b8ea1897.gif)

After:
![after](https://cloud.githubusercontent.com/assets/5355/17948136/80615f90-6a1d-11e6-86bb-57b8e27ed040.gif)

