### PR TITLE
Specified WYSIWYG after first use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Trix
 ### A Rich Text Editor for Everyday Writing
 
-**Compose beautifully formatted text in your web application.** Trix is a WYSIWYG editor for writing messages, comments, articles, and lists—the simple documents most web apps are made of. It features a sophisticated document model, support for embedded attachments, and outputs terse and consistent HTML.
+**Compose beautifully formatted text in your web application.** Trix is a WYSIWYG ('What You See Is What You Get') editor for writing messages, comments, articles, and lists—the simple documents most web apps are made of. It features a sophisticated document model, support for embedded attachments, and outputs terse and consistent HTML.
 
 Trix is an open-source project from [Basecamp](https://basecamp.com/), the creators of [Ruby on Rails](http://rubyonrails.org/). Millions of people trust their text to Basecamp, and we built Trix to give them the best possible editing experience. See Trix in action in the [all-new Basecamp 3](https://basecamp.com/3-is-coming).
 


### PR DESCRIPTION
on the first instance of the acronym's use specify what is stands for.