### PR TITLE
Fix dropping a file onto an existing attachment

### DIFF
--- a/src/trix/controllers/level_2_input_controller.coffee
+++ b/src/trix/controllers/level_2_input_controller.coffee
@@ -92,6 +92,9 @@ class Trix.Level2InputController extends Trix.InputController
           @dragging.point = point
           @responder?.setLocationRangeFromPointRange(point)
 
+      else if dragEventHasFiles(event)
+        event.preventDefault()
+
     drop: (event) ->
       if @dragging
         event.preventDefault()


### PR DESCRIPTION
Without this fix, the file was opened in a new tab when being dropped onto an existing attachment inside the editor.

With this fix, the file is inserted next to the existing attachment, which seems like a better defaut.