### PR TITLE
Altered setAttributes to always return a promise

### DIFF
--- a/src/trix/models/attachment.coffee
+++ b/src/trix/models/attachment.coffee
@@ -34,10 +34,12 @@ class Trix.Attachment extends Trix.Object
 
   setAttributes: (attributes = {}) ->
     newAttributes = @attributes.merge(attributes)
-    unless @attributes.isEqualTo(newAttributes)
+    if @attributes.isEqualTo(newAttributes)
+      Promise.resolve()
+    else
       @attributes = newAttributes
-      @didChangeAttributes()
-      @delegate?.attachmentDidChangeAttributes?(this)
+      Promise.resolve(@didChangeAttributes()).then =>
+        @delegate?.attachmentDidChangeAttributes?(this)
 
   didChangeAttributes: ->
     if @isPreviewable()

--- a/test/src/system/custom_element_test.coffee
+++ b/test/src/system/custom_element_test.coffee
@@ -35,7 +35,7 @@ testGroup "Custom element API", template: "editor_empty", ->
     attachment.remove()
     assert.deepEqual events, ["trix-file-accept", "trix-attachment-add", "trix-attachment-remove"]
 
-  test "element triggers trix-change when an attachment is edited", ->
+  test "element triggers trix-change when an attachment is edited", (done) ->
     file = createFile()
     element = getEditorElement()
     composition = getComposition()
@@ -53,8 +53,9 @@ testGroup "Custom element API", template: "editor_empty", ->
     element.addEventListener "trix-change", (event) ->
       events.push(event.type)
 
-    attachment.setAttributes(width: 9876)
-    assert.deepEqual events, ["trix-attachment-edit", "trix-change"]
+    attachment.setAttributes(width: 9876).then ->
+      assert.deepEqual events, ["trix-attachment-edit", "trix-change"]
+      done()
 
   test "editing the document in a trix-attachment-add handler doesn't trigger trix-attachment-add again", ->
     element = getEditorElement()


### PR DESCRIPTION
setAttributes sometimes delves into the `preload` method that uses a
promise (operation) to wait for the source file to load into the
browser before doing some additional things. Thus, setAttributes should
also return a promise so that third-party code using this method can
wait for it to complete before doing other things such as allowing the
content of the editor to be saved.

I’ve changed the function so that we wait for `didChangeAttributes()`
to complete before executing `attachmentDidChangeAttributes()` on the
delegate as before this was triggering a premature notification.

I’ve not added any new tests but have adjusted the only one testing
this functionality so that it waits for the promise to resolve before
asserting.

I've not done much coffee script / javascript work before so please let me know if I've done something in a non-optimal way :)

Fixes: #388