### PR TITLE
Remove toolbar buttons from the navigation flow

### DIFF
--- a/src/trix/config/toolbar.coffee
+++ b/src/trix/config/toolbar.coffee
@@ -5,25 +5,25 @@ Trix.config.toolbar =
   content: makeFragment """
     <div class="button_row">
       <span class="button_group text_tools">
-        <button type="button" class="icon bold" data-trix-attribute="bold" data-trix-key="b" title="#{lang.bold}">#{lang.bold}</button>
-        <button type="button" class="icon italic" data-trix-attribute="italic" data-trix-key="i" title="#{lang.italic}">#{lang.italic}</button>
-        <button type="button" class="icon strike" data-trix-attribute="strike" title="#{lang.strike}">#{lang.strike}</button>
-        <button type="button" class="icon link" data-trix-attribute="href" data-trix-action="link" data-trix-key="k" title="#{lang.link}">#{lang.link}</button>
+        <button type="button" class="icon bold" data-trix-attribute="bold" data-trix-key="b" title="#{lang.bold}" tabindex="-1">#{lang.bold}</button>
+        <button type="button" class="icon italic" data-trix-attribute="italic" data-trix-key="i" title="#{lang.italic}" tabindex="-1">#{lang.italic}</button>
+        <button type="button" class="icon strike" data-trix-attribute="strike" title="#{lang.strike}" tabindex="-1">#{lang.strike}</button>
+        <button type="button" class="icon link" data-trix-attribute="href" data-trix-action="link" data-trix-key="k" title="#{lang.link}" tabindex="-1">#{lang.link}</button>
       </span>
 
       <span class="button_group block_tools">
-        <button type="button" class="icon heading-1" data-trix-attribute="heading1" title="#{lang.heading1}">#{lang.heading1}</button>
-        <button type="button" class="icon quote" data-trix-attribute="quote" title="#{lang.quote}">#{lang.quote}</button>
-        <button type="button" class="icon code" data-trix-attribute="code" title="#{lang.code}">#{lang.code}</button>
-        <button type="button" class="icon list bullets" data-trix-attribute="bullet" title="#{lang.bullets}">#{lang.bullets}</button>
-        <button type="button" class="icon list numbers" data-trix-attribute="number" title="#{lang.numbers}">#{lang.numbers}</button>
-        <button type="button" class="icon nesting-level decrease" data-trix-action="decreaseNestingLevel" title="#{lang.outdent}">#{lang.outdent}</button>
-        <button type="button" class="icon nesting-level increase" data-trix-action="increaseNestingLevel" title="#{lang.indent}">#{lang.indent}</button>
+        <button type="button" class="icon heading-1" data-trix-attribute="heading1" title="#{lang.heading1}" tabindex="-1">#{lang.heading1}</button>
+        <button type="button" class="icon quote" data-trix-attribute="quote" title="#{lang.quote}" tabindex="-1">#{lang.quote}</button>
+        <button type="button" class="icon code" data-trix-attribute="code" title="#{lang.code}" tabindex="-1">#{lang.code}</button>
+        <button type="button" class="icon list bullets" data-trix-attribute="bullet" title="#{lang.bullets}" tabindex="-1">#{lang.bullets}</button>
+        <button type="button" class="icon list numbers" data-trix-attribute="number" title="#{lang.numbers}" tabindex="-1">#{lang.numbers}</button>
+        <button type="button" class="icon nesting-level decrease" data-trix-action="decreaseNestingLevel" title="#{lang.outdent}" tabindex="-1">#{lang.outdent}</button>
+        <button type="button" class="icon nesting-level increase" data-trix-action="increaseNestingLevel" title="#{lang.indent}" tabindex="-1">#{lang.indent}</button>
       </span>
 
       <span class="button_group history_tools">
-        <button type="button" class="icon undo" data-trix-action="undo" data-trix-key="z" title="#{lang.undo}">#{lang.undo}</button>
-        <button type="button" class="icon redo" data-trix-action="redo" data-trix-key="shift+z" title="#{lang.redo}">#{lang.redo}</button>
+        <button type="button" class="icon undo" data-trix-action="undo" data-trix-key="z" title="#{lang.undo}" tabindex="-1">#{lang.undo}</button>
+        <button type="button" class="icon redo" data-trix-action="redo" data-trix-key="shift+z" title="#{lang.redo}" tabindex="-1">#{lang.redo}</button>
       </span>
     </div>
 


### PR DESCRIPTION
You can't tab directly to the content area.

In this PR, every toolbar button gets a tabindex property with a value of -1. It removes the buttons
from the navigation flow, meaning a user cannot tab to it. It improves usability when
Trix is placed after a focusable field (i.e. the user can tab directly to the content
area). It also improves the accessibility of Trix.