### PR TITLE
Fix undo for blocks

### DIFF
--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -8,7 +8,7 @@
 #= require trix/models/attachment_manager
 #= require trix/models/selection_manager
 
-{rangeIsCollapsed, rangesAreEqual, objectsAreEqual} = Trix
+{rangeIsCollapsed, rangesAreEqual, objectsAreEqual, getBlockConfig} = Trix
 
 class Trix.EditorController extends Trix.Controller
   constructor: ({@editorElement, document, html}) ->
@@ -387,8 +387,9 @@ class Trix.EditorController extends Trix.Controller
     @render()
 
   recordFormattingUndoEntry: (attributeName) ->
+    blockConfig = getBlockConfig(attributeName)
     locationRange = @selectionManager.getLocationRange()
-    unless rangeIsCollapsed(locationRange)
+    if blockConfig or not rangeIsCollapsed(locationRange)
       @editor.recordUndoEntry("Formatting", context: @getUndoContext(), consolidatable: true)
 
   recordTypingUndoEntry: ->

--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -189,8 +189,8 @@ class Trix.EditorController extends Trix.Controller
   inputControllerWillPerformTyping: ->
     @recordTypingUndoEntry()
 
-  inputControllerWillPerformFormatting: ->
-    @recordFormattingUndoEntry()
+  inputControllerWillPerformFormatting: (attributeName) ->
+    @recordFormattingUndoEntry(attributeName)
 
   inputControllerWillCutText: ->
     @editor.recordUndoEntry("Cut")
@@ -249,19 +249,19 @@ class Trix.EditorController extends Trix.Controller
     @invokeAction(actionName)
 
   toolbarDidToggleAttribute: (attributeName) ->
-    @recordFormattingUndoEntry()
+    @recordFormattingUndoEntry(attributeName)
     @composition.toggleCurrentAttribute(attributeName)
     @render()
     @editorElement.focus() unless @selectionFrozen
 
   toolbarDidUpdateAttribute: (attributeName, value) ->
-    @recordFormattingUndoEntry()
+    @recordFormattingUndoEntry(attributeName)
     @composition.setCurrentAttribute(attributeName, value)
     @render()
     @editorElement.focus() unless @selectionFrozen
 
   toolbarDidRemoveAttribute: (attributeName) ->
-    @recordFormattingUndoEntry()
+    @recordFormattingUndoEntry(attributeName)
     @composition.removeCurrentAttribute(attributeName)
     @render()
     @editorElement.focus() unless @selectionFrozen
@@ -386,7 +386,7 @@ class Trix.EditorController extends Trix.Controller
     @composition.removeAttachment(attachment)
     @render()
 
-  recordFormattingUndoEntry: ->
+  recordFormattingUndoEntry: (attributeName) ->
     locationRange = @selectionManager.getLocationRange()
     unless rangeIsCollapsed(locationRange)
       @editor.recordUndoEntry("Formatting", context: @getUndoContext(), consolidatable: true)

--- a/src/trix/controllers/level_2_input_controller.coffee
+++ b/src/trix/controllers/level_2_input_controller.coffee
@@ -355,13 +355,13 @@ class Trix.Level2InputController extends Trix.InputController
 
   toggleAttributeIfSupported: (attributeName) ->
     if attributeName in Trix.getAllAttributeNames()
-      @delegate?.inputControllerWillPerformFormatting()
+      @delegate?.inputControllerWillPerformFormatting(attributeName)
       @withTargetDOMRange ->
         @responder?.toggleCurrentAttribute(attributeName)
 
   activateAttributeIfSupported: (attributeName, value) ->
     if attributeName in Trix.getAllAttributeNames()
-      @delegate?.inputControllerWillPerformFormatting()
+      @delegate?.inputControllerWillPerformFormatting(attributeName)
       @withTargetDOMRange ->
         @responder?.setCurrentAttribute(attributeName, value)
 

--- a/test/src/system/undo_test.coffee
+++ b/test/src/system/undo_test.coffee
@@ -46,3 +46,14 @@ testGroup "Undo/Redo", template: "editor_empty", ->
                         clickToolbarButton action: "redo", ->
                           assert.ok getDocument().isEqualTo(third)
                           done()
+
+  test "block formatting are undoable", (done) ->
+    typeCharacters "abc", ->
+      first = getDocument().copy()
+      clickToolbarButton attribute: "heading1", ->
+        second = getDocument().copy()
+        clickToolbarButton action: "undo", ->
+          assert.ok getDocument().isEqualTo(first)
+          clickToolbarButton action: "redo", ->
+            assert.ok getDocument().isEqualTo(second)
+            done()


### PR DESCRIPTION
Fix for #628.

All tests including the new one are passing on:
* Safari 12.0 macOS 10.14
* Firefox 66.0 macOS 10.14
* Chrome 74.0.3729.131 macOS 10.14 (although I had to run it twice to pass test 110)