### PR TITLE
Fix backspacing into a block from offset 0 in Firefox

### DIFF
--- a/test/src/system/mutation_input_test.coffee
+++ b/test/src/system/mutation_input_test.coffee
@@ -46,6 +46,18 @@ testGroup "Mutation input", template: "editor_empty", ->
         assert.locationRange index: 0, offset: 0
         expectDocument("\n")
 
+  test "backspacing a block comment node", (expectDocument) ->
+    element = getEditorElement()
+    element.editor.loadHTML("""<blockquote>a</blockquote><div>b</div>""")
+    defer ->
+      element.editor.setSelectedRange(2)
+      triggerEvent(element, "keydown", charCode: 0, keyCode: 8, which: 8)
+      commentNode = element.lastChild.firstChild
+      commentNode.parentNode.removeChild(commentNode)
+      defer ->
+        assert.locationRange index: 0, offset: 1
+        expectDocument("ab\n")
+
   test "typing formatted text with autocapitalization on", (expectDocument) ->
     element = getEditorElement()
 


### PR DESCRIPTION
In Firefox, pressing backspace when the cursor is positioned after a comment node will only remove that node, which effectively deletes nothing.

Minimal test case: Open `data:text/html;charset=utf-8,%3Cdiv contenteditable%3Ea%3C!--z--%3E%3C!--z--%3E%3C!--z--%3Eb%3C/div%3E` in Firefox and press backspace from the end.

Possibly related bug: https://bugzilla.mozilla.org/show_bug.cgi?id=685445

Trix, as of 759e62d5846b5d59cdd6174fae6027ce984752aa, detects the mutation / input mismatch and reparses the document resulting in no deletion and the cursor jumping to the end of the block.

Before: 
![backspace-before](https://cloud.githubusercontent.com/assets/5355/20248585/4e8dc922-a9b5-11e6-90ae-aa3675f6728f.gif)

After:
![backspace-after](https://cloud.githubusercontent.com/assets/5355/20248588/587115e8-a9b5-11e6-9d99-be8021d718cb.gif)

