### PR TITLE
Idempotent Custom Element registration

### DIFF
--- a/src/trix/core/helpers/custom_elements.coffee
+++ b/src/trix/core/helpers/custom_elements.coffee
@@ -78,7 +78,8 @@ registerElement = do ->
       Object.setPrototypeOf(constructor.prototype, HTMLElement.prototype)
       Object.setPrototypeOf(constructor, HTMLElement)
       Object.defineProperties(constructor.prototype, properties)
-      window.customElements.define(tagName, constructor)
+      unless window.customElements.get(tagName)
+        window.customElements.define(tagName, constructor)
       constructor
   else
     (tagName, properties) ->


### PR DESCRIPTION
If the package is accidentally imported a second time, the Custom
Element registrations will raise an exception like:

```
NotSupportedError: Cannot define multiple custom elements with the same tag name
```

This commit adds a guard that checks whether or not the element has been
registered through a call to [CustomElementRegistry.get][]. When
present, the redundant call to [CustomElementRegistry.define][] is
skipped.

[CustomElementRegistry.get]: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/get
[CustomElementRegistry.define]: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define