### PR TITLE
Use trix- prefix for dialog CSS classnames

### DIFF
--- a/assets/trix/stylesheets/toolbar.scss
+++ b/assets/trix/stylesheets/toolbar.scss
@@ -127,10 +127,10 @@ trix-toolbar {
     }
   }
 
-  .dialogs {
+  .trix-dialogs {
     position: relative;
 
-    .dialog {
+    .trix-dialog {
       position: absolute;
       top: 0;
       left: 0;

--- a/src/trix/config/toolbar.coffee
+++ b/src/trix/config/toolbar.coffee
@@ -27,8 +27,8 @@ Trix.config.toolbar =
       </span>
     </div>
 
-    <div class="dialogs">
-      <div class="dialog link_dialog" data-trix-attribute="href" data-trix-dialog="href">
+    <div class="trix-dialogs">
+      <div class="trix-dialog link_dialog" data-trix-attribute="href" data-trix-dialog="href">
         <div class="link_url_fields">
           <input type="url" required name="href" placeholder="#{lang.urlPlaceholder}">
           <div class="button_group">

--- a/src/trix/controllers/toolbar_controller.coffee
+++ b/src/trix/controllers/toolbar_controller.coffee
@@ -4,7 +4,7 @@ class Trix.ToolbarController extends Trix.BasicObject
   actionButtonSelector = "button[data-trix-action]"
   attributeButtonSelector = "button[data-trix-attribute]"
   toolbarButtonSelector = [actionButtonSelector, attributeButtonSelector].join(", ")
-  dialogSelector = ".dialog[data-trix-dialog]"
+  dialogSelector = ".trix-dialog[data-trix-dialog]"
   activeDialogSelector = "#{dialogSelector}.active"
   dialogButtonSelector = "#{dialogSelector} input[data-trix-method]"
   dialogInputSelector = "#{dialogSelector} input[type=text], #{dialogSelector} input[type=url]"
@@ -155,7 +155,7 @@ class Trix.ToolbarController extends Trix.BasicObject
       input.classList.remove("validate")
 
   getDialog: (dialogName) ->
-    @element.querySelector(".dialog[data-trix-dialog=#{dialogName}]")
+    @element.querySelector(".trix-dialog[data-trix-dialog=#{dialogName}]")
 
   getInputForDialog = (element, attributeName) ->
     attributeName ?= getAttributeName(element)

--- a/src/trix/elements/trix_toolbar_element.coffee
+++ b/src/trix/elements/trix_toolbar_element.coffee
@@ -6,15 +6,15 @@ Trix.registerElement "trix-toolbar",
       white-space: nowrap;
     }
 
-    %t .dialog {
+    %t .trix-dialog {
       display: none;
     }
 
-    %t .dialog.active {
+    %t .trix-dialog.active {
       display: block;
     }
 
-    %t .dialog input.validate:invalid {
+    %t .trix-dialog input.validate:invalid {
       background-color: #ffdddd;
     }
 

--- a/test/src/test_helpers/toolbar_helpers.coffee
+++ b/test/src/test_helpers/toolbar_helpers.coffee
@@ -15,7 +15,7 @@ helpers.extend
     helpers.defer(callback)
 
   clickToolbarDialogButton: ({method}, callback) ->
-    button = getToolbarElement().querySelector(".dialog input[type=button][data-trix-method='#{method}']")
+    button = getToolbarElement().querySelector(".trix-dialog input[type=button][data-trix-method='#{method}']")
     helpers.triggerEvent(button, "click")
     helpers.defer(callback)
 
@@ -42,4 +42,4 @@ getToolbarButton = ({attribute, action}) ->
   getToolbarElement().querySelector("button[data-trix-attribute='#{attribute}'], button[data-trix-action='#{action}']")
 
 getToolbarDialog = ({attribute, action}) ->
-  getToolbarElement().querySelector(".dialog[data-trix-attribute='#{attribute}'], .dialog[data-trix-action='#{action}']")
+  getToolbarElement().querySelector(".trix-dialog[data-trix-attribute='#{attribute}'], .trix-dialog[data-trix-action='#{action}']")


### PR DESCRIPTION
Using `.dialog` for Trix CSS classnames may conflict with generic UI frameworks or other CSS libraries.  Better to scope the CSS classnames using a `.trix-` prefix.