### PR TITLE
Fixed mistake with readme section for Loading and Saving Editor State.

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Serialize an editor’s state with `JSON.stringify` and restore saved state with
 localStorage["editorState"] = JSON.stringify(element.editor)
 
 // Restore editor state from local storage
-element.editor.loadJSON(JSON.parse(localStorage["editorState"]))
+element.editor.loadJSON({document: JSON.parse(localStorage["editorState"])})
 ```
 
 ## Observing Editor Changes


### PR DESCRIPTION
The readme section for explaining how to load saved editor state had an incorrect method signature which caused it to throw an error when loading state as per the readme instructions.

I've updated the readme section to include the correct method signature so that it will now work if people implement what's in the readme.

See here for others having the same issue: https://stackoverflow.com/questions/63090235/basecamp-trix-editor-loading-stored-content-from-json