### PR TITLE
Exposes insertAttachments function in editor model

### DIFF
--- a/src/trix/models/editor.coffee
+++ b/src/trix/models/editor.coffee
@@ -42,6 +42,9 @@ class Trix.Editor
   insertAttachment: (attachment) ->
     @composition.insertAttachment(attachment)
 
+  insertAttachments: (attachments) ->
+    @composition.insertAttachments(attachments)
+
   insertDocument: (document) ->
     @composition.insertDocument(document)
 


### PR DESCRIPTION
I'm using a third-party file uploader, and in order to be able to add multiple images in a gallery configuration, I need to use `insertAttachments`, which was not exposed to the `editor` instance.