### PR TITLE
Remove duplicate text-indent css

### DIFF
--- a/assets/trix/stylesheets/attachments.scss
+++ b/assets/trix/stylesheets/attachments.scss
@@ -84,7 +84,6 @@ trix-editor {
     height: 1.8em;
     line-height: 1.8em;
     border-radius: 50%;
-    text-indent: -9999px;
     background-color: #fff;
     border: 2px solid highlight;
     box-shadow: 1px 1px 6px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
`text-indent: -9999px;` is declared in the same block on line 75.