### PR TITLE
Revert the simplification of the v1 constructor.

### DIFF
--- a/src/trix/core/helpers/custom_elements.coffee
+++ b/src/trix/core/helpers/custom_elements.coffee
@@ -62,8 +62,14 @@ rewriteLifecycleCallbacks = do ->
 registerElement = do ->
   if window.customElements
     (tagName, properties) ->
-      constructor = -> Reflect.construct(HTMLElement, [], constructor)
-      constructor.prototype = Object.create(HTMLElement.prototype, properties)
+      constructor = ->
+        if typeof Reflect is "object"
+          Reflect.construct(HTMLElement, [], constructor)
+        else
+          HTMLElement.apply(this)
+      Object.setPrototypeOf(constructor.prototype, HTMLElement.prototype)
+      Object.setPrototypeOf(constructor, HTMLElement)
+      Object.defineProperties(constructor.prototype, properties)
       window.customElements.define(tagName, constructor)
       constructor
   else


### PR DESCRIPTION
This fixes #669 

It is just a revert of this [commit](https://github.com/basecamp/trix/commit/4b4235dea290bd4edc3080b4dbed372f3204963f)

Maybe there is a simpler implementation, but I don't know how. 