### PR TITLE
Add TrixEditorElement.form property

### DIFF
--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -146,6 +146,10 @@ Trix.registerElement "trix-editor", do ->
         @parentNode.insertBefore(element, this)
         element
 
+  form:
+    get: ->
+      @inputElement?.form
+
   inputElement:
     get: ->
       if @hasAttribute("input")
@@ -222,7 +226,7 @@ Trix.registerElement "trix-editor", do ->
 
   resetBubbled: (event) ->
     return if event.defaultPrevented
-    return unless event.target is @inputElement?.form
+    return unless event.target is @form
     @reset()
 
   clickBubbled: (event) ->

--- a/test/src/system/custom_element_test.coffee
+++ b/test/src/system/custom_element_test.coffee
@@ -407,3 +407,21 @@ testGroup "<label> support", template: "editor_with_labels", ->
     label.click()
     assert.notEqual getEditorElement(), document.activeElement
     done()
+
+testGroup "form property references its <form>", template: "editors_with_forms", container: "div", ->
+  test "accesses its ancestor form", (done) ->
+    form = document.getElementById("ancestor-form")
+    editor = document.getElementById("editor-with-ancestor-form")
+    assert.equal editor.form, form
+    done()
+
+  test "transitively accesses its related <input> element's <form>", (done) ->
+    form = document.getElementById("input-form")
+    editor = document.getElementById("editor-with-input-form")
+    assert.equal editor.form, form
+    done()
+
+  test "returns null when there is no associated <form>", (done) ->
+    editor = document.getElementById("editor-with-no-form")
+    assert.equal editor.form, null
+    done()

--- a/test/src/test_helpers/fixtures/editors_with_forms.jst.eco
+++ b/test/src/test_helpers/fixtures/editors_with_forms.jst.eco
@@ -1,0 +1,10 @@
+<form id="ancestor-form">
+  <trix-editor id="editor-with-ancestor-form"></trix-editor>
+</form>
+
+<form id="input-form">
+  <input type="hidden" id="hidden-input">
+</form>
+<trix-editor id="editor-with-input-form" input="hidden-input"></trix-editor>
+
+<trix-editor id="editor-with-no-form"></trix-editor>

--- a/test/src/test_helpers/test_helpers.coffee
+++ b/test/src/test_helpers/test_helpers.coffee
@@ -1,22 +1,22 @@
 helpers = Trix.TestHelpers
+{removeNode} = Trix
 
-setFixtureHTML = (html) ->
-  element = findOrCreateTrixContainer()
+setFixtureHTML = (html, container = "form") ->
+  element = document.getElementById("trix-container")
+  removeNode(element) if element?
+
+  element = document.createElement(container)
+  element.id = "trix-container"
   element.innerHTML = html
 
-findOrCreateTrixContainer = ->
-  if container = document.getElementById("trix-container")
-    container
-  else
-    document.body.insertAdjacentHTML("afterbegin", """<form id="trix-container"></form>""")
-    document.getElementById("trix-container")
+  document.body.insertAdjacentElement("afterbegin", element)
 
 ready = null
 
 helpers.extend
   testGroup: (name, options, callback) ->
     if callback?
-      {template, setup, teardown} = options
+      {container,template, setup, teardown} = options
     else
       callback = options
 
@@ -32,7 +32,7 @@ helpers.extend
               target.editor.setSelectedRange(0)
             callback(target)
 
-          setFixtureHTML(JST["test_helpers/fixtures/#{template}"]())
+          setFixtureHTML(JST["test_helpers/fixtures/#{template}"](), container)
         else
           callback()
       setup?()


### PR DESCRIPTION
Add TrixEditorElement.form property
===

The problem:
---

Consider the following HTML:

```html
<form action="/articles" method="post">
  <textarea name="content"></textarea>

  <button type="submit">Save</button>
</form>
```

Then, consider a theoretical event listener:

```js
addEventListener("keydown", ({ key, metaKey, target }) => {
  if (target.form && key == "Enter" && (metaKey || ctrlKey)) {
    form.requestSubmit()
  }
})
```

This relies on [HTMLTextAreaElement.form][] finding its related `<form>`
element. Given the way the `[form]` attribute can reference a `<form>`
element that is _not an ancestor_, that same event listener would
continue to work with this HTML:

```html
<textarea name="content" form="new_article"></textarea>

<!-- elsewhere -->
<form id="new_article" action="/articles" method="post">
  <button type="submit">Save</button>
</form>
```

Unfortunately, if the `<textarea>` element were replaced with a
`<trix-editor>`, the event listener's reliance on accessing the `form`
as a property would break, since the `<trix-editor>` custom element
doesn't declare that property.

[HTMLTextAreaElement.form]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement#properties

The proposed changes:
---

Provide property access for `<trix-editor>` elements, similar to how an
`<input>` or `<textarea>` element can access a form outside of its
direct tree of ancestors via the [form="..."][] attribute and the
corresponding `.form` property.

Related testing changes
---

All other system tests in the suite are rendered into a `<form
id="trix-container">` element on the page. In order to test this new
behavior, the fixture HTML declare several new `<form>` elements.

These are incompatible with an ancestor `<form>`, since HTML forbids
nesting `<form>` elements.

To address that, this commit changes the implementation of how its Test
Helpers create elements from the fixture HTML files.

[form="..."]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-form
