### PR TITLE
Add support for multi-line placeholder text

### DIFF
--- a/src/trix/elements/trix_editor_element.coffee
+++ b/src/trix/elements/trix_editor_element.coffee
@@ -71,6 +71,7 @@ Trix.registerElement "trix-editor", do ->
       color: graytext;
       cursor: text;
       pointer-events: none;
+      white-space: pre-line;
     }
 
     %t a[contenteditable=false] {


### PR DESCRIPTION
Adds support for multi-line placeholder text by adding `white-space: pre-line;` to placeholder style.
Closes #901 