### PR TITLE
Advise users about WebComponentsReady event

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ If you don’t want to accept dropped or pasted files, call `preventDefault()` o
 
 # Editing Text Programmatically
 
-You can manipulate a Trix editor programmatically through the `Trix.Editor` interface, available on each `<trix-editor>` element through its `editor` property.
+You can manipulate a Trix editor programmatically through the `Trix.Editor` interface, available on each `<trix-editor>` element through its `editor` property. Note that you will need to wait for the browser to recognize the `<trix-editor>` custom element first before interacting with it. We will assume in examples below that you've already done this:
 
 ```js
-var element = document.querySelector("trix-editor")
-element.editor  // is a Trix.Editor instance
+window.addEventListener("WebComponentsReady", function() {
+  var element = document.querySelector("trix-editor")
+  element.editor  // is a Trix.Editor instance
+})
 ```
 
 ## Understanding the Document Model


### PR DESCRIPTION
In browsers such as Firefox that do not support custom elements natively, it is important to wrap any code that interacts with the `<trix-editor>` element in a event handler that listens for the `WebComponentsReady` event to fire, otherwise the `editor` property will not be available on the `<trix-editor>` element object.