### PR TITLE
Ensure trix-editor element is ARIA labeled

### DIFF
--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -24,6 +24,22 @@ Trix.registerElement "trix-editor", do ->
     return if element.hasAttribute("role")
     element.setAttribute("role", "textbox")
 
+  ensureAriaLabel = (element) ->
+    return if element.hasAttribute("aria-label") or element.hasAttribute("aria-labelledby")
+
+    update = ->
+      texts = (label.textContent for label in element.labels when not label.contains(element))
+      text = texts.join(" ")
+
+      if text
+        element.setAttribute("aria-label", text)
+      else
+        element.removeAttribute("aria-label")
+
+    update()
+
+    handleEvent("focus", onElement: element, withCallback: update)
+
   configureContentEditable = (element) ->
     disableObjectResizing(element)
     setDefaultParagraphSeparator(element)
@@ -172,6 +188,7 @@ Trix.registerElement "trix-editor", do ->
   initialize: ->
     makeEditable(this)
     addAccessibilityRole(this)
+    ensureAriaLabel(this)
 
   connect: ->
     unless @hasAttribute("data-trix-internal")

--- a/test/src/system/accessibility_test.coffee
+++ b/test/src/system/accessibility_test.coffee
@@ -1,0 +1,45 @@
+{assert, test, testGroup, triggerEvent} = Trix.TestHelpers
+
+testGroup "Accessibility attributes", template: "editor_default_aria_label", ->
+  test "sets the role to textbox", (done) ->
+    editor = document.getElementById("editor-without-labels")
+
+    assert.equal editor.getAttribute("role"), "textbox"
+    done()
+
+  test "does not set aria-label when the element has no <label> elements", (done) ->
+    editor = document.getElementById("editor-without-labels")
+
+    assert.equal editor.hasAttribute("aria-label"), false
+    done()
+
+  test "does not override aria-label when the element declares it", (done) ->
+    editor = document.getElementById("editor-with-aria-label")
+
+    assert.equal editor.getAttribute("aria-label"), "ARIA Label text"
+    done()
+
+  test "does not set aria-label when the element declares aria-labelledby", (done) ->
+    editor = document.getElementById("editor-with-aria-labelledby")
+
+    assert.equal editor.hasAttribute("aria-label"), false
+    assert.equal editor.getAttribute("aria-labelledby"),"aria-labelledby-id"
+    done()
+
+  test "assigns aria-label to the text of the element's <label> elements", (done) ->
+    editor = document.getElementById("editor-with-labels")
+
+    assert.equal editor.getAttribute("aria-label"), "Label 1 Label 2 Label 3"
+    done()
+
+  test "updates the aria-label on focus", (done) ->
+    editor = document.getElementById("editor-with-modified-label")
+    label = document.getElementById("modified-label")
+
+    assert.equal editor.getAttribute("aria-label"), "Original Value"
+
+    label.innerHTML = "<span>New Value</span>"
+    triggerEvent(editor, "focus")
+
+    assert.equal editor.getAttribute("aria-label"), "New Value"
+    done()

--- a/test/src/test_helpers/fixtures/editor_default_aria_label.jst.eco
+++ b/test/src/test_helpers/fixtures/editor_default_aria_label.jst.eco
@@ -1,0 +1,19 @@
+<trix-editor id="editor-without-labels"></trix-editor>
+
+<label for="editor-with-aria-label"><span>Label text</span></label>
+<trix-editor id="editor-with-aria-label" aria-label="ARIA Label text"></trix-editor>
+
+<span id="aria-labelledby-id">ARIA Labelledby</span>
+<label for="editor-with-aria-labelledby"><span>Label text</span></label>
+<trix-editor id="editor-with-aria-labelledby" aria-labelledby="aria-labelledby-id"></trix-editor>
+
+<label for="editor-with-labels"><span>Label 1</span></label>
+<label for="editor-with-labels"><span>Label 2</span></label>
+<label for="editor-with-labels"><span>Label 3</span></label>
+<label>
+  <span>Label 4</span>
+  <trix-editor id="editor-with-labels"></trix-editor>
+</label>
+
+<label id="modified-label" for="editor-with-modified-label">Original Value</label>
+<trix-editor id="editor-with-modified-label"></trix-editor>


### PR DESCRIPTION
Since the `<trix-editor>` element is custom and not a browser `<input>`,
we can't rely that assistive technology will be able to [read the label
text from a `<label for="...">` that corresponds to a `<trix-editor
id="...">` element][labelable].

When a `<trix-editor>` element is attached to the DOM and initialized,
collect the text from its related `<label>` elements and combine it to
set a default `[aria-label]` value.

If the `<trix-editor>` element is a descendant of any of its `<label>`
elements, *omit* those elements when generating an `[aria-label]` value.

If an [`[aria-label]` value][aria-label] is already specified, *do not*
override it.

Similarly, if a [`[aria-labelledby]` value][aria-labelledby] is
specified, don't set the `[aria-label]` attribute at all.

[labelable]: https://html.spec.whatwg.org/multipage/forms.html#category-label
[aria-label]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute
[aria-labelledby]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute
