### PR TITLE
Change default height of editor to 6.25em

### DIFF
--- a/assets/trix/stylesheets/editor.scss
+++ b/assets/trix/stylesheets/editor.scss
@@ -3,6 +3,6 @@ trix-editor {
   border-radius: 3px;
   margin: 0;
   padding: 0.4em 0.6em;
-  min-height: 5em;
+  min-height: 6.25em;
   outline: none;
 }


### PR DESCRIPTION
I have been using Trix for a while now and I found it very weird that styling the editor was something I always had to do. I have been wondering if we could move the default min-height of the editor to 6.25em which is somewhat round and moderately long enough for a text-area.