### PR TITLE
Update readme to describe `editor.attributeIsActive` function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,15 @@ element.editor.setSelectedRange([0, 4])
 element.editor.activateAttribute("href", "https://trix-editor.org/")
 ```
 
+### Detecting Formatting
+
+To detect if a formatting is applied to current selection, use the `editor.attributeIsActive` method.
+
+```js
+element.editor.setSelectedRange([0, 5])
+element.editor.attributeIsActive("bold")
+```
+
 ### Removing Formatting
 
 Use the `editor.deactivateAttribute` method to remove formatting from a selection.


### PR DESCRIPTION
The function is defined here: https://github.com/basecamp/trix/blob/master/src/trix/models/editor.coffee#L95.

I needed this function for my current usecase of creating a custom toolbar vs using the default one and could not easily find it. Hence adding to the documentation