### PR TITLE
iOS: Fix broken emojis

### DIFF
--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -155,15 +155,10 @@ class Trix.InputController extends Trix.BasicObject
       return if keyEventIsWebInspectorShortcut(event)
       return if keyEventIsPasteAndMatchStyleShortcut(event)
 
-      if event.which is null
-        character = String.fromCharCode event.keyCode
-      else if event.which isnt 0 and event.charCode isnt 0
-        character = String.fromCharCode event.charCode
-
-      if character?
+      if string = stringFromKeyEvent(event)
         @delegate?.inputControllerWillPerformTyping()
-        @responder?.insertString(character)
-        @setInputSummary(textAdded: character, didDelete: @selectionIsExpanded())
+        @responder?.insertString(string)
+        @setInputSummary(textAdded: string, didDelete: @selectionIsExpanded())
 
     textInput: (event) ->
       # Handle autocapitalization
@@ -450,6 +445,20 @@ class Trix.InputController extends Trix.BasicObject
 
 extensionForFile = (file) ->
   file.type?.match(/\/(\w+)$/)?[1]
+
+hasStringCodePointAt = " ".codePointAt?(0)?
+
+stringFromKeyEvent = (event) ->
+  if event.key and hasStringCodePointAt and event.key.codePointAt(0) is event.keyCode
+    event.key
+  else
+    if event.which is null
+      code = event.keyCode
+    else if event.which isnt 0 and event.charCode isnt 0
+      code = event.charCode
+
+    if code?
+      Trix.UTF16String.fromCodepoints([code]).toString()
 
 keyEventIsWebInspectorShortcut = (event) ->
   event.metaKey and event.altKey and not event.shiftKey and event.keyCode is 94

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -103,7 +103,7 @@ class Trix.InputController extends Trix.BasicObject
           if unexpectedNewlineAddition
             textAdded.replace(/\n$/, "").length or -1
           else
-            1
+            textAdded?.length or 1
         if @responder?.positionIsBlockBreak(range[1] + offset)
           return true
 

--- a/test/src/system/mutation_input_test.coffee
+++ b/test/src/system/mutation_input_test.coffee
@@ -50,6 +50,22 @@ testGroup "Mutation input", template: "editor_empty", ->
         assert.textAttributes([3, 4], bold: true)
         expectDocument("a\n\nb\n")
 
+  test "typing an emoji after a newline at the end of block", (expectDocument) ->
+    element = getEditorElement()
+
+    typeCharacters "\n", ->
+      # Tap 👏🏻 on iOS
+      triggerEvent(element, "keydown", charCode: 0, keyCode: 0, which: 0, key: "👏🏻")
+      triggerEvent(element, "keypress", charCode: 128079, keyCode: 128079, which: 128079, key: "👏🏻")
+
+      node = document.createTextNode("👏🏻")
+      extraBR = element.querySelectorAll("br")[1]
+      extraBR.parentNode.insertBefore(node, extraBR)
+      extraBR.parentNode.removeChild(extraBR)
+
+      requestAnimationFrame ->
+        expectDocument("\n👏🏻\n")
+
   test "backspacing an attachment at the beginning of an otherwise empty document", (expectDocument) ->
     element = getEditorElement()
     element.editor.loadHTML("""<img src="#{TEST_IMAGE_URL}" width="10" height="10">""")


### PR DESCRIPTION
* Fixes that typing an emoji on iOS could result in a broken  [U+F44F: INVALID CHARACTER](http://www.charbase.com/f44f-unicode-invalid-character)
* Adds support for determining `keypress` event input from the [`event.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) property when available *and* support for handling `event.keyCode`s > 65535

The root of the problem was the use of `String.fromCharCode` for handling `event.keyCode`. When you type a "👏🏻", for example, on iOS Safari you get a `keypress` event (TIL!) with an `event.keyCode` of `128079`.  The maximum value `String.fromCharCode` accepts is 65535 (2<sup>16</sup> - 1), and passing a larger value results in an incorrect string value:

```js
> string = String.fromCharCode(128079)
''

> string.length
1

> string.codePointAt(0)
62543

> string.codePointAt(0).toString(16)
'f44f'
```

---

| Before 🙅‍♂️ | After 🙆‍♂️ |
| --- | --- |
| ![ios-before](https://user-images.githubusercontent.com/5355/29792577-cc3e7f9c-8c0e-11e7-86ec-4bda861b75e6.gif) | ![ios-after](https://user-images.githubusercontent.com/5355/29792528-ad332b52-8c0e-11e7-977d-a90c7bcdb8b5.gif) |