### PR TITLE
Sanitize pasted URLs

### DIFF
--- a/src/trix/controllers/input_controller.coffee
+++ b/src/trix/controllers/input_controller.coffee
@@ -51,3 +51,9 @@ class Trix.InputController extends Trix.BasicObject
       callback.call(this)
     finally
       @delegate?.inputControllerDidHandleInput()
+
+  createLinkHTML: (href, text) ->
+    link = document.createElement("a")
+    link.href = href
+    link.textContent = text ? href
+    link.outerHTML

--- a/src/trix/controllers/level_0_input_controller.coffee
+++ b/src/trix/controllers/level_0_input_controller.coffee
@@ -199,15 +199,15 @@ class Trix.Level0InputController extends Trix.InputController
         return
 
       if href = clipboard.getData("URL")
-        paste.type = "URL"
-        paste.href = href
+        paste.type = "text/html"
         if name = clipboard.getData("public.url-name")
-          paste.string = Trix.squishBreakableWhitespace(name).trim()
+          string = Trix.squishBreakableWhitespace(name).trim()
         else
-          paste.string = href
+          string = href
+        paste.html = @createLinkHTML(href, string)
         @delegate?.inputControllerWillPaste(paste)
-        @setInputSummary(textAdded: paste.string, didDelete: @selectionIsExpanded())
-        @responder?.insertText(Trix.Text.textForStringWithAttributes(paste.string, href: paste.href))
+        @setInputSummary(textAdded: string, didDelete: @selectionIsExpanded())
+        @responder?.insertHTML(paste.html)
         @requestRender()
         @delegate?.inputControllerDidPaste(paste)
 

--- a/src/trix/controllers/level_2_input_controller.coffee
+++ b/src/trix/controllers/level_2_input_controller.coffee
@@ -58,11 +58,10 @@ class Trix.Level2InputController extends Trix.InputController
       else if href = event.clipboardData?.getData("URL")
         event.preventDefault()
         paste =
-          type: "URL"
-          href: href
-          string: href
+          type: "text/html"
+          html: @createLinkHTML(href)
         @delegate?.inputControllerWillPaste(paste)
-        @responder?.insertText(Trix.Text.textForStringWithAttributes(paste.string, href: paste.href))
+        @responder?.insertHTML(paste.html)
         @render()
         @delegate?.inputControllerDidPaste(paste)
 
@@ -278,15 +277,15 @@ class Trix.Level2InputController extends Trix.InputController
       paste = {dataTransfer}
 
       if href = dataTransfer.getData("URL")
-        paste.type = "URL"
-        paste.href = href
+        paste.type = "text/html"
         if name = dataTransfer.getData("public.url-name")
-          paste.string = Trix.squishBreakableWhitespace(name).trim()
+          string = Trix.squishBreakableWhitespace(name).trim()
         else
-          paste.string = href
+          string = href
+        paste.html = @createLinkHTML(href, string)
         @delegate?.inputControllerWillPaste(paste)
         @withTargetDOMRange ->
-          @responder?.insertText(Trix.Text.textForStringWithAttributes(paste.string, href: paste.href))
+          @responder?.insertHTML(paste.html)
         @afterRender = =>
           @delegate?.inputControllerDidPaste(paste)
 

--- a/test/src/system/pasting_test.coffee
+++ b/test/src/system/pasting_test.coffee
@@ -85,6 +85,15 @@ testGroup "Pasting", template: "editor_empty", ->
       assert.textAttributes([0, 7], href: "http://example.com")
       expectDocument "Example\n"
 
+  test "paste JavaScript URL", (expectDocument) ->
+   pasteData =
+     "URL": "javascript:alert('XSS')\n"
+   pasteContent pasteData, ->
+     document = getDocument()
+     block = document.getBlockAtIndex(0)
+     assert.documentHTMLEqual(document, "<div><!--block-->javascript:alert('XSS')</div>")
+     expectDocument "javascript:alert('XSS')\n"
+
   test "paste URL with name containing extraneous whitespace", (expectDocument) ->
     pasteData =
       "URL": "http://example.com"

--- a/test/src/system/pasting_test.coffee
+++ b/test/src/system/pasting_test.coffee
@@ -87,11 +87,9 @@ testGroup "Pasting", template: "editor_empty", ->
 
   test "paste JavaScript URL", (expectDocument) ->
    pasteData =
-     "URL": "javascript:alert('XSS')\n"
+     "URL": "javascript:alert('XSS')"
    pasteContent pasteData, ->
-     document = getDocument()
-     block = document.getBlockAtIndex(0)
-     assert.documentHTMLEqual(document, "<div><!--block-->javascript:alert('XSS')</div>")
+     assert.textAttributes([0, 23], {})
      expectDocument "javascript:alert('XSS')\n"
 
   test "paste URL with name containing extraneous whitespace", (expectDocument) ->


### PR DESCRIPTION
### What are you trying to accomplish in this PR?
In Safari, trix doesn't escape pasted URLs with JavaScript protocol. To fix this issue as suggested by @javan, we insert the pasted URL as HTML so that they are passed to the same HTML sanitizer.

Resolves #779

### Manual testing 🎩 
|Master branch|This branch|
|---------------|-----------|
| ![master](https://user-images.githubusercontent.com/13983801/80264300-b8e22700-8661-11ea-8847-99616a2f5476.gif)| ![fix-self-xss](https://user-images.githubusercontent.com/13983801/83064402-b8a5c480-a02f-11ea-809f-1e5f44dfe5a6.gif) |







#### Confirming JavaScript links are sanitized on paste
1. In Safari, go to playground.abdulwahaab.ca, right click and copy the link `Click me`
2. Paste the link into the trix editor you have running locally `localhost:9292`
3. Observe that the link is pasted as a text instead of an anchor tag.

#### Confirming other pasted links are not sanitized on paste
1. Repeat the first 2 steps except of copying the `Click me` link, copy the `Clean link`
3. Observe that the link is pasted as an anchor tag.