### PR TITLE
Safari: Fix inserting composed text in empty blocks

### DIFF
--- a/src/trix/controllers/input/composition_input.coffee
+++ b/src/trix/controllers/input/composition_input.coffee
@@ -33,12 +33,7 @@ class Trix.CompositionInput extends Trix.BasicObject
       @forgetPlaceholder()
 
       if @canApplyToDocument()
-        @setInputSummary(preferDocument: true, didInput: false)
-        @delegate?.inputControllerWillPerformTyping()
-        @responder?.setSelectedRange(@range)
-        @responder?.insertString(@data.end)
-        @responder?.setSelectedRange(@range[0] + @data.end.length)
-
+        @applyToDocument()
       else if @data.start? or @data.update?
         @requestReparse()
         @inputController.reset()
@@ -61,6 +56,20 @@ class Trix.CompositionInput extends Trix.BasicObject
 
   canApplyToDocument: ->
     @data.start?.length is 0 and @data.end?.length > 0 and @range?
+
+  applyToDocument: ->
+    @setInputSummary(preferDocument: true, didInput: false)
+    @delegate?.inputControllerWillPerformTyping()
+
+    if browser.composesExistingText
+      @responder?.setSelectedRange(@range)
+      @responder?.insertString(@data.end)
+      @responder?.setSelectedRange(@range[0] + @data.end.length)
+    else
+      @responder?.setSelection(@range)
+      @requestRender()
+      Trix.defer =>
+        @responder?.insertString(@data.end)
 
   @proxyMethod "inputController.setInputSummary"
   @proxyMethod "inputController.requestRender"


### PR DESCRIPTION
Tested using the Pinyin - Simplified Chinese keyboard and typing  <kbd>A</kbd> <kbd>space</kbd> then <kbd>B</kbd> <kbd>space</kbd>, which *should* insert `啊不`. This keyboard + key combo was reported in https://github.com/basecamp/trix/issues/396, but the same issue can be reproduced with U.S. keyboard compositions.

| Before | After |
| --- | --- |
| ![safari-before](https://user-images.githubusercontent.com/5355/47878720-5bb33f80-ddf5-11e8-88a9-55ffef4d06fb.gif) <br> ![ios-before](https://user-images.githubusercontent.com/5355/47878718-5bb33f80-ddf5-11e8-8296-fb6ade137d93.gif) | ![safari-after](https://user-images.githubusercontent.com/5355/47878719-5bb33f80-ddf5-11e8-9d01-94835516c4ea.gif) <br> ![ios-after](https://user-images.githubusercontent.com/5355/47878717-5b1aa900-ddf5-11e8-89c3-c3abfc071e33.gif) |