### PR TITLE
Parse text after closing tag as separate block

### DIFF
--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -64,6 +64,7 @@ class Trix.HTMLParser extends Trix.BasicObject
   appendBlockForTextNode: (node) ->
     element = node.parentNode
     return if element is @currentBlockElement
+    return unless element is @containerElement or @isBlockElement(element)
     attributes = @getBlockAttributes(element)
     unless arraysAreEqual(attributes, @currentBlock?.attributes)
       @currentBlock = @appendBlockForAttributesWithElement(attributes, element)

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -64,7 +64,6 @@ class Trix.HTMLParser extends Trix.BasicObject
   appendBlockForTextNode: (node) ->
     element = node.parentNode
     return if element is @currentBlockElement
-    return unless @isBlockElement(element)
     attributes = @getBlockAttributes(element)
     unless arraysAreEqual(attributes, @currentBlock?.attributes)
       @currentBlock = @appendBlockForAttributesWithElement(attributes, element)

--- a/test/src/system/html_loading_test.coffee
+++ b/test/src/system/html_loading_test.coffee
@@ -83,3 +83,10 @@ testGroup "HTML loading", ->
         assert.equal(image.getAttribute("width"),  "10")
         assert.equal(image.getAttribute("height"), "20")
         expectDocument("#{Trix.OBJECT_REPLACEMENT_CHARACTER}\n")
+
+  testGroup "text after closing tag", template: "editor_empty", ->
+    test "parses text as separate block", (expectDocument) ->
+      getEditor().loadHTML("<h1>a</h1>b")
+      assert.blockAttributes([0, 2], ["heading1"])
+      assert.blockAttributes([2, 4], [])
+      expectDocument("a\nb\n")

--- a/test/src/system/installation_process_test.coffee
+++ b/test/src/system/installation_process_test.coffee
@@ -57,3 +57,21 @@ testGroup "Installation process with specified elements", template: "editor_with
       assert.equal editorElement.inputElement, document.getElementById("my_input")
       assert.equal editorElement.value, "<div>Hello world</div>"
       done()
+
+  testGroup "Installation process with text after closing tag", template: "editor_empty", ->
+    test "parses text after closing tag as seperate block", (done) ->
+      input = document.createElement("input")
+      input.setAttribute("id", "my_input")
+      input.setAttribute("value", "<h1>Test</h1>abc")
+
+      element = document.createElement("trix-editor")
+      element.setAttribute("input", "my_input")
+
+      container = document.getElementById("trix-container")
+      container.innerHTML = ""
+      container.appendChild(input)
+      container.appendChild(element)
+
+      element.addEventListener "trix-initialize", ->
+        assert.equal element.value, "<h1>Test</h1><div>abc</div>"
+        done()

--- a/test/src/system/installation_process_test.coffee
+++ b/test/src/system/installation_process_test.coffee
@@ -57,21 +57,3 @@ testGroup "Installation process with specified elements", template: "editor_with
       assert.equal editorElement.inputElement, document.getElementById("my_input")
       assert.equal editorElement.value, "<div>Hello world</div>"
       done()
-
-  testGroup "Installation process with text after closing tag", template: "editor_empty", ->
-    test "parses text after closing tag as separate block", (done) ->
-      input = document.createElement("input")
-      input.setAttribute("id", "my_input")
-      input.setAttribute("value", "<h1>Test</h1>abc")
-
-      element = document.createElement("trix-editor")
-      element.setAttribute("input", "my_input")
-
-      container = document.getElementById("trix-container")
-      container.innerHTML = ""
-      container.appendChild(input)
-      container.appendChild(element)
-
-      element.addEventListener "trix-initialize", ->
-        assert.equal element.value, "<h1>Test</h1><div>abc</div>"
-        done()

--- a/test/src/system/installation_process_test.coffee
+++ b/test/src/system/installation_process_test.coffee
@@ -59,7 +59,7 @@ testGroup "Installation process with specified elements", template: "editor_with
       done()
 
   testGroup "Installation process with text after closing tag", template: "editor_empty", ->
-    test "parses text after closing tag as seperate block", (done) ->
+    test "parses text after closing tag as separate block", (done) ->
       input = document.createElement("input")
       input.setAttribute("id", "my_input")
       input.setAttribute("value", "<h1>Test</h1>abc")


### PR DESCRIPTION
I tracked down the issue where setting the input value to `<h1>Hello</h1>World` would result in `<h1>HelloWorld</h1>` instead of `<h1>Hello</h1><div>World</div>`

When `appendBlockForTextNode` is called for the TextNode "World", the `isBlockElement` function is called with the trix-editor element as the argument, since the trix-editor is the ParentNode of "World". This causes `isBlockElement` to return false and no block is created for "World". Later when `appendPiece` is called, since no block was created, "World" is appended to the previous block.

Removing the call to `isBlockElement` fixes the issue and all the other tests still pass. If the `isBlockElement` check is required for other use cases this issue may be solved by bypassing the `isBlockElement` check if the TextNode's parent element in the trix-editor.

Fixes #707 