### PR TITLE
Custom Elements v1 (and v0)

### DIFF
--- a/polyfills/custom-elements-v0-fallback.js.erb
+++ b/polyfills/custom-elements-v0-fallback.js.erb
@@ -1,0 +1,9 @@
+(function() {
+  var v1support = typeof window.customElements == "object"
+  var v0support = typeof document.registerElement == "function"
+  var supported = v1support || v0support
+
+  if (!supported) {
+    <%= depend_on_asset("./vendor/CustomElements").to_s.strip %>
+  }
+}).call(this);

--- a/polyfills/polyfills.coffee
+++ b/polyfills/polyfills.coffee
@@ -1,3 +1,3 @@
 #= require ./set
 #= require ./vendor/promise
-#= require ./vendor/CustomElements
+#= require ./custom-elements-v0-fallback

--- a/polyfills/vendor/CustomElements.js
+++ b/polyfills/vendor/CustomElements.js
@@ -7,7 +7,7 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
-// @version 0.7.22
+// @version 0.7.24
 if (typeof WeakMap === "undefined") {
   (function() {
     var defineProperty = Object.defineProperty;
@@ -351,7 +351,7 @@ if (typeof WeakMap === "undefined") {
 
 (function(scope) {
   "use strict";
-  if (!window.performance) {
+  if (!(window.performance && window.performance.now)) {
     var start = Date.now();
     window.performance = {
       now: function() {

--- a/src/trix/core/helpers/custom_elements.coffee
+++ b/src/trix/core/helpers/custom_elements.coffee
@@ -62,14 +62,8 @@ rewriteLifecycleCallbacks = do ->
 registerElement = do ->
   if window.customElements
     (tagName, properties) ->
-      constructor = ->
-        if typeof Reflect is "object"
-          Reflect.construct(HTMLElement, [], constructor)
-        else
-          HTMLElement.apply(this)
-      Object.setPrototypeOf(constructor.prototype, HTMLElement.prototype)
-      Object.setPrototypeOf(constructor, HTMLElement)
-      Object.defineProperties(constructor.prototype, properties)
+      constructor = -> Reflect.construct(HTMLElement, [], constructor)
+      constructor.prototype = Object.create(HTMLElement.prototype, properties)
       window.customElements.define(tagName, constructor)
       constructor
   else

--- a/src/trix/core/helpers/custom_elements.coffee
+++ b/src/trix/core/helpers/custom_elements.coffee
@@ -1,47 +1,14 @@
-defaults =
-  extendsTagName: "div"
-  css: "%t { display: block; }"
-
 Trix.registerElement = (tagName, definition = {}) ->
   tagName = tagName.toLowerCase()
 
   definition = rewriteLifecycleCallbacks(definition)
   properties = rewriteFunctionsAsValues(definition)
 
-  extendsTagName = properties.extendsTagName ? defaults.extendsTagName
-  delete properties.extendsTagName
+  if defaultCSS = properties.defaultCSS
+    delete properties.defaultCSS
+    installDefaultCSSForTagName(defaultCSS, tagName)
 
-  defaultCSS = properties.defaultCSS
-  delete properties.defaultCSS
-
-  if defaultCSS? and extendsTagName is defaults.extendsTagName
-    defaultCSS += "\n#{defaults.css}"
-  else
-    defaultCSS = defaults.css
-
-  installDefaultCSSForTagName(defaultCSS, tagName)
-
-  if window.customElements
-    constructor = ->
-      if typeof Reflect is "object"
-        Reflect.construct(HTMLElement, [], constructor)
-      else
-        HTMLElement.apply(this)
-
-    Object.setPrototypeOf(constructor.prototype, HTMLElement.prototype)
-    Object.setPrototypeOf(constructor, HTMLElement)
-    Object.defineProperties(constructor.prototype, properties)
-
-    window.customElements.define(tagName, constructor)
-    constructor
-  else
-    extendedPrototype = Object.getPrototypeOf(document.createElement(extendsTagName))
-    extendedPrototype.__super__ = extendedPrototype
-
-    prototype = Object.create(extendedPrototype, properties)
-    constructor = document.registerElement(tagName, prototype: prototype)
-    Object.defineProperty(prototype, "constructor", value: constructor)
-    constructor
+  registerElement(tagName, properties)
 
 installDefaultCSSForTagName = (defaultCSS, tagName) ->
   styleElement = insertStyleElementForTagName(tagName)
@@ -53,15 +20,6 @@ insertStyleElementForTagName = (tagName) ->
   element.setAttribute("data-tag-name", tagName.toLowerCase())
   document.head.insertBefore(element, document.head.firstChild)
   element
-
-lifecycleMap = do ->
-  if window.customElements
-    connect: "connectedCallback"
-    disconnect: "disconnectedCallback"
-  else
-    initialize: "createdCallback"
-    connect: "attachedCallback"
-    disconnect: "detachedCallback"
 
 rewriteLifecycleCallbacks = (definition) ->
   result = Trix.copyObject(definition)
@@ -86,3 +44,32 @@ rewriteFunctionsAsValues = (definition) ->
   for key, value of definition
     object[key] = if typeof value is "function" then {value, writable: true} else value
   object
+
+lifecycleMap = do ->
+  if window.customElements
+    connect: "connectedCallback"
+    disconnect: "disconnectedCallback"
+  else
+    initialize: "createdCallback"
+    connect: "attachedCallback"
+    disconnect: "detachedCallback"
+
+registerElement = do ->
+  if window.customElements
+    (tagName, properties) ->
+      constructor = ->
+        if typeof Reflect is "object"
+          Reflect.construct(HTMLElement, [], constructor)
+        else
+          HTMLElement.apply(this)
+      Object.setPrototypeOf(constructor.prototype, HTMLElement.prototype)
+      Object.setPrototypeOf(constructor, HTMLElement)
+      Object.defineProperties(constructor.prototype, properties)
+      window.customElements.define(tagName, constructor)
+      constructor
+  else
+    (tagName, properties) ->
+      prototype = Object.create(HTMLElement.prototype, properties)
+      constructor = document.registerElement(tagName, prototype: prototype)
+      Object.defineProperty(prototype, "constructor", value: constructor)
+      constructor

--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -156,11 +156,10 @@ Trix.registerElement "trix-editor", do ->
 
   # Element lifecycle
 
-  createdCallback: ->
+  connect: ->
     makeEditable(this)
     addAccessibilityRole(this)
 
-  attachedCallback: ->
     unless @hasAttribute("data-trix-internal")
       @editorController ?= new Trix.EditorController(editorElement: this, html: @defaultValue = @value)
       @editorController.registerSelectionManager()
@@ -168,7 +167,7 @@ Trix.registerElement "trix-editor", do ->
       autofocus(this)
       requestAnimationFrame => @notify("initialize")
 
-  detachedCallback: ->
+  disconnect: ->
     @editorController?.unregisterSelectionManager()
     @unregisterResetListener()
 

--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -50,6 +50,10 @@ Trix.registerElement "trix-editor", do ->
       width: "1px"
 
   defaultCSS: """
+    %t {
+      display: block;
+    }
+
     %t:empty:not(:focus)::before {
       content: attr(placeholder);
       color: graytext;

--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -156,10 +156,11 @@ Trix.registerElement "trix-editor", do ->
 
   # Element lifecycle
 
-  connect: ->
+  initialize: ->
     makeEditable(this)
     addAccessibilityRole(this)
 
+  connect: ->
     unless @hasAttribute("data-trix-internal")
       @editorController ?= new Trix.EditorController(editorElement: this, html: @defaultValue = @value)
       @editorController.registerSelectionManager()

--- a/src/trix/elements/trix_toolbar_element.coffee
+++ b/src/trix/elements/trix_toolbar_element.coffee
@@ -19,17 +19,6 @@ Trix.registerElement "trix-toolbar",
 
   # Element lifecycle
 
-  # `attachedCallback` (defined as `connect` here) doesn't run in Firefox when
-  # an element is dynamically inserted while the document is still loading. Most
-  # likely due to a bug in the v0 polyfill. For this element, the result is a
-  # blank toolbar. Workaround: Render when created too in `createdCallback`.
-  createdCallback: ->
-    @render()
-
-  connect: ->
-    @render()
-
-  # Private
-
-  render: ->
-    @innerHTML ||= Trix.config.toolbar.getDefaultHTML()
+  initialize: ->
+    if @innerHTML is ""
+      @innerHTML = Trix.config.toolbar.getDefaultHTML()

--- a/src/trix/elements/trix_toolbar_element.coffee
+++ b/src/trix/elements/trix_toolbar_element.coffee
@@ -17,6 +17,19 @@ Trix.registerElement "trix-toolbar",
     }
   """
 
+  # Element lifecycle
+
+  # `attachedCallback` (defined as `connect` here) doesn't run in Firefox when
+  # an element is dynamically inserted while the document is still loading. Most
+  # likely due to a bug in the v0 polyfill. For this element, the result is a
+  # blank toolbar. Workaround: Render when created too in `createdCallback`.
+  createdCallback: ->
+    @render()
+
   connect: ->
-    if @innerHTML is ""
-      @innerHTML = Trix.config.toolbar.getDefaultHTML()
+    @render()
+
+  # Private
+
+  render: ->
+    @innerHTML ||= Trix.config.toolbar.getDefaultHTML()

--- a/src/trix/elements/trix_toolbar_element.coffee
+++ b/src/trix/elements/trix_toolbar_element.coffee
@@ -1,6 +1,10 @@
 Trix.registerElement "trix-toolbar",
   defaultCSS: """
     %t {
+      display: block;
+    }
+
+    %t {
       white-space: nowrap;
     }
 

--- a/src/trix/elements/trix_toolbar_element.coffee
+++ b/src/trix/elements/trix_toolbar_element.coffee
@@ -17,6 +17,6 @@ Trix.registerElement "trix-toolbar",
     }
   """
 
-  createdCallback: ->
+  connect: ->
     if @innerHTML is ""
       @innerHTML = Trix.config.toolbar.getDefaultHTML()

--- a/src/trix/inspector/element.coffee
+++ b/src/trix/inspector/element.coffee
@@ -1,6 +1,10 @@
 Trix.registerElement "trix-inspector",
   defaultCSS: """
     %t {
+      display: block;
+    }
+
+    %t {
       position: fixed;
       background: #fff;
       border: 1px solid #444;

--- a/src/trix/inspector/element.coffee
+++ b/src/trix/inspector/element.coffee
@@ -54,7 +54,7 @@ Trix.registerElement "trix-inspector",
     }
   """
 
-  attachedCallback: ->
+  connect: ->
     @editorElement = document.querySelector("trix-editor[trix-id='#{@dataset.trixId}']")
     @views = @createViews()
 
@@ -67,7 +67,7 @@ Trix.registerElement "trix-inspector",
     @resizeHandler = @reposition.bind(this)
     addEventListener("resize", @resizeHandler)
 
-  detachedCallback: ->
+  disconnect: ->
     removeEventListener("resize", @resizeHandler)
 
   createViews: ->


### PR DESCRIPTION
This pull requests adds support for [Custom Elements v1](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements), the official standardized spec recognized by all major platforms. [v1 has already landed](https://platform-status.mozilla.org/#custom-elements) in Chrome, Safari, and Opera, and development is underway in Firefox and Microsoft Edge.

Custom Elements v1 and v0 are conceptually identical, although they don't share much in common API-wise. For better or worse, those API differences make v1 much tricker to polyfill.

<details>
<summary>v1 gotchas…</summary>

> **Caveat: an unpolyfillable upgrade**
> There are things that current V1 makes impossible to reproduce via plain JS and the most obvious is the JS instance upgrade. In older engines, extending any DOM native class is not enough to have a proper DOM instance.

— https://www.webreflection.co.uk/blog/2016/08/21/custom-elements-v1#caveat-an-unpolyfillable-upgrade

> **ES5 vs ES2015**
> The custom elements v1 spec is not compatible with ES5 style classes. This means ES2015 code compiled to ES5 will not work with a native implementation of Custom Elements.[0] While it's possible to force the custom elements polyfill to be used to workaround this issue (by setting (`customElements.forcePolyfill = true;` before loading the polyfill), you will not be using the UA's native implementation in that case.
>
> Since this is not ideal, we've provided an alternative: [native-shim.js](https://github.com/webcomponents/custom-elements/blob/master/src/native-shim.js). Loading this shim minimally augments the native implementation to be compatible with ES5 code. We are also working on some future refinements to this approach that will improve the implementation and automatically detect if it's needed.
>
> [0] The spec requires that an element call the `HTMLElement` constructor. Typically an ES5 style class would do something like `HTMLElement.call(this)` to emulate `super()`. However, `HTMLElement` *must* be called as a constructor and not as a plain function, i.e. with `Reflect.construct(HTMLElement, [], MyCEConstructor)`, or it will throw.

— https://github.com/webcomponents/custom-elements/blob/master/README.md#es5-vs-es2015

</details><br>

In my testing, none of the v1 polyfills worked reliably in older versions of Safari or on older Android devices. v0 on the other hand, even though it's only officially supported in Chrome, has far better polyfill support with years of battle hardening. And so, **this pull requests preserves support for v0 too**. 

To smooth over the v1/v0 API differences, this change introduces its own distinct naming convention for lifecycle callbacks: `initialize()`, `connect()`, `disconnect()` (thanks, Stimulus!), and automatically maps them to the supported custom element API.

v1:
```
initialize() → connectedCallback() (once)
connect()    → connectedCallback()
disconnect() → disconnectedCallback()
```

v0 (polyfilled if necessary):
```
initialize() → createdCallback() 
connect()    → attachedCallback()
disconnect() → detachedCallback()
```

---

Fixes https://github.com/basecamp/trix/issues/495