### PR TITLE
Fix: Toolbar buttons reacted to right-clicks

### DIFF
--- a/src/trix/controllers/toolbar_controller.coffee
+++ b/src/trix/controllers/toolbar_controller.coffee
@@ -24,31 +24,34 @@ class Trix.ToolbarController extends Trix.BasicObject
   # Event handlers
 
   didClickActionButton: (event, element) =>
-    @delegate?.toolbarDidClickButton()
-    event.preventDefault()
-    actionName = getActionName(element)
+    if event.button is 0
+      @delegate?.toolbarDidClickButton()
+      event.preventDefault()
+      actionName = getActionName(element)
 
-    if @getDialog(actionName)
-      @toggleDialog(actionName)
-    else
-      @delegate?.toolbarDidInvokeAction(actionName)
+      if @getDialog(actionName)
+        @toggleDialog(actionName)
+      else
+        @delegate?.toolbarDidInvokeAction(actionName)
 
   didClickAttributeButton: (event, element) =>
-    @delegate?.toolbarDidClickButton()
-    event.preventDefault()
-    attributeName = getAttributeName(element)
+    if event.button is 0
+      @delegate?.toolbarDidClickButton()
+      event.preventDefault()
+      attributeName = getAttributeName(element)
 
-    if @getDialog(attributeName)
-      @toggleDialog(attributeName)
-    else
-      @delegate?.toolbarDidToggleAttribute(attributeName)
+      if @getDialog(attributeName)
+        @toggleDialog(attributeName)
+      else
+        @delegate?.toolbarDidToggleAttribute(attributeName)
 
-    @refreshAttributeButtons()
+      @refreshAttributeButtons()
 
   didClickDialogButton: (event, element) =>
-    dialogElement = findClosestElementFromNode(element, matchingSelector: dialogSelector)
-    method = element.getAttribute("data-trix-method")
-    @[method].call(this, dialogElement)
+    if event.button is 0
+      dialogElement = findClosestElementFromNode(element, matchingSelector: dialogSelector)
+      method = element.getAttribute("data-trix-method")
+      @[method].call(this, dialogElement)
 
   didKeyDownDialogInput: (event, element) =>
     if event.keyCode is 13 # Enter key
@@ -98,7 +101,7 @@ class Trix.ToolbarController extends Trix.BasicObject
       buttonKeys = button.getAttribute("data-trix-key").split("+")
       buttonKeyString = JSON.stringify(buttonKeys.sort())
       if buttonKeyString is keyString
-        triggerEvent("mousedown", onElement: button)
+        triggerEvent("mousedown", onElement: button, attributes: {button: 0})
         return true
     false
 

--- a/test/src/test_helpers/toolbar_helpers.coffee
+++ b/test/src/test_helpers/toolbar_helpers.coffee
@@ -4,7 +4,7 @@ helpers.extend
   clickToolbarButton: (selector, callback) ->
     Trix.selectionChangeObserver.update()
     button = getToolbarButton(selector)
-    helpers.triggerEvent(button, "mousedown")
+    helpers.triggerEvent(button, "mousedown", {button: 0})
     helpers.defer(callback)
 
   typeToolbarKeyCommand: (selector, callback) ->
@@ -16,7 +16,7 @@ helpers.extend
 
   clickToolbarDialogButton: ({method}, callback) ->
     button = getToolbarElement().querySelector("[data-trix-dialog] [data-trix-method='#{method}']")
-    helpers.triggerEvent(button, "click")
+    helpers.triggerEvent(button, "click", {button: 0})
     helpers.defer(callback)
 
   isToolbarButtonActive: (selector) ->
@@ -31,7 +31,7 @@ helpers.extend
     input = dialog.querySelector("[data-trix-input][name='#{attribute}']")
     button = dialog.querySelector("[data-trix-method='setAttribute']")
     input.value = string
-    helpers.triggerEvent(button, "click")
+    helpers.triggerEvent(button, "click", {button: 0})
     helpers.defer(callback)
 
   isToolbarDialogActive: (selector) ->


### PR DESCRIPTION
… which buttons normally don’t do.

I’d normally do an early bail (aka `if (event.button !== 0) return;`) but I haven’t spotted that style in this codebase, so I opted for nesting.