### PR TITLE
Postion figure elements relative to the figure

### DIFF
--- a/assets/trix/stylesheets/attachments.scss
+++ b/assets/trix/stylesheets/attachments.scss
@@ -22,6 +22,8 @@ trix-editor {
   }
 
   .attachment {
+    position: relative;
+
     &:hover {
       cursor: default;
     }


### PR DESCRIPTION
`trix-editor .attachment button.remove.icon::before` is absolutely positioned, & the parent is the figure. The figure element should have `position: relative`.

![screen shot 2017-05-12 at 3 20 09 pm](https://cloud.githubusercontent.com/assets/54017/26017533/44dab5ac-3727-11e7-90b6-3c4e1021ca3c.png)

