### PR TITLE
Remove extra @charset "UTF-8" in compiled CSS

### DIFF
--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -77,7 +77,7 @@ $quote-padding-start: 0.6em;
 
     .attachment__name + .attachment__size {
       &::before {
-        content: ' · ';
+        content: ' \2022 ';
       }
     }
   }


### PR DESCRIPTION
The content style for attachments where a "bullet" character was being
injected before the element's content was causing the compiled CSS to
shove an extra `@charset "UTF-8";` in the middle of the file (line
~300). This can cause warnings and possibly errors for CSS build
systems.

For example, this warning is emitted from `postcss-loader` when importing
the Trix CSS in webpack...

```
Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
Warning
(300:1) postcss-import: @charset must precede all other statements
```

I changed the style to use an escaped unicode version of a bullet
instead of the actual character. After running `bin/blade build`
locally, the extra `@charset` no longer showed up in the compiled file.

Fixes #795 