### PR TITLE
Style: Improve displaying code blocks in list items

### DIFF
--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -1,6 +1,10 @@
 .trix-content {
   line-height: 1.5;
 
+  * {
+    box-sizing: border-box;
+  }
+
   h1 {
     font-size: 1.2em;
     line-height: 1.2;
@@ -14,6 +18,9 @@
   }
 
   pre {
+    display: inline-block;
+    width: 100%;
+    vertical-align: top;
     font-family: monospace;
     font-size: 0.9em;
     margin: 0;


### PR DESCRIPTION
Before
<img width="489" alt="before" src="https://user-images.githubusercontent.com/5355/30908519-cbd95b0e-a34b-11e7-9497-5e6454d12fdb.png">

After
<img width="489" alt="after" src="https://user-images.githubusercontent.com/5355/30908531-d56c4898-a34b-11e7-8a79-fda70afdbece.png">

h/t @uptonic 
