### PR TITLE
Fix ensureAttachmentExclusivelyHasAttribute

### DIFF
--- a/src/trix/core/collections/hash.js
+++ b/src/trix/core/collections/hash.js
@@ -49,7 +49,7 @@ export default class Hash extends TrixObject {
   slice(keys) {
     const values = {}
 
-    keys.forEach((key) => {
+    Array.from(keys).forEach((key) => {
       if (this.has(key)) {
         values[key] = this.values[key]
       }

--- a/src/trix/models/attachment_piece.js
+++ b/src/trix/models/attachment_piece.js
@@ -23,7 +23,7 @@ export default class AttachmentPiece extends Piece {
   ensureAttachmentExclusivelyHasAttribute(attribute) {
     if (this.hasAttribute(attribute)) {
       if (!this.attachment.hasAttribute(attribute)) {
-        this.attachment.setAttributes(this.attributes.slice(attribute))
+        this.attachment.setAttributes(this.attributes.slice([ attribute ]))
       }
       this.attributes = this.attributes.remove(attribute)
     }


### PR DESCRIPTION
The method was calling `Hash.slice` with a string and `Hash.slice` was using `forEach` on the string, but `forEach` is not defined for strings.