### PR TITLE
Fix Safari image pasting

### DIFF
--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -465,7 +465,11 @@ pasteEventIsCrippledSafariHTMLPaste = (event) ->
     else
       isExternalHTMLPaste = "com.apple.webarchive" in paste.types
       isExternalRichTextPaste = "com.apple.flat-rtfd" in paste.types
-      isExternalHTMLPaste or isExternalRichTextPaste
+      # Safari pastes directly copied images such as Command+Control+Shift+4
+      # captured screenshots as inaccessble files which must be sniffed from
+      # the DOM
+      isImagePasteWithoutFile = paste.files.length is 0 and paste.types.some((type) -> type.indexOf("image/") is 0)
+      isExternalHTMLPaste or isExternalRichTextPaste or isImagePasteWithoutFile
 
 dataTransferIsPlainText = (dataTransfer) ->
   text = dataTransfer.getData("text/plain")


### PR DESCRIPTION
Copying image data directly, such as with a Command+Ctrl+Shift+4 screenshot, currently doesn't Command+V paste into Trix editors (like in Basecamp) when using Safari. This seems to be because Safari doesn't expose the image data as a "file" in the clipboard data for Trix to attach. But triggering the crippled safari paste behaviour in these cases seems to create an img element with the correct data which triggers Trix attachment behaviour and all works great.