### PR TITLE
nbsp before a tag can be significant in Firefox (fixes #265)

### DIFF
--- a/src/trix/views/document_view.coffee
+++ b/src/trix/views/document_view.coffee
@@ -65,4 +65,4 @@ class Trix.DocumentView extends Trix.ObjectView
     ignoreSpaces(element.innerHTML) is ignoreSpaces(otherElement.innerHTML)
 
   ignoreSpaces = (html) ->
-    html.replace(/&nbsp;/g, " ")
+    html.replace(/&nbsp;(?!<)/g, " ")


### PR DESCRIPTION
PieceView/TextView try to turn the final space in a text into a nbsp. This is important for Firefox, which doesn't like a bare space at the end of a block (see e.g. #265). But that nbsp doesn't get rendered, because DocumentView ignores space/nbsp differences.