### PR TITLE
Only allow HTTP & HTTPS hrefs in HTML sanitizer

### DIFF
--- a/src/trix/models/html_sanitizer.coffee
+++ b/src/trix/models/html_sanitizer.coffee
@@ -44,9 +44,12 @@ class Trix.HTMLSanitizer extends Trix.BasicObject
     @body
 
   sanitizeElement: (element) ->
-    for {name} in [element.attributes...]
+    for {name, value} in [element.attributes...]
       unless name in @allowedAttributes or name.indexOf("data-trix") is 0
         element.removeAttribute(name)
+      if name == "href"
+        unless value.match(/^https?:\/\//)
+          element.removeAttribute(name)
     element
 
   normalizeListElementNesting: ->

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -168,6 +168,21 @@ testGroup "Trix.HTMLParser", ->
       delete window.unsanitized
       done()
 
+  test "allows http URL in href", ->
+    html = """<a href="http://example.com/">foo</a>"""
+    expectedHTML = """<div><!--block--><a href=\"http://example.com/\">foo</a></div>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
+  test "allows https URL in href", ->
+    html = """<a href="https://example.com/">foo</a>"""
+    expectedHTML = """<div><!--block--><a href=\"https://example.com/\">foo</a></div>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
+  test "disallows javascript URL in href", ->
+    html = """<a href="javascript:alert(1)">foo</a>"""
+    expectedHTML = """<div><!--block-->foo</div>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
   test "parses attachment caption from large html string", (done) ->
     html = fixtures["image attachment with edited caption"].html
 


### PR DESCRIPTION
When HTML content is pasted into Trix, its HTML sanitizer strips out all but a small list of whitelisted attributes, to prevent cross-site scripting:

https://github.com/basecamp/trix/blob/e6a164167a91d7a4c27088f54ca7d080dfe234f2/src/trix/models/html_sanitizer.coffee#L4

https://github.com/basecamp/trix/blob/e6a164167a91d7a4c27088f54ca7d080dfe234f2/src/trix/models/html_sanitizer.coffee#L46-L50

The whitelist includes `href`, so that links can be pasted. But the `href` value is not validated, and so cross-site scripting can occur if content such as `<a href="javascript:alert(1)">foo</a>` is pasted.

To correct the problem, I've added a check to ensure that any pasted `href` attribute begins with either `http://` or `https://`.