### PR TITLE
Fix incorrect getSelectedRange when typing on block element under OSX

### DIFF
--- a/src/trix/models/composition.coffee
+++ b/src/trix/models/composition.coffee
@@ -32,7 +32,7 @@ class Trix.Composition extends Trix.BasicObject
   # Responder protocol
 
   insertText: (text, {updatePosition} = updatePosition: true) ->
-    selectedRange = @getSelectedRange()
+    selectedRange = @getSelectedRange({ strict: false })
     @setDocument(@document.insertTextAtRange(text, selectedRange))
 
     startPosition = selectedRange[0]
@@ -366,8 +366,8 @@ class Trix.Composition extends Trix.BasicObject
     locationRange = @document.locationRangeFromRange(selectedRange)
     @delegate?.compositionDidRequestChangingSelectionToLocationRange(locationRange)
 
-  getSelectedRange: ->
-    if locationRange = @getLocationRange()
+  getSelectedRange: (options) ->
+    if locationRange = @getLocationRange(options)
       @document.rangeFromLocationRange(locationRange)
 
   setSelectedRange: (selectedRange) ->


### PR DESCRIPTION
Hi,

I found a bug related to getSelectedRange are incorrect when using Simplified Chinese IME in osx Chrome.

The reason are comment element are remove when compostion input trigger auto correct in Chrome, which cause compute selectedRange incorrect because selectedRange uses `Trix.nodeIsBlockStartComment` with strict mode to infer the block element. 

https://user-images.githubusercontent.com/10810452/106426553-c5bd6200-64a0-11eb-977e-f47178a591bd.mov

Seems the issue can be simply resolved by turn off selectedRange strict mode

