### PR TITLE
Added support for HTML className for Block objects

### DIFF
--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -5,12 +5,13 @@
 class Trix.Block extends Trix.Object
   @fromJSON: (blockJSON) ->
     text = Trix.Text.fromJSON(blockJSON.text)
-    new this text, blockJSON.attributes
+    new this text, blockJSON.attributes, blockJSON.className
 
-  constructor: (text = new Trix.Text, attributes = []) ->
+  constructor: (text = new Trix.Text, attributes = [], className = '') ->
     super
     @text = applyBlockBreakToText(text)
     @attributes = attributes
+    @className = className
 
   isEmpty: ->
     @text.isBlockBreak()
@@ -22,7 +23,7 @@ class Trix.Block extends Trix.Object
     )
 
   copyWithText: (text) ->
-    new @constructor text, @attributes
+    new @constructor text, @attributes, @className
 
   copyWithoutText: ->
     @copyWithText(null)

--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -136,7 +136,7 @@ class Trix.HTMLParser extends Trix.BasicObject
 
   appendBlockForAttributesWithElement: (attributes, element) ->
     @blockElements.push(element)
-    block = blockForAttributes(attributes)
+    block = blockForAttributes(attributes, element?.className)
     @blocks.push(block)
     block
 
@@ -181,9 +181,9 @@ class Trix.HTMLParser extends Trix.BasicObject
     type = "attachment"
     {attachment, attributes, type}
 
-  blockForAttributes = (attributes = {}) ->
+  blockForAttributes = (attributes = {}, className = '') ->
     text = []
-    {text, attributes}
+    {text, attributes, className}
 
   # Attribute parsing
 

--- a/src/trix/views/block_view.coffee
+++ b/src/trix/views/block_view.coffee
@@ -23,14 +23,21 @@ class Trix.BlockView extends Trix.ObjectView
     if @attributes.length
       nodes
     else
-      element = makeElement(Trix.config.blockAttributes.default.tagName)
+      options = {
+        tagName: Trix.config.blockAttributes.default.tagName,
+        className: @block.className
+      }
+      element = makeElement(options)
       element.appendChild(node) for node in nodes
       [element]
 
   createContainerElement: (depth) ->
     attribute = @attributes[depth]
     {tagName} = getBlockConfig(attribute)
-    options = {tagName}
+    options = {
+      tagName: tagName,
+      className: @block.className
+    }
 
     if attribute is "attachmentGallery"
       size = @block.getBlockBreakPosition()

--- a/test/src/test_helpers/fixtures/fixtures.coffee
+++ b/test/src/test_helpers/fixtures/fixtures.coffee
@@ -564,6 +564,18 @@ removeWhitespace = (string) ->
     document: createDocument(["a", { bold: true }, ["heading1"]], ["b", { italic: true, bold: true }, ["heading1"]])
     html: "<h1>#{blockComment}<strong>a</strong></h1><h1>#{blockComment}<strong><em>b</em></strong></h1>"
 
+  "block with className":
+    document: new Trix.Document [
+      new Trix.Block(
+        new Trix.Text([
+          new Trix.StringPiece("a")
+        ]),
+        [],
+        'align-right'
+      )
+    ]
+    html: """<div class="align-right">#{blockComment}a</div>"""
+
 @eachFixture = (callback) ->
   for name, details of @fixtures
     callback(name, details)


### PR DESCRIPTION
This PR allows to use HTML class attribute (className) for Block level objects and that allows to add extended functionality like text alignment adding and toggling those classes for the nearest block object.