### PR TITLE
Fix 'Invalid property value' for trix toolbar default CSS

### DIFF
--- a/src/trix/elements/trix_toolbar_element.coffee
+++ b/src/trix/elements/trix_toolbar_element.coffee
@@ -3,7 +3,7 @@
 Trix.registerElement "trix-toolbar",
   defaultCSS: """
     %t {
-      white-space: collapse;
+      white-space: nowrap;
     }
 
     %t .dialog {


### PR DESCRIPTION
Chrome tells me that 'collapse' is not a valid property for 'white-space'. Based on trix.css, I think it should be 'nowrap'?