### PR TITLE
Safari 10.1 line break bug workaround

### DIFF
--- a/src/trix/core/helpers/functions.coffee
+++ b/src/trix/core/helpers/functions.coffee
@@ -1,3 +1,10 @@
 Trix.extend
   defer: (fn) ->
     setTimeout fn, 1
+
+  throttleAnimationFrame: (fn) ->
+    request = null
+    (args...) ->
+      request ?= requestAnimationFrame =>
+        request = null
+        fn.apply(this, args)


### PR DESCRIPTION
The bug: https://bugs.webkit.org/show_bug.cgi?id=167525

Before:
![before](https://cloud.githubusercontent.com/assets/5355/22387770/3f6c483e-e4ab-11e6-976f-d5f86ca4acad.gif)

After:
![after](https://cloud.githubusercontent.com/assets/5355/22387777/4535490a-e4ab-11e6-8171-3cab1017245f.gif)