### PR TITLE
Associate `<label>` elements to `<trix-editor>`

### DIFF
--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -196,6 +196,7 @@ Trix.registerElement "trix-editor", do ->
       @editorController.registerSelectionManager()
       @registerResetListener()
       @registerClickListener()
+      @registerWithLabels()
       autofocus(this)
 
   disconnect: ->
@@ -218,6 +219,12 @@ Trix.registerElement "trix-editor", do ->
 
   unregisterClickListener: ->
     window.removeEventListener("click", @clickListener, false)
+
+  registerWithLabels: ->
+    element = this
+
+    for label in @labels
+      Object.defineProperty label, "control", get: -> element
 
   resetBubbled: (event) ->
     return if event.defaultPrevented

--- a/test/src/system/accessibility_test.coffee
+++ b/test/src/system/accessibility_test.coffee
@@ -1,6 +1,11 @@
 {assert, test, testGroup, triggerEvent} = Trix.TestHelpers
 
 testGroup "Accessibility attributes", template: "editor_default_aria_label", ->
+  test "associates the editor with its label elements", ->
+    editor = document.getElementById("editor-with-labels")
+    for label in editor.labels
+      assert.equal label.control, editor
+
   test "sets the role to textbox", ->
     editor = document.getElementById("editor-without-labels")
     assert.equal editor.getAttribute("role"), "textbox"


### PR DESCRIPTION
Typically, [HTMLLabelElement.control][control] returns the `input`,
`textarea`, `select`, or `button` element that it's associated with.

Unfortunately, since `<trix-editor>` is a custom element, we don't get
this behavior for free. The `<trix-editor>` to `<label>` element
association has been improved ([basecamp/trix#843][],
[basecamp/trix#829][]), but could be improved.

[control]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control
[basecamp/trix#843]: https://github.com/basecamp/trix/pull/843
[basecamp/trix#829]: https://github.com/basecamp/trix/pull/829