### PR TITLE
Fix deleting formatted words with option+backspace

### DIFF
--- a/src/trix/controllers/attachment_editor_controller.coffee
+++ b/src/trix/controllers/attachment_editor_controller.coffee
@@ -33,7 +33,12 @@ class Trix.AttachmentEditorController extends Trix.BasicObject
     undo: => handler.destroy()
 
   addRemoveButton: undoable ->
-    removeButton = makeElement(tagName: "a", textContent: lang.remove, className: classNames.attachment.removeButton, attributes: { href: "#", title: lang.remove })
+    removeButton = makeElement
+      tagName: "a"
+      textContent: lang.remove
+      className: classNames.attachment.removeButton
+      attributes: href: "#", title: lang.remove
+      data: trixMutable: true
     handleEvent("click", onElement: removeButton, withCallback: @didClickRemoveButton)
     do: => @element.appendChild(removeButton)
     undo: => @element.removeChild(removeButton)

--- a/src/trix/observers/mutation_observer.coffee
+++ b/src/trix/observers/mutation_observer.coffee
@@ -126,4 +126,6 @@ class Trix.MutationObserver extends Trix.BasicObject
         when Node.ELEMENT_NODE
           if tagName(node) is "br"
             text.push("\n")
+          else
+            text.push(getTextForNodes(node.childNodes)...)
     text

--- a/test/src/system/html_replacement_test.coffee
+++ b/test/src/system/html_replacement_test.coffee
@@ -57,11 +57,11 @@ testGroup "HTML replacement", ->
         expectDocument("a\n\nc\n")
 
     test "a formatted word", (expectDocument) ->
-      getEditor().loadHTML("<div>a <strong>bc</strong></div>")
+      getEditor().loadHTML("<div>a<strong>bc</strong></div>")
       getSelectionManager().setLocationRange(index: 0, offset: 4)
       pressCommandBackspace replaceElementWithText: "bc", ->
-        assert.locationRange(index: 0, offset: 2)
-        expectDocument("a \n")
+        assert.locationRange(index: 0, offset: 1)
+        expectDocument("a\n")
 
 pressCommandBackspace = ({replaceText, replaceElementWithText}, callback) ->
   triggerEvent(document.activeElement, "keydown", charCode: 0, keyCode: 8, which: 8, metaKey: true)

--- a/test/src/system/html_replacement_test.coffee
+++ b/test/src/system/html_replacement_test.coffee
@@ -56,26 +56,46 @@ testGroup "HTML replacement", ->
         assert.locationRange(index: 0, offset: 2)
         expectDocument("a\n\nc\n")
 
-pressCommandBackspace = ({replaceText}, callback) ->
+    test "a formatted word", (expectDocument) ->
+      getEditor().loadHTML("<div>a <strong>bc</strong></div>")
+      getSelectionManager().setLocationRange(index: 0, offset: 4)
+      pressCommandBackspace replaceElementWithText: "bc", ->
+        assert.locationRange(index: 0, offset: 2)
+        expectDocument("a \n")
+
+pressCommandBackspace = ({replaceText, replaceElementWithText}, callback) ->
   triggerEvent(document.activeElement, "keydown", charCode: 0, keyCode: 8, which: 8, metaKey: true)
-
   range = rangy.getSelection().getRangeAt(0)
-  range.findText(replaceText, direction: "backward")
-  range.splitBoundaries()
 
-  node = range.getNodes()[0]
-  {previousSibling, nextSibling, parentNode} = node
+  if replaceElementWithText
+    element = getElementWithText(replaceElementWithText)
+    {previousSibling} = element
+    element.parentNode.removeChild(element)
+    range.collapseAfter(previousSibling)
+  else
+    range.findText(replaceText, direction: "backward")
+    range.splitBoundaries()
 
-  if previousSibling?.nodeType is Node.COMMENT_NODE
-    parentNode.removeChild(previousSibling)
+    node = range.getNodes()[0]
+    {previousSibling, nextSibling, parentNode} = node
 
-  node.data = ""
-  parentNode.removeChild(node)
+    if previousSibling?.nodeType is Node.COMMENT_NODE
+      parentNode.removeChild(previousSibling)
 
-  unless parentNode.hasChildNodes()
-    parentNode.appendChild(document.createElement("br"))
+    node.data = ""
+    parentNode.removeChild(node)
 
-  range.collapseBefore(nextSibling ? parentNode.firstChild)
+    unless parentNode.hasChildNodes()
+      parentNode.appendChild(document.createElement("br"))
+
+    range.collapseBefore(nextSibling ? parentNode.firstChild)
+
   range.select()
-
   requestAnimationFrame(callback)
+
+
+getElementWithText = (text) ->
+  for element in document.activeElement.querySelectorAll("*")
+    if element.innerText is text
+      return element
+  null

--- a/test/src/unit/mutation_observer_test.coffee
+++ b/test/src/unit/mutation_observer_test.coffee
@@ -68,3 +68,17 @@ testGroup "Trix.MutationObserver", ->
       assert.equal summaries.length, 1
       assert.deepEqual summaries[0], textDeleted: "\n"
       done()
+
+  observerTest "remove formatted element", html: "a<strong>b</strong>", (done) ->
+    element.removeChild(element.lastChild)
+    defer ->
+      assert.equal summaries.length, 1
+      assert.deepEqual summaries[0], textDeleted: "b"
+      done()
+
+  observerTest "remove nested formatted elements", html: "a<strong>b<em>c</em></strong>", (done) ->
+    element.removeChild(element.lastChild)
+    defer ->
+      assert.equal summaries.length, 1
+      assert.deepEqual summaries[0], textDeleted: "bc"
+      done()


### PR DESCRIPTION
Before:
![delete-word-before](https://cloud.githubusercontent.com/assets/5355/20312174/7b16a2fe-ab20-11e6-84af-cf86458a42cf.gif)

After:
![delete-word-after](https://cloud.githubusercontent.com/assets/5355/20312181/82219c34-ab20-11e6-9390-ade4b37ff63e.gif)
