### PR TITLE
Firefox: Fix invisible cursor when focusing an editor with leading <br>s

### DIFF
--- a/src/trix/controllers/editor_controller.coffee
+++ b/src/trix/controllers/editor_controller.coffee
@@ -146,6 +146,7 @@ class Trix.EditorController extends Trix.Controller
     @renderedCompositionRevision = @composition.revision
 
   compositionControllerDidFocus: ->
+    @setLocationRange(index: 0, offset: 0) if @isFocusedInvisibly()
     @toolbarController.hideDialog()
     @notifyEditorElement("focus")
 
@@ -414,3 +415,8 @@ class Trix.EditorController extends Trix.Controller
 
   isFocused: ->
     @editorElement is @editorElement.ownerDocument?.activeElement
+
+  # Detect "Cursor disappears sporadically" Firefox bug.
+  # - https://bugzilla.mozilla.org/show_bug.cgi?id=226301
+  isFocusedInvisibly: ->
+    @isFocused() and not @getLocationRange()


### PR DESCRIPTION
Works around this (17 year old 💀) Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=226301. h/t @nali! 

<table>
<tr>
<td align="center">
<strong>Before</strong><br><sup>element is focused, cursor <em>is not</em> visible</sup><br>
<img src="https://user-images.githubusercontent.com/5355/80720302-bac94180-8aca-11ea-8177-ff3a7e89e2f3.gif">
</td>
<td align="center">
<strong>After</strong><br><sup>element is focused, cursor <em>is</em> visible</sup><br>
<img src="https://user-images.githubusercontent.com/5355/80720724-4fcc3a80-8acb-11ea-9fd3-2d78235271ae.gif">
</td>
</tr>
</table>