### PR TITLE
Add nested `code` tags to `pre` tags i code blocks

### DIFF
--- a/src/trix/config/block_attributes.coffee
+++ b/src/trix/config/block_attributes.coffee
@@ -10,8 +10,12 @@ Trix.config.blockAttributes = attributes =
     terminal: true
     breakOnReturn: true
     group: false
-  code:
+  pre:
     tagName: "pre"
+    parse: false
+  code:
+    tagName: "code"
+    listAttribute: "pre"
     terminal: true
     text:
       plaintext: true

--- a/test/src/system/block_formatting_test.coffee
+++ b/test/src/system/block_formatting_test.coffee
@@ -7,7 +7,7 @@ testGroup "Block formatting", template: "editor_empty", ->
         assert.blockAttributes([0, 4], ["quote"])
         assert.ok isToolbarButtonActive(attribute: "quote")
         clickToolbarButton attribute: "code", ->
-          assert.blockAttributes([0, 4], ["quote", "code"])
+          assert.blockAttributes([0, 4], ["quote", "pre", "code"])
           assert.ok isToolbarButtonActive(attribute: "code")
           clickToolbarButton attribute: "code", ->
             assert.blockAttributes([0, 4], ["quote"])
@@ -275,9 +275,9 @@ testGroup "Block formatting", template: "editor_empty", ->
       typeCharacters "ab\n\n", ->
         clickToolbarButton attribute: "code", ->
           typeCharacters "cd", ->
-            getSelectionManager().setLocationRange([{index: 0, offset: 0}, {index: 1, offset: 1}])
+            getSelectionManager().setLocationRange([{index: 0, offset: 3}, {index: 6, offset: 1}])
             getComposition().deleteInDirection("backward")
-            assert.blockAttributes([0, 2], ["code"])
+            assert.blockAttributes([3, 4], ["pre", "code"])
             expectDocument("d\n")
 
   test "increasing list level", (done) ->
@@ -529,17 +529,17 @@ testGroup "Block formatting", template: "editor_empty", ->
     selectAll ->
       clickToolbarButton attribute: "code", ->
         assert.equal getDocument().getBlockCount(), 3
-        assert.blockAttributes([0, 1], ["code"])
-        assert.blockAttributes([2, 3], ["code"])
-        assert.blockAttributes([4, 5], ["code"])
+        assert.blockAttributes([0, 1], ["pre", "code"])
+        assert.blockAttributes([2, 3], ["pre", "code"])
+        assert.blockAttributes([4, 5], ["pre", "code"])
         expectDocument("a\nb\nc\n")
 
   test "code blocks preserve newlines", (expectDocument) ->
     typeCharacters "a\nb", ->
       selectAll ->
         clickToolbarButton attribute: "code", ->
-          assert.equal getDocument().getBlockCount(), 1
-          assert.blockAttributes([0, 3], ["code"])
+          assert.equal getDocument().getBlockCount(), 2
+          assert.blockAttributes([0, 2], ["pre", "code"])
           expectDocument("a\nb\n")
 
   test "code blocks are not indentable", (done) ->
@@ -565,7 +565,7 @@ testGroup "Block formatting", template: "editor_empty", ->
           clickToolbarButton action: "decreaseNestingLevel", ->
             document = getDocument()
             assert.equal document.getBlockCount(), 1
-            assert.blockAttributes([0, 1], ["code"])
+            assert.blockAttributes([0, 1], ["pre", "code"])
             expectDocument("a\n")
 
   test "indenting a heading inside a bullet", (expectDocument) ->

--- a/test/src/test_helpers/fixtures/fixtures.coffee
+++ b/test/src/test_helpers/fixtures/fixtures.coffee
@@ -120,16 +120,16 @@ removeWhitespace = (string) ->
 
   "code formatted block":
     document: createDocument(["123", {}, ["code"]])
-    html: "<pre>#{blockComment}123</pre>"
+    html: "<pre><code>#{blockComment}123</code></pre>"
 
   "code with newline":
     document: createDocument(["12\n3", {}, ["code"]])
-    html: "<pre>#{blockComment}12\n3</pre>"
+    html: "<pre><code>#{blockComment}12\n3</code></pre>"
 
   "multiple blocks with block comments in their text":
     document: createDocument(["a#{blockComment}b", {}, ["quote"]], ["#{blockComment}c", {}, ["code"]])
-    html: "<blockquote>#{blockComment}a&lt;!--block--&gt;b</blockquote><pre>#{blockComment}&lt;!--block--&gt;c</pre>"
-    serializedHTML: "<blockquote>a&lt;!--block--&gt;b</blockquote><pre>&lt;!--block--&gt;c</pre>"
+    html: "<blockquote>#{blockComment}a&lt;!--block--&gt;b</blockquote><pre><code>#{blockComment}&lt;!--block--&gt;c</code></pre>"
+    serializedHTML: "<blockquote>a&lt;!--block--&gt;b</blockquote><pre><code>&lt;!--block--&gt;c</code></pre>"
 
   "unordered list with one item":
     document: createDocument(["a", {}, ["bulletList", "bullet"]])
@@ -352,11 +352,11 @@ removeWhitespace = (string) ->
 
   "nested quote and code formatted block":
     document: createDocument(["ab3", {}, ["quote", "code"]])
-    html: "<blockquote><pre>#{blockComment}ab3</pre></blockquote>"
+    html: "<blockquote><pre><code>#{blockComment}ab3</code></pre></blockquote>"
 
   "nested code and quote formatted block":
     document: createDocument(["ab3", {}, ["code", "quote"]])
-    html: "<pre><blockquote>#{blockComment}ab3</blockquote></pre>"
+    html: "<pre><code><blockquote>#{blockComment}ab3</blockquote></code></pre>"
 
   "nested code blocks in quote":
     document: createDocument(
@@ -372,8 +372,10 @@ removeWhitespace = (string) ->
         <br>
         <br>
         <pre>
+        <code>
           #{blockComment}
           b
+        </code>
         </pre>
         #{blockComment}
         <br>
@@ -381,8 +383,10 @@ removeWhitespace = (string) ->
         <br>
         <br>
         <pre>
+        <code>
           #{blockComment}
           d
+        </code>
         </pre>
       </blockquote>
     """
@@ -392,14 +396,18 @@ removeWhitespace = (string) ->
         <br>
         <br>
         <pre>
+        <code>
           b
+        </code>
         </pre>
         <br>
         c
         <br>
         <br>
         <pre>
+        <code>
           d
+        </code>
         </pre>
       </blockquote>
     """
@@ -420,8 +428,10 @@ removeWhitespace = (string) ->
       <br>
       <br>
       <pre>
+      <code>
         #{blockComment}
         b
+      </code>
       </pre>
       #{blockComment}
       <br>
@@ -451,7 +461,9 @@ removeWhitespace = (string) ->
         <br>
         <br>
         <pre>
+        <code>
           b
+        </code>
         </pre>
         <br>
         c


### PR DESCRIPTION
I ran into the problem described in [this PR](https://github.com/basecamp/trix/pull/715). I think the solution in my PR should add the nested `code` tags as it worked locally. I'm not as familiar with coffeescript however and so am not entirely sure if this is the best approach (would be great to get a second opinion on this actually). Essentially, this treats the `code` tags as a list item nested beneath the `pre` tags.

I've updated the tests to take the new tag into account. I noticed the following test would fail in an unrelated way (it returned `quote` tags but expected `code` tags) so I've changed this as well. I will see if this passes in Travis and try to change it back if it doesn't.
  - `Block formatting: backspace selection spanning and entire formatted
    block and a formatted block`