### PR TITLE
Change the protocol blacklist to a whitelist

### DIFF
--- a/src/trix/models/html_sanitizer.coffee
+++ b/src/trix/models/html_sanitizer.coffee
@@ -2,16 +2,16 @@
 
 class Trix.HTMLSanitizer extends Trix.BasicObject
   DEFAULT_ALLOWED_ATTRIBUTES = "style href src width height class".split(" ")
-  DEFAULT_FORBIDDEN_PROTOCOLS = "javascript:".split(" ")
+  DEFAULT_ALLOWED_PROTOCOLS = "http: https: ftp: ftps: mailto: tel: callto: cid: xmpp:".split(" ")
 
   @sanitize: (html, options) ->
     sanitizer = new this html, options
     sanitizer.sanitize()
     sanitizer
 
-  constructor: (html, {@allowedAttributes, @forbiddenProtocols} = {}) ->
+  constructor: (html, {@allowedAttributes, @allowedProtocols} = {}) ->
     @allowedAttributes ?= DEFAULT_ALLOWED_ATTRIBUTES
-    @forbiddenProtocols ?= DEFAULT_FORBIDDEN_PROTOCOLS
+    @allowedProtocols ?= DEFAULT_ALLOWED_PROTOCOLS
     @body = createBodyElementForHTML(html)
 
   sanitize: ->
@@ -47,7 +47,7 @@ class Trix.HTMLSanitizer extends Trix.BasicObject
 
   sanitizeElement: (element) ->
     if element.hasAttribute("href")
-      if element.protocol in @forbiddenProtocols
+      unless element.protocol in @allowedProtocols
         element.removeAttribute("href")
 
     for {name} in [element.attributes...]

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -173,6 +173,26 @@ testGroup "Trix.HTMLParser", ->
     expectedHTML = """<div><!--block-->a b c</div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
+  test "forbids href attributes with an invalid protocol", ->
+    html = """<a href="foobar:baz">a</a> <a href=" foobar: baz">b</a> <a href="FooBar:baz">c</a>"""
+    expectedHTML = """<div><!--block-->a b c</div>"""
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
+  test "allows attributes with safe protocols", ->
+    html = """
+    <a href="http://example.com">a</a>
+    <a href="https://example.com">b</a>
+    <a href="ftp://example.com">c</a>
+    <a href="ftps://example.com">d</a>
+    <a href="mailto:test@example.com">e</a>
+    <a href="tel:1234567890">f</a>
+    <a href="callto:1234567890">g</a>
+    <a href="cid:foobar">h</a>
+    <a href="xmpp:user@example.com">i</a>
+    """
+    expectedHTML = "<div><!--block-->" + html.replace(/\n/g, ' ') + "</div>"
+    assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
+
   test "parses attachment caption from large html string", (done) ->
     html = fixtures["image attachment with edited caption"].html
 


### PR DESCRIPTION
As mentioned in https://github.com/basecamp/trix/pull/712#issuecomment-577906177, I think using a whitelist of allowed protocols would be more secure than blacklisting just `javascript:`. Other HTML sanitizers such as Loofah and DOMPurify also take this approach.

DOMPurify's whitelist (https://github.com/cure53/DOMPurify/blob/2f38855533f96f13f49632e813cf2d07baadec3e/src/regexp.js#L7-L9) seems sensible, and includes the specific protocols (`mailto:` and `tel:`) discussed in https://github.com/basecamp/trix/pull/712#issuecomment-565609141, so I've used that here.