### PR TITLE
Add markup for better JAWS and NVDA screenreader performance

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -49,7 +49,7 @@
   </head>
   <body>
     <main>
-      <trix-editor autofocus class="trix-content" role="textbox" contenteditable="true" aria-multiline="true" aria-label="Rich text input"></trix-editor>
+      <trix-editor autofocus class="trix-content"></trix-editor>
     </main>
   </body>
 </html>

--- a/assets/index.html
+++ b/assets/index.html
@@ -49,7 +49,7 @@
   </head>
   <body>
     <main>
-      <trix-editor autofocus class="trix-content"></trix-editor>
+      <trix-editor autofocus class="trix-content" role="textbox" contenteditable="true" aria-multiline="true" aria-label="Rich text input"></trix-editor>
     </main>
   </body>
 </html>

--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -20,6 +20,10 @@ Trix.registerElement "trix-editor", do ->
     element.setAttribute("contenteditable", "")
     handleEventOnce("focus", onElement: element, withCallback: -> configureContentEditable(element))
 
+  addAccessibilityRole = (element) ->
+    return if element.hasAttribute("role")
+    element.setAttribute("role", "textbox")
+
   configureContentEditable = (element) ->
     disableObjectResizing(element)
     setDefaultParagraphSeparator(element)
@@ -153,6 +157,7 @@ Trix.registerElement "trix-editor", do ->
 
   createdCallback: ->
     makeEditable(this)
+    addAccessibilityRole(this)
 
   attachedCallback: ->
     unless @hasAttribute("data-trix-internal")


### PR DESCRIPTION
This is designed to improve the situation described in https://github.com/basecamp/trix/issues/195. The changes are based on [this MDN doc](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_textbox_role).

- Without the explicit `role="textbox"` JAWS + Firefox doesn't correctly describe the input.
---
After chatting with @sstephenson I did another round of testing. This time I selectively tested `role="textbox"` in addition to `aria-multiline` and an explicit `aria-label` to see which combinations worked best. [Results documented here](https://docs.google.com/spreadsheets/d/17FtEZ5b2Eyyto2VwAd7T-FuZMFMFta_PSQ_JIYiTWL4/edit?usp=sharing). To summarize:
- Adding a `role="textbox"` fixes the JAWS + FF issue that instigated this. It's the only attribute I think we should add at this point.

- `role="textbox"` + `aria-multiline` only gets picked up by NVDA + FF, and causes JAWS + FF to no longer read the text area contents.
- `role="textbox"` + an `aria-label` causes JAWS + IE11 to no longer speak the contents of the text area, and VoiceOver to no longer convey when the text area is empty.