### PR TITLE
fix: ghost attachment when setting an empty content attribute

### DIFF
--- a/src/trix/models/attachment.coffee
+++ b/src/trix/models/attachment.coffee
@@ -20,7 +20,8 @@ class Trix.Attachment extends Trix.Object
 
   constructor: (attributes = {}) ->
     super
-    @attributes = Trix.Hash.box(attributes)
+    @attributes = new Trix.Hash
+    @setAttributes(attributes)
     @didChangeAttributes()
 
   getAttribute: (attribute) ->
@@ -34,6 +35,10 @@ class Trix.Attachment extends Trix.Object
 
   setAttributes: (attributes = {}) ->
     newAttributes = @attributes.merge(attributes)
+
+    if newAttributes.has('content') and newAttributes.get('content').trim() is ''
+      newAttributes = newAttributes.remove('content')
+
     unless @attributes.isEqualTo(newAttributes)
       @attributes = newAttributes
       @didChangeAttributes()

--- a/test/src/unit/attachment_test.coffee
+++ b/test/src/unit/attachment_test.coffee
@@ -21,3 +21,18 @@ testGroup "Trix.Attachment", ->
 
     attrs = previewable: false, contentType: previewableTypes[0]
     assert.notOk createAttachment(attrs).isPreviewable()
+
+  test "empty string content attribute is removed from hash", ->
+    attrs = content: ''
+    attachment = createAttachment()
+    attachment.setAttributes(attrs)
+    assert.strictEqual attachment.getContent undefined
+
+    attrs = content: ' '
+    attachment = createAttachment()
+    attachment.setAttributes(attrs)
+    assert.strictEqual attachment.getContent undefined
+
+    attrs = {}
+    attachment = createAttachment()
+    attachment.setAttributes(attrs)


### PR DESCRIPTION
When setting an attachment with an empty `content`,  it creates a "ghost attachment". The issue is more obvious when using a non-image attachment, because there is no caption.

Maybe that's the expected behaviour, in which case you can just close the pull request.

Also, let's say you set the `content` attribute,  and later forget what the content attribute is pointing to (because it isn't showing default file info like the default content would) should there not be an easy way to access the attachment info or actually download the attachment by clicking on it?

Cheers!