### PR TITLE
Set `tabindex="-1"` on attachment links

### DIFF
--- a/src/trix/config/serialization.coffee
+++ b/src/trix/config/serialization.coffee
@@ -1,5 +1,5 @@
 unserializableElementSelector = "[data-trix-serialize=false]"
-unserializableAttributeNames = ["contenteditable", "data-trix-id", "data-trix-store-key", "data-trix-mutable", "data-trix-placeholder"]
+unserializableAttributeNames = ["contenteditable", "data-trix-id", "data-trix-store-key", "data-trix-mutable", "data-trix-placeholder", "tabindex"]
 serializedAttributesAttribute = "data-trix-serialized-attributes"
 serializedAttributesSelector = "[#{serializedAttributesAttribute}]"
 

--- a/src/trix/views/attachment_view.coffee
+++ b/src/trix/views/attachment_view.coffee
@@ -47,7 +47,7 @@ class Trix.AttachmentView extends Trix.ObjectView
       data.trixSerialize = false
 
     if href = @getHref()
-      element = makeElement("a", {href})
+      element = makeElement("a", {href, tabindex: -1})
       element.appendChild(figure)
     else
       element = figure

--- a/test/src/test_helpers/fixtures/fixtures.coffee
+++ b/test/src/test_helpers/fixtures/fixtures.coffee
@@ -288,7 +288,7 @@ removeWhitespace = (string) ->
       trixContentType: "application/pdf"
       trixId: attachment.id
 
-    link = Trix.makeElement("a", href: attrs.href)
+    link = Trix.makeElement("a", href: attrs.href, tabindex: -1)
     link.dataset[key] = value for key, value of data
     link.setAttribute("contenteditable", false)
     link.appendChild(figure)


### PR DESCRIPTION
Fixes an accessibility issue where pressing the Tab key in an editor will incorrectly move focus to a linked attachment instead of the next form element.

h/t @bergatron