### PR TITLE
Make trix toolbar XHTML compatible

### DIFF
--- a/src/trix/config/toolbar.coffee
+++ b/src/trix/config/toolbar.coffee
@@ -32,13 +32,13 @@ Trix.config.toolbar =
       </span>
     </div>
 
-    <div class="trix-dialogs" data-trix-dialogs>
+    <div class="trix-dialogs" data-trix-dialogs="data-trix-dialogs">
       <div class="trix-dialog trix-dialog--link" data-trix-dialog="href" data-trix-dialog-attribute="href">
         <div class="trix-dialog__link-fields">
-          <input type="url" name="href" class="trix-input trix-input--dialog" placeholder="#{lang.urlPlaceholder}" aria-label="#{lang.url}" required data-trix-input>
+          <input type="url" name="href" class="trix-input trix-input--dialog" placeholder="#{lang.urlPlaceholder}" aria-label="#{lang.url}" required="required" data-trix-input="data-trix-input"></input>
           <div class="trix-button-group">
-            <input type="button" class="trix-button trix-button--dialog" value="#{lang.link}" data-trix-method="setAttribute">
-            <input type="button" class="trix-button trix-button--dialog" value="#{lang.unlink}" data-trix-method="removeAttribute">
+            <input type="button" class="trix-button trix-button--dialog" value="#{lang.link}" data-trix-method="setAttribute"></input>
+            <input type="button" class="trix-button trix-button--dialog" value="#{lang.unlink}" data-trix-method="removeAttribute"></input>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Without this change, the toolbar doesn't get created when trix is placed in an xhtml5 context. the line:

    this.innerHTML = e.config.toolbar.getDefaultHTML()

Fails because the document fragment is not XML.

I've only tested that patch by manually applying this change to the trix.js distribution make trix toolbar works on an xhtml page.