### PR TITLE
Add basic right-to-left language support

### DIFF
--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -12,10 +12,12 @@
   }
 
   blockquote {
-    margin: 0;
+    margin-block: 0;
     margin-inline-start: 0.3em;
-    padding: 0;
+    margin-inline-end: 0;
+    padding-block: 0;
     padding-inline-start: 0.6em;
+    padding-inline-end: 0;
     border-inline-start: 0.3em solid #ccc;
   }
 

--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -12,13 +12,18 @@
   }
 
   blockquote {
+    margin: 0 0 0 0.3em;
     margin-block: 0;
     margin-inline-start: 0.3em;
     margin-inline-end: 0;
+    padding: 0 0 0 0.6em;
     padding-block: 0;
     padding-inline-start: 0.6em;
     padding-inline-end: 0;
+    border-left: 0.3em solid #ccc;
+    border-right: 0;
     border-inline-start: 0.3em solid #ccc;
+    border-inline-end: 0;
   }
 
   pre {
@@ -91,6 +96,7 @@
   .attachment--file {
     color: #333;
     line-height: 1;
+    margin: 0 2px 2px 0;
     margin-inline-start: 0;
     margin-inline-end: 2px;
     margin-block-start: 0;

--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -91,7 +91,9 @@
   .attachment--file {
     color: #333;
     line-height: 1;
+    margin-inline-start: 0;
     margin-inline-end: 2px;
+    margin-block-start: 0;
     margin-block-end: 2px;
     padding: 0.4em 1em;
     border: 1px solid #bbb;

--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -12,9 +12,11 @@
   }
 
   blockquote {
-    margin: 0 0 0 0.3em;
-    padding: 0 0 0 0.6em;
-    border-left: 0.3em solid #ccc;
+    margin: 0;
+    margin-inline-start: 0.3em;
+    padding: 0;
+    padding-inline-start: 0.6em;
+    border-inline-start: 0.3em solid #ccc;
   }
 
   pre {
@@ -35,7 +37,7 @@
     padding: 0;
 
     li {
-      margin-left: 1em;
+      margin-inline-start: 1em;
     }
   }
 
@@ -87,7 +89,8 @@
   .attachment--file {
     color: #333;
     line-height: 1;
-    margin: 0 2px 2px 0;
+    margin-inline-end: 2px;
+    margin-block-end: 2px;
     padding: 0.4em 1em;
     border: 1px solid #bbb;
     border-radius: 5px;

--- a/src/trix/config/input.coffee
+++ b/src/trix/config/input.coffee
@@ -1,6 +1,8 @@
 Trix.config.input =
   level2Enabled: true
 
+  textDirection: "auto"
+
   getLevel: ->
     if @level2Enabled and Trix.browser.supportsInputEvents
       2

--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -1,7 +1,7 @@
 #= require trix/elements/trix_toolbar_element
 #= require trix/controllers/editor_controller
 
-{browser, makeElement, triggerEvent, handleEvent, handleEventOnce} = Trix
+{browser, config, makeElement, triggerEvent, handleEvent, handleEventOnce} = Trix
 
 {attachmentSelector} = Trix.AttachmentView
 
@@ -23,6 +23,10 @@ Trix.registerElement "trix-editor", do ->
   addAccessibilityRole = (element) ->
     return if element.hasAttribute("role")
     element.setAttribute("role", "textbox")
+
+  addTextDirection = (element) ->
+    return if element.hasAttribute("dir")
+    element.setAttribute("dir", config.input.textDirection)
 
   configureContentEditable = (element) ->
     disableObjectResizing(element)
@@ -163,6 +167,7 @@ Trix.registerElement "trix-editor", do ->
   initialize: ->
     makeEditable(this)
     addAccessibilityRole(this)
+    addTextDirection(this)
 
   connect: ->
     unless @hasAttribute("data-trix-internal")


### PR DESCRIPTION
This adds in a configurable `dir` attribute to the editor element, with a default of `auto` (`auto` will determine the direction based on the first character encountered with strong directionality [1]). 

To support right-to-left languages correctly, the physical CSS properties have been replaced with logical ones. CSS logical properties are now supported by all modern browsers [2]. 

**Before**:
(with `dir="rtl"` manually applied to the editor element)
![image](https://user-images.githubusercontent.com/1028877/89445887-089db780-d754-11ea-9588-7e4bbe3b547c.png)


**After**:
![image](https://user-images.githubusercontent.com/1028877/89445404-667dcf80-d753-11ea-8aa7-fa191879efa4.png)
![image](https://user-images.githubusercontent.com/1028877/89445711-cffdde00-d753-11ea-845b-4ecb2ae340c1.png)


Tested in Chrome, Firefox, Edge, and Safari.

[1] https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute
[2] https://caniuse.com/#feat=css-logical-props