### PR TITLE
Invalidate attachment view cache when preview URL changes. Fixes #77

### DIFF
--- a/src/trix/controllers/composition_controller.coffee
+++ b/src/trix/controllers/composition_controller.coffee
@@ -51,8 +51,11 @@ class Trix.CompositionController extends Trix.BasicObject
     @delegate?.compositionControllerDidRender?()
 
   rerenderViewForObject: (object) ->
-    @documentView.invalidateViewForObject(object)
+    @invalidateViewForObject(object)
     @render()
+
+  invalidateViewForObject: (object) ->
+    @documentView.invalidateViewForObject(object)
 
   isViewCachingEnabled: ->
     @documentView.isViewCachingEnabled()

--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -69,6 +69,9 @@ class Trix.EditorController extends Trix.Controller
     @editorElement.notify("attachment-edit", attachment: managedAttachment)
     @editorElement.notify("change")
 
+  compositionDidChangeAttachmentPreviewURL: (attachment) ->
+    @compositionController.invalidateViewForObject(attachment)
+
   compositionDidRemoveAttachment: (attachment) ->
     managedAttachment = @attachmentManager.unmanageAttachment(attachment)
     @editorElement.notify("attachment-remove", attachment: managedAttachment)

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -432,6 +432,9 @@ class Trix.Composition extends Trix.BasicObject
     @revision++
     @delegate?.compositionDidEditAttachment?(attachment)
 
+  attachmentDidChangePreviewURL: (attachment) ->
+    @delegate?.compositionDidChangeAttachmentPreviewURL?(attachment)
+
   # Attachment editing
 
   editAttachment: (attachment) ->

--- a/src/trix/views/previewable_attachment_view.coffee
+++ b/src/trix/views/previewable_attachment_view.coffee
@@ -25,10 +25,10 @@ class Trix.PreviewableAttachmentView extends Trix.AttachmentView
 
   updateAttributesForImage: (image) ->
     url = @attachment.getURL()
-    preloadedURL = @attachment.getPreloadedURL()
-    image.src = preloadedURL or url
+    previewURL = @attachment.getPreviewURL()
+    image.src = previewURL or url
 
-    if preloadedURL is url
+    if previewURL is url
       image.removeAttribute("data-trix-serialized-attributes")
     else
       serializedAttributes = JSON.stringify(src: url)
@@ -42,6 +42,6 @@ class Trix.PreviewableAttachmentView extends Trix.AttachmentView
 
   # Attachment delegate
 
-  attachmentDidPreload: ->
+  attachmentDidChangePreviewURL: ->
     @refresh(@image)
     @refresh()


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/5355/20366697/453b91b2-ac1a-11e6-82d6-c1c1c2b3349a.gif)

After:
![after](https://cloud.githubusercontent.com/assets/5355/20366704/4b341f1c-ac1a-11e6-9eb3-75f6899316a0.gif)

