### PR TITLE
Android: Ignore Chrome 65’s new composition events during cursor movement

### DIFF
--- a/src/trix/controllers/input/composition_input.coffee
+++ b/src/trix/controllers/input/composition_input.coffee
@@ -1,3 +1,5 @@
+{browser} = Trix
+
 class Trix.CompositionInput extends Trix.BasicObject
   constructor: (@inputController) ->
     {@responder, @delegate, @inputSummary} = @inputController
@@ -50,7 +52,10 @@ class Trix.CompositionInput extends Trix.BasicObject
     @getEndData()?
 
   isSignificant: ->
-    @inputSummary.didInput
+    if browser.composesExistingText
+      @inputSummary.didInput
+    else
+      true
 
   # Private
 

--- a/src/trix/controllers/input/composition_input.coffee
+++ b/src/trix/controllers/input/composition_input.coffee
@@ -6,35 +6,41 @@ class Trix.CompositionInput extends Trix.BasicObject
   start: (data) ->
     @data.start = data
 
-    if @inputSummary.eventName is "keypress" and @inputSummary.textAdded
-      @responder?.deleteInDirection("left")
+    if @isSignificant()
+      if @inputSummary.eventName is "keypress" and @inputSummary.textAdded
+        @responder?.deleteInDirection("left")
 
-    unless @selectionIsExpanded()
-      @insertPlaceholder()
-      @requestRender()
+      unless @selectionIsExpanded()
+        @insertPlaceholder()
+        @requestRender()
 
-    @range = @responder?.getSelectedRange()
+      @range = @responder?.getSelectedRange()
 
   update: (data) ->
     @data.update = data
 
-    if range = @selectPlaceholder()
-      @forgetPlaceholder()
-      @range = range
+    if @isSignificant()
+      if range = @selectPlaceholder()
+        @forgetPlaceholder()
+        @range = range
 
   end: (data) ->
     @data.end = data
-    @forgetPlaceholder()
 
-    if @canApplyToDocument()
-      @setInputSummary(preferDocument: true)
-      @delegate?.inputControllerWillPerformTyping()
-      @responder?.setSelectedRange(@range)
-      @responder?.insertString(@data.end)
-      @responder?.setSelectedRange(@range[0] + @data.end.length)
+    if @isSignificant()
+      @forgetPlaceholder()
 
-    else if @data.start? or @data.update?
-      @requestReparse()
+      if @canApplyToDocument()
+        @setInputSummary(preferDocument: true)
+        @delegate?.inputControllerWillPerformTyping()
+        @responder?.setSelectedRange(@range)
+        @responder?.insertString(@data.end)
+        @responder?.setSelectedRange(@range[0] + @data.end.length)
+
+      else if @data.start? or @data.update?
+        @requestReparse()
+        @inputController.reset()
+    else
       @inputController.reset()
 
   getEndData: ->
@@ -42,6 +48,9 @@ class Trix.CompositionInput extends Trix.BasicObject
 
   isEnded: ->
     @getEndData()?
+
+  isSignificant: ->
+    @inputSummary.didInput
 
   # Private
 

--- a/src/trix/controllers/input/composition_input.coffee
+++ b/src/trix/controllers/input/composition_input.coffee
@@ -33,7 +33,7 @@ class Trix.CompositionInput extends Trix.BasicObject
       @forgetPlaceholder()
 
       if @canApplyToDocument()
-        @setInputSummary(preferDocument: true)
+        @setInputSummary(preferDocument: true, didInput: false)
         @delegate?.inputControllerWillPerformTyping()
         @responder?.setSelectedRange(@range)
         @responder?.insertString(@data.end)

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -161,9 +161,6 @@ class Trix.InputController extends Trix.BasicObject
         @responder?.insertString(string)
         @setInputSummary(textAdded: string, didDelete: @selectionIsExpanded())
 
-    keyup: (event) ->
-      @inputSummary.didInput = true
-
     textInput: (event) ->
       # Handle autocapitalization
       {data} = event

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -129,6 +129,7 @@ class Trix.InputController extends Trix.BasicObject
   events:
     keydown: (event) ->
       @resetInputSummary() unless @isComposing()
+      @inputSummary.didInput = true
 
       if keyName = @constructor.keyNames[event.keyCode]
         context = @keys
@@ -297,7 +298,11 @@ class Trix.InputController extends Trix.BasicObject
     compositionend: (event) ->
       @getCompositionInput().end(event.data)
 
+    beforeinput: (event) ->
+      @inputSummary.didInput = true
+
     input: (event) ->
+      @inputSummary.didInput = true
       event.stopPropagation()
 
   keys:

--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -161,6 +161,9 @@ class Trix.InputController extends Trix.BasicObject
         @responder?.insertString(string)
         @setInputSummary(textAdded: string, didDelete: @selectionIsExpanded())
 
+    keyup: (event) ->
+      @inputSummary.didInput = true
+
     textInput: (event) ->
       # Handle autocapitalization
       {data} = event

--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -1,7 +1,7 @@
 #= require trix/elements/trix_toolbar_element
 #= require trix/controllers/editor_controller
 
-{makeElement, triggerEvent, handleEvent, handleEventOnce} = Trix
+{browser, makeElement, triggerEvent, handleEvent, handleEventOnce} = Trix
 
 {attachmentSelector} = Trix.AttachmentView
 
@@ -37,11 +37,8 @@ Trix.registerElement "trix-editor", do ->
 
   # Style
 
-  # IE 11 activates resizing handles on editable elements that have "layout"
-  browserForcesObjectResizing = /Trident.*rv:11/.test(navigator.userAgent)
-
   cursorTargetStyles = do ->
-    if browserForcesObjectResizing
+    if browser.forcesObjectResizing
       display: "inline"
       width: "auto"
     else

--- a/src/trix/index.coffee.erb
+++ b/src/trix/index.coffee.erb
@@ -15,5 +15,7 @@
     # Android emits composition events when moving the cursor through existing text
     # Introduced in Chrome 65: https://bugs.chromium.org/p/chromium/issues/detail?id=764439#c9
     composesExistingText: /Android.*Chrome/.test(navigator.userAgent)
+    # IE 11 activates resizing handles on editable elements that have "layout"
+    forcesObjectResizing: /Trident.*rv:11/.test(navigator.userAgent)
 
   config: {}

--- a/src/trix/index.coffee.erb
+++ b/src/trix/index.coffee.erb
@@ -11,4 +11,9 @@
   NON_BREAKING_SPACE: "\u00A0"
   OBJECT_REPLACEMENT_CHARACTER: "\uFFFC"
 
+  browser:
+    # Android emits composition events when moving the cursor through existing text
+    # Introduced in Chrome 65: https://bugs.chromium.org/p/chromium/issues/detail?id=764439#c9
+    composesExistingText: /Android.*Chrome/.test(navigator.userAgent)
+
   config: {}

--- a/test/src/system/composition_input_test.coffee
+++ b/test/src/system/composition_input_test.coffee
@@ -164,26 +164,6 @@ testGroup "Composition input", template: "editor_empty", ->
             assert.locationRange(index: 0, offset: 2)
             expectDocument("éé\n")
 
-  # Simulates compositions in Firefox on Linux, which aren't preceded by
-  # keydown and don't dispatch input after compositionupdate.
-  test "composition with limited contextual keyboard and input events", (expectDocument) ->
-    element = getEditorElement()
-    element.editor.insertString("i")
-    element.editor.setSelectedRange(1)
-    defer ->
-      triggerEvent(element, "keyup", charCode: 0, keyCode: 0, which: 0)
-      triggerEvent(element, "compositionstart", data: "")
-      triggerEvent(element, "compositionupdate", data: "ó")
-      node = document.createTextNode("ó")
-      insertNode(node)
-      selectNode(node)
-      defer ->
-        triggerEvent(element, "compositionend", data: "ó")
-        triggerEvent(element, "input")
-        typeCharacters "n", ->
-          assert.locationRange(index: 0, offset: 3)
-          expectDocument("ión\n")
-
 removeCharacters = (direction, callback) ->
   selection = rangy.getSelection()
   range = selection.getRangeAt(0)

--- a/test/src/system/composition_input_test.coffee
+++ b/test/src/system/composition_input_test.coffee
@@ -164,6 +164,26 @@ testGroup "Composition input", template: "editor_empty", ->
             assert.locationRange(index: 0, offset: 2)
             expectDocument("éé\n")
 
+  # Simulates compositions in Firefox on Linux, which aren't preceded by
+  # keydown and don't dispatch input after compositionupdate.
+  test "composition with limited contextual keyboard and input events", (expectDocument) ->
+    element = getEditorElement()
+    element.editor.insertString("i")
+    element.editor.setSelectedRange(1)
+    defer ->
+      triggerEvent(element, "keyup", charCode: 0, keyCode: 0, which: 0)
+      triggerEvent(element, "compositionstart", data: "")
+      triggerEvent(element, "compositionupdate", data: "ó")
+      node = document.createTextNode("ó")
+      insertNode(node)
+      selectNode(node)
+      defer ->
+        triggerEvent(element, "compositionend", data: "ó")
+        triggerEvent(element, "input")
+        typeCharacters "n", ->
+          assert.locationRange(index: 0, offset: 3)
+          expectDocument("ión\n")
+
 removeCharacters = (direction, callback) ->
   selection = rangy.getSelection()
   range = selection.getRangeAt(0)

--- a/test/src/system/composition_input_test.coffee
+++ b/test/src/system/composition_input_test.coffee
@@ -1,4 +1,5 @@
-{assert, clickToolbarButton, defer, endComposition, insertNode, pressKey, selectNode, startComposition, test, testGroup, triggerEvent, typeCharacters, updateComposition} = Trix.TestHelpers
+{assert, clickToolbarButton, defer, endComposition, insertNode, pressKey, selectNode, startComposition, test, testIf, testGroup, triggerEvent, typeCharacters, updateComposition} = Trix.TestHelpers
+{browser} = Trix
 
 testGroup "Composition input", template: "editor_empty", ->
   test "composing", (expectDocument) ->
@@ -114,11 +115,7 @@ testGroup "Composition input", template: "editor_empty", ->
         defer ->
           expectDocument("ca\n")
 
-  # Simulates the sequence of events when moving the cursor through a word on Android
-  # Introduced in Chrome 65:
-  # - https://bugs.chromium.org/p/chromium/issues/detail?id=812674
-  # - https://bugs.chromium.org/p/chromium/issues/detail?id=764439#c9
-  test "composition events from cursor movement are ignored", (expectDocument) ->
+  testIf browser.composesExistingText, "composition events from cursor movement are ignored", (expectDocument) ->
     element = getEditorElement()
     element.editor.insertString("ab ")
 

--- a/test/src/system/custom_element_test.coffee
+++ b/test/src/system/custom_element_test.coffee
@@ -1,4 +1,4 @@
-{after, assert, clickElement, clickToolbarButton, createFile, defer, insertImageAttachment, moveCursor, pasteContent, skip, test, testGroup, triggerEvent, typeCharacters, typeInToolbarDialog} = Trix.TestHelpers
+{after, assert, clickElement, clickToolbarButton, createFile, defer, insertImageAttachment, moveCursor, pasteContent, skip, test, testIf, testGroup, triggerEvent, typeCharacters, typeInToolbarDialog} = Trix.TestHelpers
 
 testGroup "Custom element API", template: "editor_empty", ->
   test "files are accepted by default", ->
@@ -286,8 +286,7 @@ testGroup "Custom element API", template: "editor_empty", ->
 
   # Selenium doesn't seem to focus windows properly in some browsers (FF 47 on OS X)
   # so skip this test when unfocused pending a better solution.
-  testOrSkip = if document.hasFocus() then test else skip
-  testOrSkip "element triggers custom focus event when autofocusing", (done) ->
+  testIf document.hasFocus(), "element triggers custom focus event when autofocusing", (done) ->
     element = document.createElement("trix-editor")
     element.setAttribute("autofocus", "")
 

--- a/test/src/test_helpers/test_helpers.coffee
+++ b/test/src/test_helpers/test_helpers.coffee
@@ -69,4 +69,10 @@ helpers.extend
         else
           callback(done)
 
+  testIf: (condition, args...) ->
+    if condition
+      helpers.test(args...)
+    else
+      helpers.skip(args...)
+
   skip: QUnit.skip


### PR DESCRIPTION
Attempting to get ahead of Chrome 65's composition event changes so Android isn't totally broken when it's released on March 6.

References:
- https://twitter.com/javan/status/966360950562582528
- https://bugs.chromium.org/p/chromium/issues/detail?id=812674
- https://bugs.chromium.org/p/chromium/issues/detail?id=764439#c9