### PR TITLE
Update toolbar when an attachment is selected (fixes #554)

### DIFF
--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -153,6 +153,7 @@ class Trix.EditorController extends Trix.Controller
     @notifyEditorElement("blur")
 
   compositionControllerDidSelectAttachment: (attachment, options) ->
+    @toolbarController.hideDialog()
     @composition.editAttachment(attachment, options)
 
   compositionControllerDidRequestDeselectingAttachment: (attachment) ->


### PR DESCRIPTION
Hey @javan, I thought I'd take a stab at resolving this old issue. 

The link dialog was being hidden when the editor was focussed but not when an attachment was selected. Clicking an attachment now closes the dialog and updates the toolbar the same way focussing on the editor would.

Fixes #554