### PR TITLE
Fix selecting attachments in MS Edge 17

### DIFF
--- a/src/trix/models/location_mapper.coffee
+++ b/src/trix/models/location_mapper.coffee
@@ -56,10 +56,13 @@ class Trix.LocationMapper
     return unless node
 
     if nodeIsTextNode(node)
-      container = node
-      string = node.textContent
-      offset = location.offset - nodeOffset
-
+      if nodeLength(node) is 0
+        container = node.parentNode.parentNode
+        offset = findChildIndexOfNode(node.parentNode)
+      else
+        container = node
+        string = node.textContent
+        offset = location.offset - nodeOffset
     else
       container = node.parentNode
 

--- a/src/trix/models/location_mapper.coffee
+++ b/src/trix/models/location_mapper.coffee
@@ -61,7 +61,6 @@ class Trix.LocationMapper
         offset = findChildIndexOfNode(node.parentNode)
       else
         container = node
-        string = node.textContent
         offset = location.offset - nodeOffset
     else
       container = node.parentNode

--- a/src/trix/models/selection_manager.coffee
+++ b/src/trix/models/selection_manager.coffee
@@ -3,8 +3,8 @@
 #= require trix/observers/selection_change_observer
 
 {getDOMSelection, getDOMRange, setDOMRange, elementContainsNode,
- nodeIsCursorTarget, nodeIsTextNode, innerElementIsActive, handleEvent,
- normalizeRange, rangeIsCollapsed, rangesAreEqual} = Trix
+ nodeIsCursorTarget, innerElementIsActive, handleEvent, normalizeRange,
+ rangeIsCollapsed, rangesAreEqual} = Trix
 
 class Trix.SelectionManager extends Trix.BasicObject
   constructor: (@element) ->
@@ -107,21 +107,9 @@ class Trix.SelectionManager extends Trix.BasicObject
       @findContainerAndOffsetFromLocation(locationRange[1]) ? rangeStart
 
     if rangeStart? and rangeEnd?
-      [startContainer, startOffset] = rangeStart
-      [endContainer, endOffset] = rangeEnd
-
       domRange = document.createRange()
-
-      if nodeIsCursorTarget(startContainer) and nodeIsTextNode(startContainer)
-        domRange.setStartBefore(startContainer.parentNode)
-      else
-        domRange.setStart(startContainer, startOffset)
-
-      if nodeIsCursorTarget(endContainer) and nodeIsTextNode(endContainer)
-        domRange.setEndBefore(endContainer.parentNode)
-      else
-        domRange.setEnd(endContainer, endOffset)
-
+      domRange.setStart(rangeStart...)
+      domRange.setEnd(rangeEnd...)
       domRange
 
   createLocationRangeFromDOMRange: (domRange, options) ->

--- a/src/trix/models/selection_manager.coffee
+++ b/src/trix/models/selection_manager.coffee
@@ -3,8 +3,8 @@
 #= require trix/observers/selection_change_observer
 
 {getDOMSelection, getDOMRange, setDOMRange, elementContainsNode,
- nodeIsCursorTarget, innerElementIsActive, handleEvent, normalizeRange,
- rangeIsCollapsed, rangesAreEqual} = Trix
+ nodeIsCursorTarget, nodeIsTextNode, innerElementIsActive, handleEvent,
+ normalizeRange, rangeIsCollapsed, rangesAreEqual} = Trix
 
 class Trix.SelectionManager extends Trix.BasicObject
   constructor: (@element) ->
@@ -107,9 +107,21 @@ class Trix.SelectionManager extends Trix.BasicObject
       @findContainerAndOffsetFromLocation(locationRange[1]) ? rangeStart
 
     if rangeStart? and rangeEnd?
+      [startContainer, startOffset] = rangeStart
+      [endContainer, endOffset] = rangeEnd
+
       domRange = document.createRange()
-      domRange.setStart(rangeStart...)
-      domRange.setEnd(rangeEnd...)
+
+      if nodeIsCursorTarget(startContainer) and nodeIsTextNode(startContainer)
+        domRange.setStartBefore(startContainer.parentNode)
+      else
+        domRange.setStart(startContainer, startOffset)
+
+      if nodeIsCursorTarget(endContainer) and nodeIsTextNode(endContainer)
+        domRange.setEndBefore(endContainer.parentNode)
+      else
+        domRange.setEnd(endContainer, endOffset)
+
       domRange
 
   createLocationRangeFromDOMRange: (domRange, options) ->


### PR DESCRIPTION
Currently, Trix programmatically selects attachments using a [DOM Range](https://developer.mozilla.org/en-US/docs/Web/API/Range) anchored to the text nodes in the surrounding cursor target elements.

<pre><code>&lt;span&gt;<kbd>⋮&lt;/span&gt;&lt;figure&gt;…&lt;/figure&gt;&lt;span&gt;</kbd>⋮&lt;/span&gt;</code></pre>
<sup>`⋮` represents a zero width space character.</sup>

That range has worked reliably in all browsers including Microsoft Edge… until recently. Edge 17 regressed from 16 and incorrectly applies it around the left cursor target’s text node.

<pre><code>&lt;span&gt;<kbd>⋮ </kbd>&lt;/span&gt;&lt;figure&gt;…&lt;/figure&gt;&lt;span&gt;&lt;/span&gt;</code></pre>

This change works around the problem by anchoring to the cursor target elements instead of their text nodes.

<pre><code><kbd>&lt;span&gt;⋮&lt;/span&gt;&lt;figure &gt;…&lt;/figure&gt;</kbd>&lt;span&gt;⋮&lt;/span&gt;</code></pre>

The resulting selection is visually and functionally equivalent.