### PR TITLE
update compiled CSS to remove the extra @charset "UTF-8"

### DIFF
--- a/dist/trix.css
+++ b/dist/trix.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Trix 1.3.1
-Copyright © 2020 Basecamp, LLC
+Copyright © 2021 Basecamp, LLC
 http://trix-editor.org/*/
 trix-editor {
   border: 1px solid #bbb;
@@ -297,7 +297,6 @@ trix-editor .attachment__metadata {
   trix-editor .attachment__metadata .attachment__size {
     margin-left: 0.2em;
     white-space: nowrap; }
-@charset "UTF-8";
 .trix-content {
   line-height: 1.5; }
   .trix-content * {
@@ -347,7 +346,7 @@ trix-editor .attachment__metadata {
   .trix-content .attachment__caption {
     text-align: center; }
     .trix-content .attachment__caption .attachment__name + .attachment__size::before {
-      content: ' · '; }
+      content: ' \2022 '; }
   .trix-content .attachment--preview {
     width: 100%;
     text-align: center; }


### PR DESCRIPTION
https://github.com/basecamp/trix/pull/897 updates the source file, but not the compiled CSS.
I added the compiled CSS to piggyback on https://github.com/basecamp/trix/pull/897.

This update completes the fix for https://github.com/basecamp/trix/issues/795.
The compiled CSS still shows the following postcss warning:

```
Module Warning (from ./node_modules/postcss-loader/dist/cjs.js):
Warning
(300:1) postcss-import: @charset must precede all other statements
```