### PR TITLE
Make sure selection elements have 0 line height to not offset line height

### DIFF
--- a/src/trix/config/selection_elements.coffee
+++ b/src/trix/config/selection_elements.coffee
@@ -19,6 +19,7 @@ Trix.extend
       padding: 0 !important;
       margin: 0 !important;
       border: none !important;
+      line-height: 0 !important;
     """
 
     create: (name) ->


### PR DESCRIPTION
I had issues that line height got larger inside the editor because of selection elements because selector from outside was setting it to 1.5 of line length. This fixes this and make sure selection elements are really not influencing anything.