### PR TITLE
Revert "nbsp before a tag can be significant in Firefox (fixes #265)"

### DIFF
--- a/src/trix/views/document_view.coffee
+++ b/src/trix/views/document_view.coffee
@@ -65,4 +65,4 @@ class Trix.DocumentView extends Trix.ObjectView
     ignoreSpaces(element.innerHTML) is ignoreSpaces(otherElement.innerHTML)
 
   ignoreSpaces = (html) ->
-    html.replace(/&nbsp;(?!<)/g, " ")
+    html.replace(/&nbsp;/g, " ")


### PR DESCRIPTION
Unfortunately, basecamp/trix#603 introduced a worse bug in IE 11: The cursors jumps to the beginning when deleting into a space at the end of a block.

![ie-11-cursor-jump](https://user-images.githubusercontent.com/5355/55741113-80da5880-59fa-11e9-80ea-f5f4ace4ad59.gif)

Reverting the change for now pending a better fix.