### PR TITLE
Ensure "trix-change" fires and HTML is serialized when toggling attributes

### DIFF
--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -126,11 +126,14 @@ class Trix.EditorController extends Trix.Controller
     if @requestedLocationRange?
       if @documentWhenLocationRangeRequested.isEqualTo(@composition.document)
         @selectionManager.setLocationRange(@requestedLocationRange)
-
-      @composition.updateCurrentAttributes()
       @requestedLocationRange = null
       @documentWhenLocationRangeRequested = null
+
+    unless @renderedCompositionRevision is @composition.revision
+      @composition.updateCurrentAttributes()
       @editorElement.notify("render")
+
+    @renderedCompositionRevision = @composition.revision
 
   compositionControllerDidFocus: ->
     @toolbarController.hideDialog()

--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -87,7 +87,7 @@ class Trix.EditorController extends Trix.Controller
   compositionDidRequestChangingSelectionToLocationRange: (locationRange) ->
     return if @loadingSnapshot and not @isFocused()
     @requestedLocationRange = locationRange
-    @documentWhenLocationRangeRequested = @composition.document
+    @compositionRevisionWhenLocationRangeRequested = @composition.revision
     @render() unless @handlingInput
 
   compositionWillLoadSnapshot: ->
@@ -124,10 +124,10 @@ class Trix.EditorController extends Trix.Controller
 
   compositionControllerDidRender: ->
     if @requestedLocationRange?
-      if @documentWhenLocationRangeRequested.isEqualTo(@composition.document)
+      if @compositionRevisionWhenLocationRangeRequested is @composition.revision
         @selectionManager.setLocationRange(@requestedLocationRange)
       @requestedLocationRange = null
-      @documentWhenLocationRangeRequested = null
+      @compositionRevisionWhenLocationRangeRequested = null
 
     unless @renderedCompositionRevision is @composition.revision
       @composition.updateCurrentAttributes()

--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -187,9 +187,7 @@ class Trix.EditorController extends Trix.Controller
     range = @pastedRange
     @pastedRange = null
     @pasting = null
-
     @editorElement.notify("paste", {pasteData, range})
-    @render()
 
   inputControllerWillMoveText: ->
     @editor.recordUndoEntry("Move")

--- a/test/src/system/custom_element_test.coffee
+++ b/test/src/system/custom_element_test.coffee
@@ -71,15 +71,34 @@ testGroup "Custom element API", template: "editor_empty", ->
             assert.equal eventCount, 5
             done()
 
-  test "element triggers trix-change event after activating attributes", (done) ->
+  test "element triggers trix-change event after toggling attributes", (done) ->
     element = getEditorElement()
     editor = element.editor
 
+    afterChangeEvent = (edit, callback) ->
+      element.addEventListener "trix-change", handler = (event) ->
+        element.removeEventListener("trix-change", handler)
+        callback(event)
+      edit()
+
     typeCharacters "hello", ->
-      element.addEventListener "trix-change", (event) ->
+      edit = -> editor.activateAttribute("quote")
+      afterChangeEvent edit, ->
         assert.ok editor.attributeIsActive("quote")
-        done()
-      editor.activateAttribute("quote")
+
+        edit = -> editor.deactivateAttribute("quote")
+        afterChangeEvent edit, ->
+          assert.notOk editor.attributeIsActive("quote")
+
+          editor.setSelectedRange([0, 5])
+          edit = -> editor.activateAttribute("bold")
+          afterChangeEvent edit, ->
+            assert.ok editor.attributeIsActive("bold")
+
+            edit = -> editor.deactivateAttribute("bold")
+            afterChangeEvent edit, ->
+              assert.notOk editor.attributeIsActive("bold")
+              done()
 
   test "element triggers trix-selection-change events when the location range changes", (done) ->
     element = getEditorElement()

--- a/test/src/system/custom_element_test.coffee
+++ b/test/src/system/custom_element_test.coffee
@@ -230,6 +230,22 @@ testGroup "Custom element API", template: "editor_empty", ->
       assert.equal focusEventCount, 1
       done()
 
+  test "element serializes HTML after attribute changes", (done) ->
+    element = getEditorElement()
+    serializedHTML = element.value
+
+    typeCharacters "a", ->
+      assert.notEqual serializedHTML, element.value
+      serializedHTML = element.value
+
+      clickToolbarButton attribute: "quote", ->
+        assert.notEqual serializedHTML, element.value
+        serializedHTML = element.value
+
+        clickToolbarButton attribute: "quote", ->
+          assert.notEqual serializedHTML, element.value
+          done()
+
   test "editor resets to its original value on form reset", (expectDocument) ->
     element = getEditorElement()
     form = element.inputElement.form


### PR DESCRIPTION
Followup to 0668fdec4c3d81884879c73b26f18113c315c1fd. Closes #316.