### PR TITLE
Remove leading whitespace and autocomplete www URLs

### DIFF
--- a/src/trix/config/toolbar.coffee
+++ b/src/trix/config/toolbar.coffee
@@ -29,7 +29,7 @@ Trix.config.toolbar =
     <div class="trix-dialogs" data-trix-dialogs>
       <div class="trix-dialog trix-dialog--link" data-trix-dialog="href" data-trix-dialog-attribute="href">
         <div class="trix-dialog__link-fields">
-          <input type="url" name="href" class="trix-input trix-input--dialog" placeholder="#{lang.urlPlaceholder}" required data-trix-input>
+          <input type="url" name="href" class="trix-input trix-input--dialog" placeholder="#{lang.urlPlaceholder}" required data-trix-input data-trix-url-input>
           <div class="trix-button-group">
             <input type="button" class="trix-button trix-button--dialog" value="#{lang.link}" data-trix-method="setAttribute">
             <input type="button" class="trix-button trix-button--dialog" value="#{lang.unlink}" data-trix-method="removeAttribute">

--- a/src/trix/controllers/toolbar_controller.coffee
+++ b/src/trix/controllers/toolbar_controller.coffee
@@ -146,13 +146,11 @@ class Trix.ToolbarController extends Trix.BasicObject
 
   cleanInputValue: (input) ->
     if input.hasAttribute('data-trix-url-input')
-      input.value = input.value?.replace(/\s*(https?:\/\/)?(www\.)?/, (_, protocol, www) ->
+      input.value = input.value?.replace(/\s*(\S+:\/\/)?/, (_, protocol) ->
         if protocol # valid start of URL => just drop any leading whitespace
-          protocol + (www or '')
-        else if www # starts with www, must surely be a URL => prepend protocol
-          'https://www.'
-        else        # not sure if this is a URL => don't prepend protocol
-          ''
+          protocol
+        else        # no protocol found => prepend 'https://'
+          'https://'
       )
 
   removeAttribute: (dialogElement) ->

--- a/src/trix/controllers/toolbar_controller.coffee
+++ b/src/trix/controllers/toolbar_controller.coffee
@@ -135,6 +135,7 @@ class Trix.ToolbarController extends Trix.BasicObject
   setAttribute: (dialogElement) ->
     attributeName = getAttributeName(dialogElement)
     input = getInputForDialog(dialogElement, attributeName)
+    @cleanInputValue(input)
     if input.willValidate and not input.checkValidity()
       input.setAttribute("data-trix-validate", "")
       input.classList.add("trix-validate")
@@ -142,6 +143,17 @@ class Trix.ToolbarController extends Trix.BasicObject
     else
       @delegate?.toolbarDidUpdateAttribute(attributeName, input.value)
       @hideDialog()
+
+  cleanInputValue: (input) ->
+    if input.hasAttribute('data-trix-url-input')
+      input.value = input.value?.replace(/\s*(https?:\/\/)?(www\.)?/, (_, protocol, www) ->
+        if protocol # valid start of URL => just drop any leading whitespace
+          protocol + (www or '')
+        else if www # starts with www, must surely be a URL => prepend protocol
+          'https://www.'
+        else        # not sure if this is a URL => don't prepend protocol
+          ''
+      )
 
   removeAttribute: (dialogElement) ->
     attributeName = getAttributeName(dialogElement)

--- a/test/src/system/text_formatting_test.coffee
+++ b/test/src/system/text_formatting_test.coffee
@@ -31,6 +31,32 @@ testGroup "Text formatting", template: "editor_empty", ->
           assert.textAttributes([1, 19], href: "http://example.com")
           expectDocument("ahttp://example.com\n")
 
+  test "inserting a link with leading whitespace", (expectDocument) ->
+    typeCharacters "a", ->
+      clickToolbarButton attribute: "href", ->
+        assert.ok isToolbarDialogActive(attribute: "href")
+        typeInToolbarDialog "    http://example.com", attribute: "href", ->
+          assert.textAttributes([0, 1], {})
+          assert.textAttributes([1, 19], href: "http://example.com")
+          expectDocument("ahttp://example.com\n")
+
+  test "inserting a www link without protocol", (expectDocument) ->
+    typeCharacters "a", ->
+      clickToolbarButton attribute: "href", ->
+        assert.ok isToolbarDialogActive(attribute: "href")
+        typeInToolbarDialog "www.example.com", attribute: "href", ->
+          assert.textAttributes([0, 1], {})
+          assert.textAttributes([1, 20], {href: "https://www.example.com"})
+          expectDocument("ahttps://www.example.com\n")
+
+  test "inserting a non-www link without protocol", (expectDocument) ->
+    typeCharacters "a", ->
+      clickToolbarButton attribute: "href", ->
+        assert.ok isToolbarDialogActive(attribute: "href")
+        typeInToolbarDialog "example.com", attribute: "href", ->
+          assert.textAttributes([0, 1], {})
+          expectDocument("a\n")
+
   test "editing a link", (done) ->
     insertString("a")
     text = Trix.Text.textForStringWithAttributes("bc", href: "http://example.com")

--- a/test/src/system/text_formatting_test.coffee
+++ b/test/src/system/text_formatting_test.coffee
@@ -40,22 +40,23 @@ testGroup "Text formatting", template: "editor_empty", ->
           assert.textAttributes([1, 19], href: "http://example.com")
           expectDocument("ahttp://example.com\n")
 
-  test "inserting a www link without protocol", (expectDocument) ->
-    typeCharacters "a", ->
-      clickToolbarButton attribute: "href", ->
-        assert.ok isToolbarDialogActive(attribute: "href")
-        typeInToolbarDialog "www.example.com", attribute: "href", ->
-          assert.textAttributes([0, 1], {})
-          assert.textAttributes([1, 20], {href: "https://www.example.com"})
-          expectDocument("ahttps://www.example.com\n")
-
-  test "inserting a non-www link without protocol", (expectDocument) ->
+  test "inserting a link without protocol", (expectDocument) ->
     typeCharacters "a", ->
       clickToolbarButton attribute: "href", ->
         assert.ok isToolbarDialogActive(attribute: "href")
         typeInToolbarDialog "example.com", attribute: "href", ->
           assert.textAttributes([0, 1], {})
-          expectDocument("a\n")
+          assert.textAttributes([1, 20], {href: "https://example.com"})
+          expectDocument("ahttps://example.com\n")
+
+  test "inserting a link with non-http protocol", (expectDocument) ->
+    typeCharacters "a", ->
+      clickToolbarButton attribute: "href", ->
+        assert.ok isToolbarDialogActive(attribute: "href")
+        typeInToolbarDialog "ftp://example.com", attribute: "href", ->
+          assert.textAttributes([0, 1], {})
+          assert.textAttributes([1, 18], {href: "ftp://example.com"})
+          expectDocument("aftp://example.com\n")
 
   test "editing a link", (done) ->
     insertString("a")


### PR DESCRIPTION
this is a quick attempt to improve the link input in two ways:

1. remove leading whitespace from the input value. it was previously added to the `href` attribute, breaking the link in some browsers (or all, if correctly sanitized to `%20` elsewhere in the stack).

2. prepend `https://` if the link starts with 'www.', making it easier to insert links, c.f. #227

let me know if this needs more work or is not feasible.