### PR TITLE
Always set selection after compositionend

### DIFF
--- a/src/trix/controllers/input/composition_input.coffee
+++ b/src/trix/controllers/input/composition_input.coffee
@@ -31,7 +31,7 @@ class Trix.CompositionInput extends Trix.BasicObject
       @responder?.setSelectedRange(@range)
       @responder?.insertString(@data.end)
       @setInputSummary(preferDocument: true)
-      @setFinalSelection()
+      @responder?.setSelectedRange(@range[0] + @data.end.length)
 
     else if @data.start? or @data.update?
       @requestReparse()
@@ -47,17 +47,6 @@ class Trix.CompositionInput extends Trix.BasicObject
 
   canApplyToDocument: ->
     @data.start?.length is 0 and @data.end?.length > 0 and @range?
-
-  # Fix for compositions remaining selected in Firefox:
-  # If the last composition update is the same as the final composition then
-  # it's likely there won't be another mutation (and subsequent render + selection change).
-  # In that case, collapse the selection and request a render.
-  setFinalSelection: ->
-    if @data.end? and @data.end is @data.update
-      @unlessMutationOccurs =>
-        if @selectionIsExpanded()
-          @responder?.setSelection(@range[0] + @data.end.length)
-          @requestRender()
 
   @proxyMethod "inputController.setInputSummary"
   @proxyMethod "inputController.requestRender"

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -23,7 +23,6 @@ class Trix.InputController extends Trix.BasicObject
   constructor: (@element) ->
     @resetInputSummary()
 
-    @mutationCount = 0
     @mutationObserver = new Trix.MutationObserver @element
     @mutationObserver.delegate = this
 
@@ -67,7 +66,6 @@ class Trix.InputController extends Trix.BasicObject
   # Mutation observer delegate
 
   elementDidMutate: (mutationSummary) ->
-    @mutationCount++
     unless @isComposing()
       @handleInput ->
         if @mutationIsSignificant(mutationSummary)
@@ -111,12 +109,6 @@ class Trix.InputController extends Trix.BasicObject
     textChanged = Object.keys(mutationSummary).length > 0
     composedEmptyString = @compositionInput?.getEndData() is ""
     textChanged or not composedEmptyString
-
-  unlessMutationOccurs: (callback) ->
-    mutationCount = @mutationCount
-    defer =>
-      if mutationCount is @mutationCount
-        callback()
 
   # File verification
 


### PR DESCRIPTION
Ensures input received before the next mutation/render doesn't overwrite the composition data.

Specifically fixes typing with Samsung Keyboard on Android.

Before:
![before](https://cloud.githubusercontent.com/assets/5355/19052301/3e592822-8984-11e6-98f4-ede62638c946.gif)

After:
![after](https://cloud.githubusercontent.com/assets/5355/19052307/4271cf54-8984-11e6-9638-04dd5f993023.gif)

