### PR TITLE
Deleting in-line attachments

### DIFF
--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -39,6 +39,7 @@ class Trix.HTMLParser extends Trix.BasicObject
       @referenceElement.parentNode.insertBefore(@containerElement, @referenceElement.nextSibling)
     else
       @containerElement = makeElement(tagName: "div", style: { display: "none" })
+      @containerElement.setAttribute("data-trix-internal", "")
       document.body.appendChild(@containerElement)
 
   removeHiddenContainer: ->


### PR DESCRIPTION
Currently there is a problem with deleting in line attachments due to the creation of a hidden container. On the creation of a new element, style that is applied to items in the trix editor is not applied to the new hidden container and the default style is applied which is block. Added data-trix-internal attribute to the new element to mimic how it works when there is a reference element. This way style can be applied to data-trix-internal and maintained throughout the creation of a hidden container.
#419 