### PR TITLE
Improve multi-file insertion performance

### DIFF
--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -119,7 +119,7 @@ class Trix.InputController extends Trix.BasicObject
     Promise.all(operations).then (files) =>
       @handleInput ->
         @delegate?.inputControllerWillAttachFiles()
-        @responder?.insertFile(file) for file in files
+        @responder?.insertFiles(files)
         @requestRender()
 
   # Input handlers

--- a/src/trix/inspector/views/performance_view.coffee
+++ b/src/trix/inspector/views/performance_view.coffee
@@ -11,6 +11,7 @@ Trix.Inspector.registerView class extends Trix.Inspector.View
     @data = {}
     @track("documentView.render")
     @track("documentView.sync")
+    @track("documentView.garbageCollectCachedViews")
     @track("composition.replaceHTML")
 
     @render()

--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -113,6 +113,14 @@ class Trix.Composition extends Trix.BasicObject
       attachment = Trix.Attachment.attachmentForFile(file)
       @insertAttachment(attachment)
 
+  insertFiles: (files) ->
+    text = new Trix.Text
+    for file in files when @delegate?.compositionShouldAcceptFile(file)
+      attachment = Trix.Attachment.attachmentForFile(file)
+      attachmentText = Trix.Text.textForAttachmentWithAttributes(attachment, @currentAttributes)
+      text = text.appendText(attachmentText)
+    @insertText(text)
+
   insertAttachment: (attachment) ->
     text = Trix.Text.textForAttachmentWithAttributes(attachment, @currentAttributes)
     @insertText(text)

--- a/src/trix/views/object_view.coffee
+++ b/src/trix/views/object_view.coffee
@@ -36,7 +36,8 @@ class Trix.ObjectView extends Trix.BasicObject
   recordChildView: (view) ->
     view.parentView = this
     view.rootView = @rootView
-    @childViews.push(view)
+    unless view in @childViews
+      @childViews.push(view)
     view
 
   getAllChildViews: ->


### PR DESCRIPTION
JS profile from dropping 30 files onto an editor using Chrome 55.0.2883.95 on macOS 10.12.1:

Before 😮
<img width="708" alt="before" src="https://cloud.githubusercontent.com/assets/5355/21358661/678bee9a-c6a7-11e6-9b5f-a23c672a7d45.png">

After 🤑
<img width="552" alt="after" src="https://cloud.githubusercontent.com/assets/5355/21358709/879cf38c-c6a7-11e6-9842-ffcd4ced041d.png">
