### PR TITLE
Right-to-left (RTL) support

### DIFF
--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -13,8 +13,17 @@
 
   blockquote {
     margin: 0 0 0 0.3em;
+    margin-block: 0;
+    margin-inline-start: 0.3em;
+    margin-inline-end: 0;
     padding: 0 0 0 0.6em;
+    padding-block: 0;
+    padding-inline-start: 0.6em;
+    padding-inline-end: 0;
     border-left: 0.3em solid #ccc;
+    border-right: 0;
+    border-inline-start: 0.3em solid #ccc;
+    border-inline-end: 0;
   }
 
   pre {
@@ -36,6 +45,9 @@
 
     li {
       margin-left: 1em;
+      margin-right: 0;
+      margin-inline-start: 1em;
+      margin-inline-end: 0;
     }
   }
 
@@ -88,6 +100,10 @@
     color: #333;
     line-height: 1;
     margin: 0 2px 2px 0;
+    margin-inline-start: 0;
+    margin-inline-end: 2px;
+    margin-block-start: 0;
+    margin-block-end: 2px;
     padding: 0.4em 1em;
     border: 1px solid #bbb;
     border-radius: 5px;

--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -1,29 +1,42 @@
+$quote-border-width: 0.3em;
+$quote-margin-start: 0.3em;
+$quote-padding-start: 0.6em;
+
 .trix-content {
   line-height: 1.5;
 
   * {
     box-sizing: border-box;
+    margin: 0;
+    padding: 0;
   }
 
   h1 {
     font-size: 1.2em;
     line-height: 1.2;
-    margin: 0;
   }
 
   blockquote {
-    margin: 0 0 0 0.3em;
-    margin-block: 0;
-    margin-inline-start: 0.3em;
-    margin-inline-end: 0;
-    padding: 0 0 0 0.6em;
-    padding-block: 0;
-    padding-inline-start: 0.6em;
-    padding-inline-end: 0;
-    border-left: 0.3em solid #ccc;
-    border-right: 0;
-    border-inline-start: 0.3em solid #ccc;
-    border-inline-end: 0;
+    border: 0 solid #ccc;
+    border-left-width: $quote-border-width;
+    margin-left: $quote-margin-start;
+    padding-left: $quote-padding-start;
+  }
+
+  [dir=rtl] blockquote,
+  blockquote[dir=rtl] {
+    border-width: 0;
+    border-right-width: $quote-border-width;
+    margin-right: $quote-margin-start;
+    padding-right: $quote-padding-start;
+  }
+
+  li {
+    margin-left: 1em;
+  }
+
+  [dir=rtl] li {
+    margin-right: 1em;
   }
 
   pre {
@@ -32,23 +45,10 @@
     vertical-align: top;
     font-family: monospace;
     font-size: 0.9em;
-    margin: 0;
     padding: 0.5em;
     white-space: pre;
     background-color: #eee;
     overflow-x: auto;
-  }
-
-  ul, ol, li {
-    margin: 0;
-    padding: 0;
-
-    li {
-      margin-left: 1em;
-      margin-right: 0;
-      margin-inline-start: 1em;
-      margin-inline-end: 0;
-    }
   }
 
   img {
@@ -60,8 +60,6 @@
     display: inline-block;
     position: relative;
     max-width: 100%;
-    margin: 0;
-    padding: 0;
 
     a {
       color: inherit;
@@ -75,7 +73,6 @@
   }
 
   .attachment__caption {
-    padding: 0;
     text-align: center;
 
     .attachment__name + .attachment__size {
@@ -99,11 +96,7 @@
   .attachment--file {
     color: #333;
     line-height: 1;
-    margin: 0 2px 2px 0;
-    margin-inline-start: 0;
-    margin-inline-end: 2px;
-    margin-block-start: 0;
-    margin-block-end: 2px;
+    margin: 0 2px 2px 2px;
     padding: 0.4em 1em;
     border: 1px solid #bbb;
     border-radius: 5px;
@@ -113,8 +106,6 @@
     display: flex;
     flex-wrap: wrap;
     position: relative;
-    margin: 0;
-    padding: 0;
 
     .attachment {
       flex: 1 0 33%;

--- a/src/trix/core/helpers/bidi.coffee
+++ b/src/trix/core/helpers/bidi.coffee
@@ -1,0 +1,7 @@
+# https://github.com/mathiasbynens/unicode-2.1.8/blob/master/Bidi_Class/Right_To_Left/regex.js
+RTL_Pattern = /[\u05BE\u05C0\u05C3\u05D0-\u05EA\u05F0-\u05F4\u061B\u061F\u0621-\u063A\u0640-\u064A\u066D\u0671-\u06B7\u06BA-\u06BE\u06C0-\u06CE\u06D0-\u06D5\u06E5\u06E6\u200F\u202B\u202E\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE72\uFE74\uFE76-\uFEFC]/
+
+Trix.extend
+  isRTL: (string = "") ->
+    char = string.trim().charAt(0)
+    RTL_Pattern.test(char)

--- a/src/trix/core/helpers/bidi.coffee
+++ b/src/trix/core/helpers/bidi.coffee
@@ -1,7 +1,27 @@
-# https://github.com/mathiasbynens/unicode-2.1.8/blob/master/Bidi_Class/Right_To_Left/regex.js
-RTL_Pattern = /[\u05BE\u05C0\u05C3\u05D0-\u05EA\u05F0-\u05F4\u061B\u061F\u0621-\u063A\u0640-\u064A\u066D\u0671-\u06B7\u06BA-\u06BE\u06C0-\u06CE\u06D0-\u06D5\u06E5\u06E6\u200F\u202B\u202E\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE72\uFE74\uFE76-\uFEFC]/
-
 Trix.extend
-  isRTL: (string = "") ->
-    char = string.trim().charAt(0)
-    RTL_Pattern.test(char)
+  # https://github.com/mathiasbynens/unicode-2.1.8/blob/master/Bidi_Class/Right_To_Left/regex.js
+  RTL_PATTERN: /[\u05BE\u05C0\u05C3\u05D0-\u05EA\u05F0-\u05F4\u061B\u061F\u0621-\u063A\u0640-\u064A\u066D\u0671-\u06B7\u06BA-\u06BE\u06C0-\u06CE\u06D0-\u06D5\u06E5\u06E6\u200F\u202B\u202E\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE72\uFE74\uFE76-\uFEFC]/
+
+  getDirection: do ->
+    input = Trix.makeElement("input", dir: "auto", name: "x", dirName: "x.dir")
+    form = Trix.makeElement("form")
+    form.appendChild(input)
+
+    supportsDirName = do ->
+      try new FormData(form).has(input.dirName)
+
+    supportsDirSelector = do ->
+      try input.matches(":dir(ltr),:dir(rtl)")
+
+    if supportsDirName
+      (string) ->
+        input.value = string
+        new FormData(form).get(input.dirName)
+    else if supportsDirSelector
+      (string) ->
+        input.value = string
+        if input.matches(":dir(rtl)") then "rtl" else "ltr"
+    else
+      (string) ->
+        char = string.trim().charAt(0)
+        if Trix.RTL_PATTERN.test(char) then "rtl" else "ltr"

--- a/src/trix/core/helpers/index.coffee
+++ b/src/trix/core/helpers/index.coffee
@@ -9,3 +9,4 @@
 #= require trix/core/helpers/custom_elements
 #= require trix/core/helpers/selection
 #= require trix/core/helpers/events
+#= require trix/core/helpers/bidi

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -125,13 +125,23 @@ class Trix.Block extends Trix.Object
     text: @text
     attributes: @attributes
 
+  # BIDI
+
+  getDirection: ->
+    @text.getDirection()
+
+  isRTL: ->
+    @text.isRTL()
+
   # Splittable
 
   getLength: ->
     @text.getLength()
 
   canBeConsolidatedWith: (block) ->
-    not @hasAttributes() and not block.hasAttributes()
+    not @hasAttributes() and
+      not block.hasAttributes() and
+      @getDirection() is block.getDirection()
 
   consolidateWith: (block) ->
     newlineText = Trix.Text.textForStringWithAttributes("\n")
@@ -171,7 +181,8 @@ class Trix.Block extends Trix.Object
 
     attribute is otherAttribute and
       not (getBlockConfig(attribute).group is false and
-           otherAttributes[depth + 1] not in getListAttributeNames())
+      otherAttributes[depth + 1] not in getListAttributeNames()) and
+      @getDirection() is otherBlock.getDirection()
 
   # Block breaks
 

--- a/src/trix/models/block.coffee
+++ b/src/trix/models/block.coffee
@@ -182,7 +182,7 @@ class Trix.Block extends Trix.Object
     attribute is otherAttribute and
       not (getBlockConfig(attribute).group is false and
       otherAttributes[depth + 1] not in getListAttributeNames()) and
-      @getDirection() is otherBlock.getDirection()
+      (@getDirection() is otherBlock.getDirection() or otherBlock.isEmpty())
 
   # Block breaks
 

--- a/src/trix/models/text.coffee
+++ b/src/trix/models/text.coffee
@@ -170,7 +170,7 @@ class Trix.Text extends Trix.Object
   # BIDI
 
   getDirection: ->
-    if @isRTL() then "rtl" else "ltr"
+    Trix.getDirection(@toString())
 
   isRTL: ->
-    Trix.isRTL(@toString())
+    @getDirection() is "rtl"

--- a/src/trix/models/text.coffee
+++ b/src/trix/models/text.coffee
@@ -166,3 +166,11 @@ class Trix.Text extends Trix.Object
 
   toConsole: ->
     JSON.stringify(JSON.parse(piece.toConsole()) for piece in @pieceList.toArray())
+
+  # BIDI
+
+  getDirection: ->
+    if @isRTL() then "rtl" else "ltr"
+
+  isRTL: ->
+    Trix.isRTL(@toString())

--- a/src/trix/views/block_view.coffee
+++ b/src/trix/views/block_view.coffee
@@ -23,20 +23,24 @@ class Trix.BlockView extends Trix.ObjectView
     if @attributes.length
       nodes
     else
-      element = makeElement(Trix.config.blockAttributes.default.tagName)
+      {tagName} = Trix.config.blockAttributes.default
+      attributes = dir: "rtl" if @block.isRTL()
+
+      element = makeElement({tagName, attributes})
       element.appendChild(node) for node in nodes
       [element]
 
   createContainerElement: (depth) ->
-    attribute = @attributes[depth]
-    {tagName} = getBlockConfig(attribute)
-    options = {tagName}
+    attributeName = @attributes[depth]
 
-    if attribute is "attachmentGallery"
+    {tagName} = getBlockConfig(attributeName)
+    attributes = dir: "rtl" if depth is 0 and @block.isRTL()
+
+    if attributeName is "attachmentGallery"
       size = @block.getBlockBreakPosition()
-      options.className = "#{css.attachmentGallery} #{css.attachmentGallery}--#{size}"
+      className = "#{css.attachmentGallery} #{css.attachmentGallery}--#{size}"
 
-    makeElement(options)
+    makeElement({tagName, className, attributes})
 
   # A single <br> at the end of a block element has no visual representation
   # so add an extra one.

--- a/test/src/test_helpers/fixtures/fixtures.coffee
+++ b/test/src/test_helpers/fixtures/fixtures.coffee
@@ -570,6 +570,7 @@ removeWhitespace = (string) ->
       ["ل", {}, ["quote"]],
       ["b", {}, ["bulletList", "bullet"]],
       ["ל", {}, ["bulletList", "bullet"]],
+      ["",  {}, ["bulletList", "bullet"]]
       ["cید"],
       ["\n گ"]
     )
@@ -577,7 +578,7 @@ removeWhitespace = (string) ->
       <div>#{blockComment}a</div>\
       <blockquote dir="rtl">#{blockComment}ل</blockquote>\
       <ul><li>#{blockComment}b</li></ul>\
-      <ul dir="rtl"><li>#{blockComment}ל</li></ul>\
+      <ul dir="rtl"><li>#{blockComment}ל</li><li>#{blockComment}<br></li></ul>\
       <div>#{blockComment}cید</div>\
       <div dir="rtl">#{blockComment}<br>&nbsp;گ</div>\
     """
@@ -585,7 +586,7 @@ removeWhitespace = (string) ->
       <div>a</div>\
       <blockquote dir="rtl">ل</blockquote>\
       <ul><li>b</li></ul>\
-      <ul dir="rtl"><li>ל</li></ul>\
+      <ul dir="rtl"><li>ל</li><li><br></li></ul>\
       <div>cید</div>\
       <div dir="rtl"><br>&nbsp;گ</div>\
     """

--- a/test/src/test_helpers/fixtures/fixtures.coffee
+++ b/test/src/test_helpers/fixtures/fixtures.coffee
@@ -564,6 +564,32 @@ removeWhitespace = (string) ->
     document: createDocument(["a", { bold: true }, ["heading1"]], ["b", { italic: true, bold: true }, ["heading1"]])
     html: "<h1>#{blockComment}<strong>a</strong></h1><h1>#{blockComment}<strong><em>b</em></strong></h1>"
 
+  "bidrectional text":
+    document: createDocument(
+      ["a"],
+      ["ل", {}, ["quote"]],
+      ["b", {}, ["bulletList", "bullet"]],
+      ["ל", {}, ["bulletList", "bullet"]],
+      ["cید"],
+      ["\n گ"]
+    )
+    html: """
+      <div>#{blockComment}a</div>\
+      <blockquote dir="rtl">#{blockComment}ل</blockquote>\
+      <ul><li>#{blockComment}b</li></ul>\
+      <ul dir="rtl"><li>#{blockComment}ל</li></ul>\
+      <div>#{blockComment}cید</div>\
+      <div dir="rtl">#{blockComment}<br>&nbsp;گ</div>\
+    """
+    serializedHTML: """
+      <div>a</div>\
+      <blockquote dir="rtl">ل</blockquote>\
+      <ul><li>b</li></ul>\
+      <ul dir="rtl"><li>ל</li></ul>\
+      <div>cید</div>\
+      <div dir="rtl"><br>&nbsp;گ</div>\
+    """
+
 @eachFixture = (callback) ->
   for name, details of @fixtures
     callback(name, details)


### PR DESCRIPTION
This change leverages available browser APIs to determine a block's text direction and automatically render `dir="rtl"` on top-level block elements when appropriate. The editing experience is functionally similar to the native behavior of `dir="auto"`, but results in HTML that's more portable, reliable, and easier to style with CSS.

Closes https://github.com/basecamp/trix/pull/806
Closes https://github.com/basecamp/trix/pull/819
Resolves https://github.com/basecamp/trix/issues/309
