### PR TITLE
Don't start Trix automatically on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Trix is built with established web standards, notably [Custom Elements](https://
 
 Trix comes bundled in ESM and UMD formats and works with any asset packaging system.
 
-The easiest way to start with Trix is including it from an npm CDN in the `<head>` of your page:
+The easiest way to start with Trix is including it from an npm CDN in the `<head>` of your page and then calling `Trix.start()` to initialize the library:
 
 ```html
 <head>

--- a/README.md
+++ b/README.md
@@ -21,19 +21,32 @@ Trix is built with established web standards, notably [Custom Elements](https://
 
 # Getting Started
 
-Include the bundled `trix.css` and `trix.js` files in the `<head>` of your page.
+Trix comes bundled in ESM and UMD formats and works with any asset packaging system.
+
+The easiest way to start with Trix is including it from an npm CDN in the `<head>` of your page:
 
 ```html
 <head>
   …
-  <link rel="stylesheet" type="text/css" href="trix.css">
-  <script type="text/javascript" src="trix.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.0.0-beta.0/dist/trix.css">
+  <script type="text/javascript" src="https://unpkg.com/trix@2.0.0-beta.0/dist/trix.umd.min.js"></script>
+  <script type="text/javascript">
+    Trix.start()
+  </script>
 </head>
 ```
 
 `trix.css` includes default styles for the Trix toolbar, editor, and attachments. Skip this file if you prefer to define these styles yourself.
 
-To use your own polyfills, or to target only browsers that support all of the required standards, include `trix-core.js` instead.
+Alternatively, you can install the npm package and import it in your application:
+
+```js
+import Trix from "trix"
+
+// Change Trix.config if you need
+
+Trix.start()
+```
 
 ## Creating an Editor
 

--- a/src/test/test_helper.js
+++ b/src/test/test_helper.js
@@ -30,3 +30,5 @@ document.head.insertAdjacentHTML(
     trix-toolbar button:disabled { color: #ccc; }
   </style>`
 )
+
+Trix.start()

--- a/src/trix/elements/trix_editor_element.js
+++ b/src/trix/elements/trix_editor_element.js
@@ -323,5 +323,3 @@ export default class TrixEditorElement extends HTMLElement {
     this.value = this.defaultValue
   }
 }
-
-window.customElements.define("trix-editor", TrixEditorElement)

--- a/src/trix/elements/trix_toolbar_element.js
+++ b/src/trix/elements/trix_toolbar_element.js
@@ -33,5 +33,3 @@ export default class TrixToolbarElement extends HTMLElement {
     }
   }
 }
-
-window.customElements.define("trix-toolbar", TrixToolbarElement)

--- a/src/trix/trix.js
+++ b/src/trix/trix.js
@@ -20,12 +20,11 @@ const Trix = {
   observers,
   operations,
   elements,
-  filters
-}
-
-Trix.start = () => {
-  customElements.define("trix-toolbar", elements.TrixToolbarElement)
-  customElements.define("trix-editor", elements.TrixEditorElement)
+  filters,
+  start: () => {
+    customElements.define("trix-toolbar", elements.TrixToolbarElement)
+    customElements.define("trix-editor", elements.TrixEditorElement)
+  }
 }
 
 window.Trix = Trix

--- a/src/trix/trix.js
+++ b/src/trix/trix.js
@@ -23,6 +23,11 @@ const Trix = {
   filters
 }
 
+Trix.start = () => {
+  customElements.define("trix-toolbar", elements.TrixToolbarElement)
+  customElements.define("trix-editor", elements.TrixEditorElement)
+}
+
 window.Trix = Trix
 
 export default Trix


### PR DESCRIPTION
Instead require a call to Trix.start.

This gives a chance to configure the editor before any instances are
created.

Fixes https://github.com/basecamp/trix/issues/964

For more context, see also https://dev.to/paramagicdev/modifying-the-default-toolbar-in-trix-411b