### PR TITLE
Improve parsing of HTML tables containing whitespace

### DIFF
--- a/src/trix/models/html_parser.coffee
+++ b/src/trix/models/html_parser.coffee
@@ -130,10 +130,10 @@ class Trix.HTMLParser extends Trix.BasicObject
           @appendAttachmentWithAttributes(attributes, @getTextAttributes(element))
           @processedElements.push(element)
         when "tr"
-          unless element.parentNode.firstChild is element
+          unless element.parentNode.firstElementChild is element
             @appendStringWithAttributes("\n")
         when "td"
-          unless element.parentNode.firstChild is element
+          unless element.parentNode.firstElementChild is element
             @appendStringWithAttributes(" | ")
 
   # Document construction

--- a/test/src/unit/html_parser_test.coffee
+++ b/test/src/unit/html_parser_test.coffee
@@ -147,7 +147,7 @@ testGroup "Trix.HTMLParser", ->
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 
   test "translates tables into plain text", ->
-    html = """<table><tr><td>a</td><td>b</td></tr><tr><td>1</td><td><p>2</p></td></tr><table>"""
+    html = """<table><tr>\r\n<td>a</td><td>b</td></tr><tr><td>1</td><td><p>2</p></td></tr><table>"""
     expectedHTML = """<div><!--block-->a | b<br>1 | 2</div>"""
     assert.documentHTMLEqual Trix.HTMLParser.parse(html).getDocument(), expectedHTML
 


### PR DESCRIPTION
We discovered this from a client that keeps the text that they're going to paste into Trix in an Excel spreadsheet, where each individual cell is copy & pasted into a new Trix instance.
In Windows Excel, copying a single cell containing "Hello world" generates some horrific HTML markup that essentially boils down to:

```html
<html><body><table><tr>\r\n<td>Hello world</td></tr></table></body></html>
```

Which Trix then formats as:

```
| Hello world
```

How about this change, which ignores text nodes when trying to determine if the current tr/td is the first element in the container?

---

h/t to @hooleyhoop for the excellent detective work