### PR TITLE
Add Auto Overflow to Trix Button Row

### DIFF
--- a/assets/trix/stylesheets/toolbar.scss
+++ b/assets/trix/stylesheets/toolbar.scss
@@ -15,6 +15,7 @@ trix-toolbar {
     display: flex;
     flex-wrap: nowrap;
     justify-content: space-between;
+    overflow-x: auto;
   }
 
   .trix-button-group {


### PR DESCRIPTION
**Before:**
<img width="741" alt="before" src="https://user-images.githubusercontent.com/44587895/72962364-5e3ee380-3d71-11ea-8814-71d862b2e7d5.png">

**After:**
<img width="678" alt="after" src="https://user-images.githubusercontent.com/44587895/72962373-6434c480-3d71-11ea-95f4-5bbb9293e001.png">
