### PR TITLE
Replace deprecated media feature

### DIFF
--- a/assets/trix/stylesheets/media-queries.scss
+++ b/assets/trix/stylesheets/media-queries.scss
@@ -1,7 +1,7 @@
 $phone-width: 768px;
 
 @mixin phone {
-  @media (max-device-width: #{$phone-width}) {
+  @media (max-width: #{$phone-width}) {
     @content;
   }
 }


### PR DESCRIPTION
`max-device-width` is a deprecated media feature and throws an error in 
the CSS Validator:

> Deprecated media feature `max-device-width`. For guidance, see the 
> Deprecated Media Features section in the current Media Queries 
> specification. 

MDN also flags it as a deprecated feature:
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/device-width

`max-width` feels like a natural replacement and should behave the same 
in most browsers (if not all?).