### PR TITLE
Fix quote placement to being outside when adding blockquote to a list

### DIFF
--- a/src/trix/core/collections/object_group.coffee
+++ b/src/trix/core/collections/object_group.coffee
@@ -17,6 +17,12 @@ class Trix.ObjectGroup
         objects.push(object)
 
     if group
+      for obj in group 
+        if obj.hasAttribute("quote")
+          attributes = obj.attributes
+          quoteIndex = attributes.indexOf("quote")
+          attributes.splice(quoteIndex, 1)
+          attributes.unshift("quote")
       objects.push(new this group, {depth, asTree})
     objects
 


### PR DESCRIPTION
Fix for issue #52.

Now the quote is placed outside a list instead of being inside when quoting a list.