### PR TITLE
Include a CSP nonce in style tags

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Trix</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="csp-nonce" content="topsecret">
     <link rel="stylesheet" type="text/css" href="trix.css">
     <style type="text/css">
       main {

--- a/src/trix/core/helpers/custom_elements.coffee
+++ b/src/trix/core/helpers/custom_elements.coffee
@@ -18,8 +18,15 @@ insertStyleElementForTagName = (tagName) ->
   element = document.createElement("style")
   element.setAttribute("type", "text/css")
   element.setAttribute("data-tag-name", tagName.toLowerCase())
+  if nonce = getNonceForStyleElement()
+    element.setAttribute("nonce", nonce)
   document.head.insertBefore(element, document.head.firstChild)
   element
+
+getNonceForStyleElement = ->
+  if element = (document.head.querySelector("meta[name=trix-csp-nonce]") ||
+      document.head.querySelector("meta[name=csp-nonce]"))
+    element.getAttribute("content")
 
 rewriteFunctionsAsValues = (definition) ->
   object = {}


### PR DESCRIPTION
If `trix-style-nonce` or `csp-nonce` is included in the page's meta tags,
Trix will automatically use them for generated style tags.

The code is mostly ripped from @javan's suggestions at #377, with the additional feature that it'll fall back to `<meta name=csp-nonce>`, so it'll work out of the box on Rails apps using `csp_meta_tag`

WDYT?
