### PR TITLE
Fix Editor XSS

### DIFF
--- a/src/trix/core/helpers/events.coffee
+++ b/src/trix/core/helpers/events.coffee
@@ -6,10 +6,9 @@ Trix.extend
     html = dataTransfer.getData("text/html")
 
     if text and html
-      element = document.createElement("div")
-      element.innerHTML = html
-      if element.textContent is text
-        not element.querySelector(":not(meta)")
+      {body} = new DOMParser().parseFromString(html, "text/html")
+      if body.textContent is text
+        not body.querySelector("*")
     else
       text?.length
 

--- a/test/src/system/pasting_test.coffee
+++ b/test/src/system/pasting_test.coffee
@@ -35,6 +35,24 @@ testGroup "Pasting", template: "editor_empty", ->
     pasteContent "text/html", "<div>a<br></div>\r\n<div>b<br></div>\r\n<div>c<br></div>", ->
       expectDocument "a\nb\nc\n"
 
+  test "paste unsafe html", (done) ->
+    window.unsanitized = []
+    pasteData =
+      "text/plain": "x"
+      "text/html": """
+        <img onload="window.unsanitized.push('img.onload');" src="#{TEST_IMAGE_URL}">
+        <img onerror="window.unsanitized.push('img.onerror');" src="data:image/gif;base64,TOTALLYBOGUS">
+        <script>
+          window.unsanitized.push('script tag');
+        </script>
+      """
+
+    pasteContent pasteData, ->
+      after 20, ->
+        assert.deepEqual window.unsanitized, []
+        delete window.unsanitized
+        done()
+
   test "prefers plain text when html lacks formatting", (expectDocument) ->
     pasteData =
       "text/html": "<meta charset='utf-8'>a\nb"


### PR DESCRIPTION
### Summary

Shopify received a report via our bug bounty program that it was possible to execute javascript on a domain using the Trix Editor by pasting specially crafted HTML. We found that the javascript executed when Trix checks if pasted content is HTML by inserting the content into a `div` via the `innerHTML` property: 

https://github.com/basecamp/trix/blob/master/src/trix/core/helpers/events.coffee#L10.

This PR addresses this by using a `DOMParser` instance to determine if there are any HTML elements in the `body`.

### Reproduction Steps

1. Visit https://jackmc.xyz/pages/super-innocent-tutorial
2. Highlight the "Copy Me!!" text
3. Paste on https://trix-editor.org/

### Payload 
```
Copy <img src="x" onerror="if (document.domain == 'trix-editor.org') alert(document.domain);" style="visibility: hidden;width:0;"> me!!
```
### Screenshot
 
<img width="1601" alt="Screen Shot 2019-11-27 at 4 45 45 PM" src="https://user-images.githubusercontent.com/42748004/69761474-80333580-1135-11ea-9779-043eaa6b7801.png">