### PR TITLE
allow the input element name to be updated

### DIFF
--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -114,7 +114,7 @@ Trix.registerElement "trix-editor", do ->
       if newInputElement
         @setAttribute("input", newInputElement.id)
       else
-         @setAttribute("input", "id_" + inputElementName)}
+         @setAttribute("input", "id_" + inputElementName)
 
   value:
     get: ->

--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -109,6 +109,12 @@ Trix.registerElement "trix-editor", do ->
   name:
     get: ->
       @inputElement?.name
+    set: (inputElementName) ->
+      newInputElement = document.getElementsByName(inputElementName)[0]
+      if newInputElement
+        @setAttribute("input", newInputElement.id)
+      else
+         @setAttribute("input", "id_" + inputElementName)}
 
   value:
     get: ->


### PR DESCRIPTION
Useful when using formset's in Django. Will attempt to find the element set by the name but if it does not exist, set's the element id to the default Django id format.

this connects to https://github.com/istrategylabs/django-trix/issues/2