### PR TITLE
fix: serialize the whole tree of models

### DIFF
--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -122,7 +122,7 @@ class Trix.Block extends Trix.Object
     @text.toString()
 
   toJSON: ->
-    text: @text
+    text: @text.toJSON()
     attributes: @attributes
 
   # Splittable

--- a/src/trix/models/splittable_list.coffee
+++ b/src/trix/models/splittable_list.coffee
@@ -147,7 +147,8 @@ class Trix.SplittableList extends Trix.Object
     @objects.slice(0)
 
   toJSON: ->
-    @toArray()
+    jsonObjects = for object in @toArray()
+      object.toJSON()
 
   isEqualTo: (splittableList) ->
     super or objectArraysAreEqual(@objects, splittableList?.objects)

--- a/test/src/unit/document_test.coffee
+++ b/test/src/unit/document_test.coffee
@@ -34,3 +34,32 @@ testGroup "Trix.Document", ->
     assert.deepEqual document.findRangesForTextAttribute("href", withValue: "http://google.com/"),   [[6, 20]]
     assert.deepEqual document.findRangesForTextAttribute("href", withValue: "http://basecamp.com/"), [[23, 27]]
     assert.deepEqual document.findRangesForTextAttribute("href", withValue: "http://amazon.com/"),   []
+
+  test "toJSON should serialize the whole object tree correctly", ->
+    document = Trix.Document.fromHTML """
+      <div><strong>Hello world!</strong></div>
+    """
+
+    expectedSerializedDocument = [
+      {
+        "attributes": [],
+        "text": [
+          {
+            "attributes": {
+              "bold": true
+            },
+            "string": "Hello world!",
+            "type": "string"
+          },
+          {
+            "attributes": {
+              "blockBreak": true
+            },
+            "string": "\n",
+            "type": "string"
+          }
+        ]
+      }
+    ]
+
+    assert.deepEqual document.toJSON(),  expectedSerializedDocument


### PR DESCRIPTION
The document and its sub resources were not serialized correctly. Something as simple as 

``` javascript
jsonDocument = document.toJSON()
document = Trix.Document.fromJSON(jsonDocument)
```

does not work correctly without the modifications contained in this pull request.

Cheers!