### PR TITLE
Feature: "Attach files" toolbar button

### DIFF
--- a/assets/trix/stylesheets/icons.scss
+++ b/assets/trix/stylesheets/icons.scss
@@ -1,3 +1,4 @@
+$icon-attach: svgo-data-uri('trix/images/attach.svg', $precision: 1);
 $icon-bold: svgo-data-uri('trix/images/bold.svg', $precision: 1);
 $icon-bullets: svgo-data-uri('trix/images/bullets.svg', $precision: 0);
 $icon-code: svgo-data-uri('trix/images/code.svg', $precision: 1);

--- a/assets/trix/stylesheets/toolbar.scss
+++ b/assets/trix/stylesheets/toolbar.scss
@@ -120,6 +120,7 @@ trix-toolbar {
     }
   }
 
+  .trix-button--icon-attach::before { background-image: $icon-attach; }
   .trix-button--icon-bold::before { background-image: $icon-bold; }
   .trix-button--icon-italic::before { background-image: $icon-italic; }
   .trix-button--icon-link::before { background-image: $icon-link; }
@@ -176,11 +177,11 @@ trix-toolbar {
     border-bottom: none;
   }
 
-  .trix-dialog--link {
+  .trix-dialog--attach, .trix-dialog--link {
     max-width: 600px;
   }
 
-  .trix-dialog__link-fields {
+  .trix-dialog__attach-fields, .trix-dialog__link-fields {
     display: flex;
     align-items: baseline;
 

--- a/src/trix/config/attachments.coffee
+++ b/src/trix/config/attachments.coffee
@@ -7,3 +7,6 @@ Trix.config.attachments =
   file:
     caption:
       size: true
+  toolbarButton:
+    # Provide a handler for `trix-attachment-add` before setting to `true`
+    enabled: false

--- a/src/trix/config/attachments.coffee
+++ b/src/trix/config/attachments.coffee
@@ -8,5 +8,8 @@ Trix.config.attachments =
     caption:
       size: true
   toolbarButton:
+    # Restrict file formats that can be selected from the file attachment dialog
+    # Format: see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept
+    accept: "*/*"
     # Provide a handler for `trix-attachment-add` before setting to `true`
     enabled: false

--- a/src/trix/config/index.coffee
+++ b/src/trix/config/index.coffee
@@ -4,8 +4,8 @@
 #= require trix/config/file_size_formatting
 #= require trix/config/text_attributes
 #= require trix/config/serialization
+#= require trix/config/attachments
 #= require trix/config/toolbar
 #= require trix/config/undo_interval
-#= require trix/config/attachments
 #= require trix/config/key_names
 #= require trix/config/input

--- a/src/trix/config/lang.coffee
+++ b/src/trix/config/lang.coffee
@@ -1,4 +1,6 @@
 Trix.config.lang =
+  attach: "Attach"
+  attachFile: "Attach file"
   bold: "Bold"
   bullets: "Bullets"
   byte:  "Byte"

--- a/src/trix/config/toolbar.coffee
+++ b/src/trix/config/toolbar.coffee
@@ -1,4 +1,4 @@
-{lang} = Trix.config
+{attachments, lang} = Trix.config
 
 Trix.config.toolbar =
   getDefaultHTML: -> """
@@ -8,6 +8,8 @@ Trix.config.toolbar =
         <button type="button" class="trix-button trix-button--icon trix-button--icon-italic" data-trix-attribute="italic" data-trix-key="i" title="#{lang.italic}" tabindex="-1">#{lang.italic}</button>
         <button type="button" class="trix-button trix-button--icon trix-button--icon-strike" data-trix-attribute="strike" title="#{lang.strike}" tabindex="-1">#{lang.strike}</button>
         <button type="button" class="trix-button trix-button--icon trix-button--icon-link" data-trix-attribute="href" data-trix-action="link" data-trix-key="k" title="#{lang.link}" tabindex="-1">#{lang.link}</button>
+        <button type="button" class="trix-button trix-button--icon trix-button--icon-attach" data-trix-attribute="attach" data-trix-action="attach" data-trix-key="a" title="#{lang.attachFile}" tabindex="-1" style="display: #{attachments.toolbarButton.enabled ? 'block' : 'none'};">
+        </button>
       </span>
 
       <span class="trix-button-group trix-button-group--block-tools" data-trix-button-group="block-tools">
@@ -35,6 +37,15 @@ Trix.config.toolbar =
           <div class="trix-button-group">
             <input type="button" class="trix-button trix-button--dialog" value="#{lang.link}" data-trix-method="setAttribute">
             <input type="button" class="trix-button trix-button--dialog" value="#{lang.unlink}" data-trix-method="removeAttribute">
+          </div>
+        </div>
+      </div>
+
+      <div class="trix-dialog trix-dialog--attach" data-trix-dialog="attach" data-trix-dialog-attribute="files">
+        <div class="trix-dialog__attach-fields">
+          <input type="file" name="files" class="trix-input trix-input--dialog" multiple required data-trix-input>
+          <div class="trix-button-group">
+            <input type="button" class="trix-button trix-button--dialog" value="#{lang.attach}" data-trix-method="attachFiles">
           </div>
         </div>
       </div>

--- a/src/trix/config/toolbar.coffee
+++ b/src/trix/config/toolbar.coffee
@@ -43,7 +43,7 @@ Trix.config.toolbar =
 
       <div class="trix-dialog trix-dialog--attach" data-trix-dialog="attach" data-trix-dialog-attribute="files">
         <div class="trix-dialog__attach-fields">
-          <input type="file" name="files" class="trix-input trix-input--dialog" multiple required data-trix-input>
+          <input type="file" name="files" class="trix-input trix-input--dialog" accept="#{attachments.toolbarButton.accept}" multiple required data-trix-input>
           <div class="trix-button-group">
             <input type="button" class="trix-button trix-button--dialog" value="#{lang.attach}" data-trix-method="attachFiles">
           </div>

--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -248,6 +248,11 @@ class Trix.EditorController extends Trix.Controller
   toolbarDidInvokeAction: (actionName) ->
     @invokeAction(actionName)
 
+  toolbarDidAttachFiles: (files) ->
+    @recordUndoEntry("Attach files")
+    @composition.insertFiles(files)
+    @render()
+
   toolbarDidToggleAttribute: (attributeName) ->
     @recordFormattingUndoEntry()
     @composition.toggleCurrentAttribute(attributeName)

--- a/src/trix/controllers/toolbar_controller.coffee
+++ b/src/trix/controllers/toolbar_controller.coffee
@@ -132,6 +132,17 @@ class Trix.ToolbarController extends Trix.BasicObject
 
     @delegate?.toolbarDidShowDialog(dialogName)
 
+  attachFiles: (dialogElement) ->
+    attributeName = getAttributeName(dialogElement)
+    input = getInputForDialog(dialogElement, attributeName)
+    if input.files.length == 0
+      input.setAttribute("data-trix-validate", "")
+      input.classList.add("trix-validate")
+      input.focus()
+    else
+      @delegate?.toolbarDidAttachFiles(input.files)
+      @hideDialog()
+
   setAttribute: (dialogElement) ->
     attributeName = getAttributeName(dialogElement)
     input = getInputForDialog(dialogElement, attributeName)


### PR DESCRIPTION
## Synopsis

Adds a toolbar button to show a dialog for attaching files to the editor. This fixes #594.

## Details

Some platforms that support the editor don't support drag and drop (for instance, mobile devices). On these platforms, it is currently impossible to attach files to a composition. This PR adds a toolbar button to allow the user to attach files to their document. It uses the `attach` icon that is already present in the repository. 

The button is disabled by default, because it requires the `trix-attachment-add` event to be handled. Once a handler for this event has been provided, it can be enabled easily by setting `attachments.toolbarButton.enabled` to `true` in the Trix configuration.

By default, the file selector will allow all files to be selected, but files can be rejected by the `trix-file-accept` event handler. To prevent the user for selecting files that cannot be handled, set the `attachments.toolbarButton.accept` setting in the Trix configuration accordingly. Format is the same as the [`accept` attribute for file inputs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept).

## Notes

**Untested**. I am currently unable to build the editor on my system due to #616. Please advise.

Some credit goes to @trheyi for providing the initial solution in #594, on which this work is based.

## Tests

Currently none. Help is appreciated.