### PR TITLE
Add `cursor: text` for placeholder

### DIFF
--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -49,6 +49,7 @@ Trix.registerElement "trix-editor", do ->
     %t:empty:not(:focus)::before {
       content: attr(placeholder);
       color: graytext;
+      cursor: text;
     }
 
     %t a[contenteditable=false] {


### PR DESCRIPTION
Hi there!

On chrome for Linux, the editor's placeholder has the default mouse cursor when hovered, which may not indicate for some people that it is an editable input. This pull-request adds `cursor: text` in the placeholder's style.

Before:
![image](https://user-images.githubusercontent.com/4276593/38474921-5f3fd69a-3b7a-11e8-9365-3152154ffadc.png)

After:
![image](https://user-images.githubusercontent.com/4276593/38474946-9bd18572-3b7a-11e8-87bc-70cfba1d9f0f.png)

Thanks!