### PR TITLE
This fixes #265, 'Firefox replaces space after deleting word'

### DIFF
--- a/assets/trix/stylesheets/editor.scss
+++ b/assets/trix/stylesheets/editor.scss
@@ -5,4 +5,6 @@ trix-editor {
   padding: 0.4em 0.6em;
   min-height: 5em;
   outline: none;
+  white-space: normal;
+  white-space: -moz-pre-space;
 }

--- a/assets/trix/stylesheets/editor.scss
+++ b/assets/trix/stylesheets/editor.scss
@@ -5,6 +5,5 @@ trix-editor {
   padding: 0.4em 0.6em;
   min-height: 5em;
   outline: none;
-  white-space: normal;
-  white-space: -moz-pre-space;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
This fixes the issue #265 where Firefox was deleting a space at end of the editor after deleting something. I have ran the tests in Firefox and Chrome and all passed without issue.