### PR TITLE
Replace callbacks with async/await in tests

### DIFF
--- a/src/test/system/attachment_gallery_test.js
+++ b/src/test/system/attachment_gallery_test.js
@@ -2,6 +2,7 @@ import {
   assert,
   clickToolbarButton,
   createImageAttachment,
+  expectDocument,
   insertAttachments,
   pressKey,
   test,
@@ -9,52 +10,52 @@ import {
   typeCharacters,
 } from "test/test_helper"
 import { OBJECT_REPLACEMENT_CHARACTER } from "trix/constants"
+import { nextFrame } from "../test_helpers/timing_helpers"
 
 const ORC = OBJECT_REPLACEMENT_CHARACTER
 
 testGroup("Attachment galleries", { template: "editor_empty" }, () => {
-  test("inserting more than one image attachment creates a gallery block", function (expectDocument) {
+  test("inserting more than one image attachment creates a gallery block", () => {
     insertAttachments(createImageAttachments(2))
     assert.blockAttributes([ 0, 2 ], [ "attachmentGallery" ])
     expectDocument(`${ORC}${ORC}\n`)
   })
 
-  test("gallery formatting is removed from blocks containing less than two image attachments", function (expectDocument) {
+  test("gallery formatting is removed from blocks containing less than two image attachments", async () => {
     insertAttachments(createImageAttachments(2))
     assert.blockAttributes([ 0, 2 ], [ "attachmentGallery" ])
     getEditor().setSelectedRange([ 1, 2 ])
-    pressKey("backspace", () => {
-      requestAnimationFrame(() => {
-        assert.blockAttributes([ 0, 2 ], [])
-        expectDocument(`${ORC}\n`)
-      })
-    })
+
+    await pressKey("backspace")
+    await nextFrame()
+
+    assert.blockAttributes([ 0, 2 ], [])
+    expectDocument(`${ORC}\n`)
   })
 
-  test("typing in an attachment gallery block splits it", function (expectDocument) {
+  test("typing in an attachment gallery block splits it", async () => {
     insertAttachments(createImageAttachments(4))
     getEditor().setSelectedRange(2)
-    typeCharacters("a", () => {
-      requestAnimationFrame(() => {
-        assert.blockAttributes([ 0, 2 ], [ "attachmentGallery" ])
-        assert.blockAttributes([ 3, 4 ], [])
-        assert.blockAttributes([ 5, 7 ], [ "attachmentGallery" ])
-        expectDocument(`${ORC}${ORC}\na\n${ORC}${ORC}\n`)
-      })
-    })
+
+    await typeCharacters("a")
+    await nextFrame()
+
+    assert.blockAttributes([ 0, 2 ], [ "attachmentGallery" ])
+    assert.blockAttributes([ 3, 4 ], [])
+    assert.blockAttributes([ 5, 7 ], [ "attachmentGallery" ])
+    expectDocument(`${ORC}${ORC}\na\n${ORC}${ORC}\n`)
   })
 
-  test("inserting a gallery in a formatted block", (expectDocument) => {
-    clickToolbarButton({ attribute: "quote" }, () => {
-      typeCharacters("abc", () => {
-        insertAttachments(createImageAttachments(2))
-        requestAnimationFrame(() => {
-          assert.blockAttributes([ 0, 3 ], [ "quote" ])
-          assert.blockAttributes([ 4, 6 ], [ "attachmentGallery" ])
-          expectDocument(`abc\n${ORC}${ORC}\n`)
-        })
-      })
-    })
+  test("inserting a gallery in a formatted block", async () => {
+    await clickToolbarButton({ attribute: "quote" })
+    await typeCharacters("abc")
+
+    insertAttachments(createImageAttachments(2))
+    await nextFrame()
+
+    assert.blockAttributes([ 0, 3 ], [ "quote" ])
+    assert.blockAttributes([ 4, 6 ], [ "attachmentGallery" ])
+    expectDocument(`abc\n${ORC}${ORC}\n`)
   })
 })
 

--- a/src/test/system/attachment_test.js
+++ b/src/test/system/attachment_test.js
@@ -2,13 +2,12 @@ import * as config from "trix/config"
 import { OBJECT_REPLACEMENT_CHARACTER } from "trix/constants"
 
 import {
-  after,
   assert,
   clickElement,
   clickToolbarButton,
   createFile,
-  defer,
   dragToCoordinates,
+  expectDocument,
   moveCursor,
   pressKey,
   test,
@@ -16,129 +15,129 @@ import {
   triggerEvent,
   typeCharacters,
 } from "test/test_helper"
+import { delay, nextFrame } from "../test_helpers/timing_helpers"
 
 testGroup("Attachments", { template: "editor_with_image" }, () => {
-  test("moving an image by drag and drop", (expectDocument) => {
-    typeCharacters("!", () => {
-      moveCursor({ direction: "right", times: 1 }, (coordinates) => {
-        const img = document.activeElement.querySelector("img")
-        triggerEvent(img, "mousedown")
-        defer(() => {
-          dragToCoordinates(coordinates, () => {
-            expectDocument(`!a${OBJECT_REPLACEMENT_CHARACTER}b\n`)
-          })
-        })
-      })
-    })
+  test("moving an image by drag and drop", async () => {
+    await typeCharacters("!")
+
+    const coordinates = await moveCursor({ direction: "right", times: 1 })
+    const img = document.activeElement.querySelector("img")
+    triggerEvent(img, "mousedown")
+
+    await nextFrame()
+    await dragToCoordinates(coordinates)
+
+    expectDocument(`!a${OBJECT_REPLACEMENT_CHARACTER}b\n`)
   })
 
-  test("removing an image", (expectDocument) => {
-    after(20, () => {
-      clickElement(getFigure(), () => {
-        const closeButton = getFigure().querySelector("[data-trix-action=remove]")
-        clickElement(closeButton, () => {
-          expectDocument("ab\n")
-        })
-      })
-    })
+  test("removing an image", async () => {
+    await delay(20)
+    await clickElement(getFigure())
+
+    const closeButton = getFigure().querySelector("[data-trix-action=remove]")
+    await clickElement(closeButton)
+
+    expectDocument("ab\n")
   })
 
-  test("editing an image caption", (expectDocument) => {
-    after(20, () => {
-      clickElement(findElement("figure"), () => {
-        clickElement(findElement("figcaption"), () => {
-          defer(() => {
-            const textarea = findElement("textarea")
-            assert.ok(textarea)
-            textarea.focus()
-            textarea.value = "my"
-            triggerEvent(textarea, "input")
-            defer(() => {
-              textarea.value = ""
-              defer(() => {
-                textarea.value = "my caption"
-                triggerEvent(textarea, "input")
-                pressKey("return", () => {
-                  assert.notOk(findElement("textarea"))
-                  assert.textAttributes([ 2, 3 ], { caption: "my caption" })
-                  assert.locationRange({ index: 0, offset: 3 })
-                  expectDocument(`ab${OBJECT_REPLACEMENT_CHARACTER}\n`)
-                })
-              })
-            })
-          })
-        })
-      })
-    })
+  test("editing an image caption", async () => {
+    await delay(20)
+
+    await clickElement(findElement("figure"))
+    await clickElement(findElement("figcaption"))
+
+    await nextFrame()
+
+    const textarea = findElement("textarea")
+    assert.ok(textarea)
+
+    textarea.focus()
+    textarea.value = "my"
+    triggerEvent(textarea, "input")
+
+    await nextFrame()
+    textarea.value = ""
+
+    await nextFrame()
+    textarea.value = "my caption"
+    triggerEvent(textarea, "input")
+
+    await pressKey("return")
+    assert.notOk(findElement("textarea"))
+    assert.textAttributes([ 2, 3 ], { caption: "my caption" })
+    assert.locationRange({ index: 0, offset: 3 })
+    expectDocument(`ab${OBJECT_REPLACEMENT_CHARACTER}\n`)
   })
 
-  test("editing an attachment caption with no filename", (done) =>
-    after(20, () => {
-      let captionElement = findElement("figcaption")
-      assert.ok(captionElement.clientHeight > 0)
-      assert.equal(captionElement.getAttribute("data-trix-placeholder"), config.lang.captionPlaceholder)
+  test("editing an attachment caption with no filename", async () => {
+    await delay(20)
 
-      clickElement(findElement("figure"), () => {
-        captionElement = findElement("figcaption")
-        assert.ok(captionElement.clientHeight > 0)
-        assert.equal(captionElement.getAttribute("data-trix-placeholder"), config.lang.captionPlaceholder)
-        done()
-      })
-    }))
+    let captionElement = findElement("figcaption")
+    assert.ok(captionElement.clientHeight > 0)
+    assert.equal(captionElement.getAttribute("data-trix-placeholder"), config.lang.captionPlaceholder)
 
-  test("updating an attachment's href attribute while editing its caption", (expectDocument) => {
+    await clickElement(findElement("figure"))
+
+    captionElement = findElement("figcaption")
+    assert.ok(captionElement.clientHeight > 0)
+    assert.equal(captionElement.getAttribute("data-trix-placeholder"), config.lang.captionPlaceholder)
+  })
+
+  test("updating an attachment's href attribute while editing its caption", async () => {
     const attachment = getEditorController().attachmentManager.getAttachments()[0]
 
-    after(20, () => {
-      clickElement(findElement("figure"), () => {
-        clickElement(findElement("figcaption"), () => {
-          defer(() => {
-            let textarea = findElement("textarea")
-            assert.ok(textarea)
-            textarea.focus()
-            textarea.value = "my caption"
-            triggerEvent(textarea, "input")
-            attachment.setAttributes({ href: "https://example.com" })
-            defer(() => {
-              textarea = findElement("textarea")
-              assert.ok(document.activeElement === textarea)
-              assert.equal(textarea.value, "my caption")
-              pressKey("return", () => {
-                assert.notOk(findElement("textarea"))
-                assert.textAttributes([ 2, 3 ], { caption: "my caption" })
-                assert.locationRange({ index: 0, offset: 3 })
-                expectDocument(`ab${OBJECT_REPLACEMENT_CHARACTER}\n`)
-              })
-            })
-          })
-        })
-      })
-    })
+    await delay(20)
+
+    await clickElement(findElement("figure"))
+    await clickElement(findElement("figcaption"))
+
+    await nextFrame()
+
+    let textarea = findElement("textarea")
+    assert.ok(textarea)
+    textarea.focus()
+    textarea.value = "my caption"
+    triggerEvent(textarea, "input")
+    attachment.setAttributes({ href: "https://example.com" })
+
+    await nextFrame()
+
+    textarea = findElement("textarea")
+    assert.ok(document.activeElement === textarea)
+    assert.equal(textarea.value, "my caption")
+
+    await pressKey("return")
+
+    assert.notOk(findElement("textarea"))
+    assert.textAttributes([ 2, 3 ], { caption: "my caption" })
+    assert.locationRange({ index: 0, offset: 3 })
+
+    expectDocument(`ab${OBJECT_REPLACEMENT_CHARACTER}\n`)
   })
 
   testGroup("File insertion", { template: "editor_empty" }, () => {
-    test("inserting a file in a formatted block", (expectDocument) => {
-      clickToolbarButton({ attribute: "bullet" }, () => {
-        clickToolbarButton({ attribute: "bold" }, () => {
-          getComposition().insertFile(createFile())
-          assert.blockAttributes([ 0, 1 ], [ "bulletList", "bullet" ])
-          assert.textAttributes([ 0, 1 ], {})
-          expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
-        })
-      })
+    test("inserting a file in a formatted block", async () => {
+      await clickToolbarButton({ attribute: "bullet" })
+      await clickToolbarButton({ attribute: "bold" })
+
+      getComposition().insertFile(createFile())
+
+      assert.blockAttributes([ 0, 1 ], [ "bulletList", "bullet" ])
+      assert.textAttributes([ 0, 1 ], {})
+      expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
     })
 
-    test("inserting a files in a formatted block", (expectDocument) => {
-      clickToolbarButton({ attribute: "quote" }, () => {
-        clickToolbarButton({ attribute: "italic" }, () => {
-          getComposition().insertFiles([ createFile(), createFile() ])
+    test("inserting a files in a formatted block", async () => {
+      await clickToolbarButton({ attribute: "quote" })
+      await clickToolbarButton({ attribute: "italic" })
 
-          assert.blockAttributes([ 0, 2 ], [ "quote" ])
-          assert.textAttributes([ 0, 1 ], {})
-          assert.textAttributes([ 1, 2 ], {})
-          expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}${OBJECT_REPLACEMENT_CHARACTER}\n`)
-        })
-      })
+      getComposition().insertFiles([ createFile(), createFile() ])
+
+      assert.blockAttributes([ 0, 2 ], [ "quote" ])
+      assert.textAttributes([ 0, 1 ], {})
+      assert.textAttributes([ 1, 2 ], {})
+      expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}${OBJECT_REPLACEMENT_CHARACTER}\n`)
     })
   })
 })

--- a/src/test/system/basic_input_test.js
+++ b/src/test/system/basic_input_test.js
@@ -1,9 +1,9 @@
 import * as config from "trix/config"
 import {
   assert,
-  defer,
   dragToCoordinates,
   expandSelection,
+  expectDocument,
   insertNode,
   moveCursor,
   pressKey,
@@ -15,91 +15,125 @@ import {
   typeCharacters,
 } from "test/test_helper"
 
+import { nextFrame } from "../test_helpers/timing_helpers"
+
 testGroup("Basic input", { template: "editor_empty" }, () => {
-  test("typing", (expectDocument) => typeCharacters("abc", () => expectDocument("abc\n")))
+  test("typing", async () => {
+    await typeCharacters("abc")
+    expectDocument("abc\n")
+  })
 
-  test("backspacing", (expectDocument) =>
-    typeCharacters("abc\b", () => {
-      expectDocument("ab\n")
-    }))
+  test("backspacing", async () => {
+    await typeCharacters("abc\b")
+    expectDocument("ab\n")
+  })
 
-  test("pressing delete", (expectDocument) =>
-    typeCharacters("ab", () => moveCursor("left", () => pressKey("delete", () => expectDocument("a\n")))))
+  test("pressing delete", async () => {
+    await typeCharacters("ab")
+    await moveCursor("left")
+    await pressKey("delete")
+    expectDocument("a\n")
+  })
 
-  test("pressing return", (expectDocument) =>
-    typeCharacters("ab", () => pressKey("return", () => typeCharacters("c", () => expectDocument("ab\nc\n")))))
+  test("pressing return", async () => {
+    await typeCharacters("ab")
+    await pressKey("return")
+    await typeCharacters("c")
 
-  test("pressing escape in Safari", (expectDocument) =>
-    typeCharacters("a", () => {
-      if (triggerEvent(document.activeElement, "keydown", { charCode: 0, keyCode: 27, which: 27, key: "Escape", code: "Escape" })) {
-        triggerEvent(document.activeElement, "keypress", { charCode: 27, keyCode: 27, which: 27, key: "Escape", code: "Escape" })
-      }
-      defer(() => expectDocument("a\n"))
-    }))
+    expectDocument("ab\nc\n")
+  })
 
-  test("pressing escape in Firefox", (expectDocument) =>
-    typeCharacters("a", () => {
-      if (triggerEvent(document.activeElement, "keydown", { charCode: 0, keyCode: 27, which: 27, key: "Escape", code: "Escape" })) {
-        triggerEvent(document.activeElement, "keypress", { charCode: 0, keyCode: 27, which: 0, key: "Escape", code: "Escape" })
-      }
-      defer(() => expectDocument("a\n"))
-    }))
+  test("pressing escape in Safari", async () => {
+    await typeCharacters("a")
 
-  test("pressing escape in Chrome", (expectDocument) =>
-    typeCharacters("a", () => {
-      triggerEvent(document.activeElement, "keydown", {
-        charCode: 0,
-        keyCode: 27,
-        which: 27,
-        key: "Escape",
-        code: "Escape",
-      })
-      defer(() => expectDocument("a\n"))
-    }))
+    if (triggerEvent(document.activeElement, "keydown", { charCode: 0, keyCode: 27, which: 27, key: "Escape", code: "Escape" })) {
+      triggerEvent(document.activeElement, "keypress", { charCode: 27, keyCode: 27, which: 27, key: "Escape", code: "Escape" })
+    }
 
-  test("cursor left", (expectDocument) =>
-    typeCharacters("ac", () => moveCursor("left", () => typeCharacters("b", () => expectDocument("abc\n")))))
+    await nextFrame()
+    expectDocument("a\n")
+  })
 
-  test("replace entire document", (expectDocument) =>
-    typeCharacters("abc", () => selectAll(() => typeCharacters("d", () => expectDocument("d\n")))))
+  test("pressing escape in Firefox", async () => {
+    await typeCharacters("a")
+    if (triggerEvent(document.activeElement, "keydown", { charCode: 0, keyCode: 27, which: 27, key: "Escape", code: "Escape" })) {
+      triggerEvent(document.activeElement, "keypress", { charCode: 0, keyCode: 27, which: 0, key: "Escape", code: "Escape" })
+    }
+    await nextFrame()
+    expectDocument("a\n")
+  })
 
-  test("remove entire document", (expectDocument) =>
-    typeCharacters("abc", () => selectAll(() => typeCharacters("\b", () => expectDocument("\n")))))
-
-  test("drag text", (expectDocument) =>
-    typeCharacters("abc", () =>
-      moveCursor({ direction: "left", times: 2 }, (coordinates) =>
-        moveCursor("right", () =>
-          expandSelection("right", () => dragToCoordinates(coordinates, () => expectDocument("acb\n")))
-        )
-      )
-    ))
-
-  testIf(config.input.getLevel() === 0, "inserting newline after cursor (control + o)", (expectDocument) => {
-    typeCharacters("ab", () => {
-      moveCursor("left", () => {
-        triggerEvent(document.activeElement, "keydown", { charCode: 0, keyCode: 79, which: 79, ctrlKey: true })
-        defer(() => {
-          assert.locationRange({ index: 0, offset: 1 })
-          expectDocument("a\nb\n")
-        })
-      })
+  test("pressing escape in Chrome", async () => {
+    await typeCharacters("a")
+    triggerEvent(document.activeElement, "keydown", {
+      charCode: 0,
+      keyCode: 27,
+      which: 27,
+      key: "Escape",
+      code: "Escape",
     })
+    await nextFrame()
+    expectDocument("a\n")
+  })
+
+  test("cursor left", async () => {
+    await typeCharacters("ac")
+    await moveCursor("left")
+    await typeCharacters("b")
+
+    expectDocument("abc\n")
+  })
+
+  test("replace entire document", async () => {
+    await typeCharacters("abc")
+    await selectAll()
+    await typeCharacters("d")
+
+    expectDocument("d\n")
+  })
+
+  test("remove entire document", async () => {
+    await typeCharacters("abc")
+    await selectAll()
+    await typeCharacters("\b")
+
+    expectDocument("\n")
+  })
+
+  test("drag text", async () => {
+    await typeCharacters("abc")
+    const coordinates = await moveCursor({ direction: "left", times: 2 })
+    await nextFrame()
+
+    await moveCursor("right")
+    await expandSelection("right")
+    await dragToCoordinates(coordinates)
+
+    await expectDocument("acb\n")
+  })
+
+  testIf(config.input.getLevel() === 0, "inserting newline after cursor (control + o)", async () => {
+    await typeCharacters("ab")
+    await moveCursor("left")
+
+    triggerEvent(document.activeElement, "keydown", { charCode: 0, keyCode: 79, which: 79, ctrlKey: true })
+    await nextFrame()
+
+    assert.locationRange({ index: 0, offset: 1 })
+    expectDocument("a\nb\n")
    })
 
-  testIf(config.input.getLevel() === 0, "inserting ó with control + alt + o (AltGr)", (expectDocument) => {
-    typeCharacters("ab", () => {
-      moveCursor("left", () => {
-        if (triggerEvent(document.activeElement, "keydown", { charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: true })) {
-          triggerEvent(document.activeElement, "keypress", { charCode: 243, keyCode: 243, which: 243, altKey: true, ctrlKey: true })
-          insertNode(document.createTextNode("ó"))
-        }
+  testIf(config.input.getLevel() === 0, "inserting ó with control + alt + o (AltGr)", async () => {
+    await typeCharacters("ab")
+    await moveCursor("left")
 
-        defer(() => {
-          assert.locationRange({ index: 0, offset: 2 })
-          expectDocument("aób\n")
-        })
-      })
-    })
+    if (triggerEvent(document.activeElement, "keydown", { charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: true })) {
+      triggerEvent(document.activeElement, "keypress", { charCode: 243, keyCode: 243, which: 243, altKey: true, ctrlKey: true })
+      insertNode(document.createTextNode("ó"))
+    }
+
+    await nextFrame()
+    assert.locationRange({ index: 0, offset: 2 })
+    expectDocument("aób\n")
   })
 })

--- a/src/test/system/block_formatting_test.js
+++ b/src/test/system/block_formatting_test.js
@@ -225,7 +225,7 @@ testGroup("Block formatting", { template: "editor_empty" }, () => {
   test("deleting the only non-block-break character in a block", async () => {
     await typeCharacters("ab")
     await clickToolbarButton({ attribute: "quote" })
-    typeCharacters("\b\b")
+    await typeCharacters("\b\b")
     assert.blockAttributes([ 0, 1 ], [ "quote" ])
   })
 

--- a/src/test/system/caching_test.js
+++ b/src/test/system/caching_test.js
@@ -1,29 +1,24 @@
 import { assert, clickToolbarButton, moveCursor, test, testGroup, typeCharacters } from "test/test_helper"
 
 testGroup("View caching", { template: "editor_empty" }, () => {
-  test("reparsing and rendering identical texts", (done) => {
-    typeCharacters("a\nb\na", () => {
-      moveCursor({ direction: "left", times: 2 }, () => {
-        clickToolbarButton({ attribute: "quote" }, () => {
-          const html = getEditorElement().innerHTML
-          getEditorController().reparse()
-          getEditorController().render()
-          assert.equal(getEditorElement().innerHTML, html)
-          done()
-        })
-      })
-    })
+  test("reparsing and rendering identical texts", async () => {
+    await typeCharacters("a\nb\na")
+    await moveCursor({ direction: "left", times: 2 })
+    await clickToolbarButton({ attribute: "quote" })
+
+    const html = getEditorElement().innerHTML
+    getEditorController().reparse()
+    getEditorController().render()
+    assert.equal(getEditorElement().innerHTML, html)
   })
 
-  test("reparsing and rendering identical blocks", (done) => {
-    clickToolbarButton({ attribute: "bullet" }, () => {
-      typeCharacters("a\na", () => {
-        const html = getEditorElement().innerHTML
-        getEditorController().reparse()
-        getEditorController().render()
-        assert.equal(getEditorElement().innerHTML, html)
-        done()
-      })
-    })
+  test("reparsing and rendering identical blocks", async () => {
+    await clickToolbarButton({ attribute: "bullet" })
+    await typeCharacters("a\na")
+
+    const html = getEditorElement().innerHTML
+    getEditorController().reparse()
+    getEditorController().render()
+    assert.equal(getEditorElement().innerHTML, html)
   })
 })

--- a/src/test/system/canceled_input_test.js
+++ b/src/test/system/canceled_input_test.js
@@ -1,4 +1,4 @@
-import { pressKey, test, testGroup, typeCharacters } from "test/test_helper"
+import { expectDocument, pressKey, test, testGroup, typeCharacters } from "test/test_helper"
 
 const testOptions = {
   template: "editor_empty",
@@ -37,27 +37,24 @@ const cancel = (event) => {
 }
 
 testGroup("Canceled input", testOptions, () => {
-  test("ignoring canceled input events in capturing phase", (expectDocument) => {
-    typeCharacters("a", () => {
-      cancelingInCapturingPhase = true
-      pressKey("backspace", () => {
-        pressKey("return", () => {
-          cancelingInCapturingPhase = false
-          typeCharacters("b", () => expectDocument("ab\n"))
-        })
-      })
-    })
+  test("ignoring canceled input events in capturing phase", async () => {
+    await typeCharacters("a")
+    cancelingInCapturingPhase = true
+    await pressKey("backspace")
+    await pressKey("return")
+    cancelingInCapturingPhase = false
+    await typeCharacters("b")
+
+    expectDocument("ab\n")
   })
 
-  test("ignoring canceled input events at target", (expectDocument) => {
-    typeCharacters("a", () => {
-      cancelingAtTarget = true
-      pressKey("backspace", () => {
-        pressKey("return", () => {
-          cancelingAtTarget = false
-          typeCharacters("b", () => expectDocument("ab\n"))
-        })
-      })
-    })
+  test("ignoring canceled input events at target", async () => {
+    await typeCharacters("a")
+    cancelingAtTarget = true
+    await pressKey("backspace")
+    await pressKey("return")
+    cancelingAtTarget = false
+    await typeCharacters("b")
+    expectDocument("ab\n")
   })
 })

--- a/src/test/system/composition_input_test.js
+++ b/src/test/system/composition_input_test.js
@@ -3,8 +3,8 @@ import * as config from "trix/config"
 import {
   assert,
   clickToolbarButton,
-  defer,
   endComposition,
+  expectDocument,
   insertNode,
   pressKey,
   selectNode,
@@ -17,99 +17,104 @@ import {
   typeCharacters,
   updateComposition,
 } from "test/test_helper"
+import { nextFrame } from "../test_helpers/timing_helpers"
 
 testGroup("Composition input", { template: "editor_empty" }, () => {
-  test("composing", (expectDocument) =>
-    startComposition("a", () => updateComposition("ab", () => endComposition("abc", () => expectDocument("abc\n")))))
+  test("composing", async () => {
+    await startComposition("a")
+    await updateComposition("ab")
+    await endComposition("abc")
 
-  test("typing and composing", (expectDocument) =>
-    typeCharacters("a", () =>
-      startComposition("b", () =>
-        updateComposition("bc", () => endComposition("bcd", () => typeCharacters("e", () => expectDocument("abcde\n"))))
-      )
-    ))
-
-  test("composition input is serialized", (expectDocument) => {
-    startComposition("´", () => {
-      endComposition("é", () => {
-        assert.equal(getEditorElement().value, "<div>é</div>")
-        expectDocument("é\n")
-      })
-    })
+    expectDocument("abc\n")
   })
 
-  test("pressing after a canceled composition", (expectDocument) => {
-    typeCharacters("ab", () => {
-      triggerEvent(document.activeElement, "compositionend", { data: "ab" })
-      pressKey("return", () => expectDocument("ab\n\n"))
-    })
+  test("typing and composing", async () => {
+    await typeCharacters("a")
+    await startComposition("b")
+    await updateComposition("bc")
+    await endComposition("bcd")
+    await typeCharacters("e")
+
+    expectDocument("abcde\n")
   })
 
-  test("composing formatted text", (expectDocument) => {
-    typeCharacters("abc", () => {
-      clickToolbarButton({ attribute: "bold" }, () => {
-        startComposition("d", () => {
-          updateComposition("de", () => {
-            endComposition("def", () => {
-              assert.textAttributes([ 0, 3 ], {})
-              assert.textAttributes([ 3, 6 ], { bold: true })
-              expectDocument("abcdef\n")
-            })
-          })
-        })
-      })
-    })
+  test("composition input is serialized", async () => {
+    await startComposition("´")
+    await endComposition("é")
+
+    assert.equal(getEditorElement().value, "<div>é</div>")
+    expectDocument("é\n")
   })
 
-  test("composing away from formatted text", (expectDocument) => {
-    clickToolbarButton({ attribute: "bold" }, () => {
-      typeCharacters("abc", () => {
-        clickToolbarButton({ attribute: "bold" }, () => {
-          startComposition("d", () => {
-            updateComposition("de", () => {
-              endComposition("def", () => {
-                assert.textAttributes([ 0, 3 ], { bold: true })
-                assert.textAttributes([ 3, 6 ], {})
-                expectDocument("abcdef\n")
-              })
-            })
-          })
-        })
-      })
-    })
+  test("pressing after a canceled composition", async () => {
+    await typeCharacters("ab")
+    triggerEvent(document.activeElement, "compositionend", { data: "ab" })
+    await pressKey("return")
+
+    expectDocument("ab\n\n")
   })
 
-  test("composing another language using a QWERTY keyboard", (expectDocument) => {
+  test("composing formatted text", async () => {
+    await typeCharacters("abc")
+    await clickToolbarButton({ attribute: "bold" })
+    await startComposition("d")
+    await updateComposition("de")
+    await endComposition("def")
+
+    assert.textAttributes([ 0, 3 ], {})
+    assert.textAttributes([ 3, 6 ], { bold: true })
+    expectDocument("abcdef\n")
+  })
+
+  test("composing away from formatted text", async () => {
+    await clickToolbarButton({ attribute: "bold" })
+    await typeCharacters("abc")
+    await clickToolbarButton({ attribute: "bold" })
+    await startComposition("d")
+    await updateComposition("de")
+    await endComposition("def")
+
+    assert.textAttributes([ 0, 3 ], { bold: true })
+    assert.textAttributes([ 3, 6 ], {})
+    expectDocument("abcdef\n")
+  })
+
+  test("composing another language using a QWERTY keyboard", async () => {
     const element = getEditorElement()
     const keyCodes = { x: 120, i: 105 }
 
     triggerEvent(element, "keypress", { charCode: keyCodes.x, keyCode: keyCodes.x, which: keyCodes.x })
-    startComposition("x", () => {
-      triggerEvent(element, "keypress", { charCode: keyCodes.i, keyCode: keyCodes.i, which: keyCodes.i })
-      updateComposition("xi", () => endComposition("喜", () => expectDocument("喜\n")))
-    })
+    await startComposition("x")
+    triggerEvent(element, "keypress", { charCode: keyCodes.i, keyCode: keyCodes.i, which: keyCodes.i })
+    await updateComposition("xi")
+    await endComposition("喜")
+
+    expectDocument("喜\n")
   })
 
   // Simulates the sequence of events when pressing backspace through a word on Android
-  testIf(config.input.getLevel() === 0, "backspacing through a composition", (expectDocument) => {
+  testIf(config.input.getLevel() === 0, "backspacing through a composition", async () => {
     const element = getEditorElement()
     element.editor.insertString("a cat")
 
     triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
     triggerEvent(element, "compositionupdate", { data: "ca" })
     triggerEvent(element, "input")
-    removeCharacters(-1, () => {
-      triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
-      triggerEvent(element, "compositionupdate", { data: "c" })
-      triggerEvent(element, "input")
-      triggerEvent(element, "compositionend", { data: "c" })
-      removeCharacters(-1, () => pressKey("backspace", () => expectDocument("a \n")))
-    })
+    await removeCharacters(-1)
+
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
+    triggerEvent(element, "compositionupdate", { data: "c" })
+    triggerEvent(element, "input")
+    triggerEvent(element, "compositionend", { data: "c" })
+    await removeCharacters(-1)
+    await pressKey("backspace")
+
+    expectDocument("a \n")
   })
 
   // Simulates the sequence of events when pressing backspace at the end of a
   // word and updating it on Android (running older versions of System WebView)
-  testIf(config.input.getLevel() === 0, "updating a composition", (expectDocument) => {
+  testIf(config.input.getLevel() === 0, "updating a composition", async () => {
     const element = getEditorElement()
     element.editor.insertString("cat")
 
@@ -117,17 +122,19 @@ testGroup("Composition input", { template: "editor_empty" }, () => {
     triggerEvent(element, "compositionstart", { data: "cat" })
     triggerEvent(element, "compositionupdate", { data: "cat" })
     triggerEvent(element, "input")
-    removeCharacters(-1, () => {
-      triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
-      triggerEvent(element, "compositionupdate", { data: "car" })
-      triggerEvent(element, "input")
-      triggerEvent(element, "compositionend", { data: "car" })
-      insertNode(document.createTextNode("r"), () => expectDocument("car\n"))
-    })
+    await removeCharacters(-1)
+
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
+    triggerEvent(element, "compositionupdate", { data: "car" })
+    triggerEvent(element, "input")
+    triggerEvent(element, "compositionend", { data: "car" })
+    await insertNode(document.createTextNode("r"))
+
+    expectDocument("car\n")
   })
 
   // Simulates the sequence of events when typing on Android and then tapping elsewhere
-  testIf(config.input.getLevel() === 0, "leaving a composition", (expectDocument) => {
+  testIf(config.input.getLevel() === 0, "leaving a composition", async () => {
     const element = getEditorElement()
 
     triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
@@ -138,44 +145,50 @@ testGroup("Composition input", { template: "editor_empty" }, () => {
     const node = document.createTextNode("c")
     insertNode(node)
     selectNode(node)
-    defer(() => {
-      triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
-      triggerInputEvent(element, "beforeinput", { inputType: "insertCompositionText", data: "ca" })
-      triggerEvent(element, "compositionupdate", { data: "ca" })
-      triggerEvent(element, "input")
-      node.data = "ca"
-      defer(() => {
-        triggerEvent(element, "compositionend", { data: "" })
-        defer(() => expectDocument("ca\n"))
-      })
-    })
+
+    await nextFrame()
+
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
+    triggerInputEvent(element, "beforeinput", { inputType: "insertCompositionText", data: "ca" })
+    triggerEvent(element, "compositionupdate", { data: "ca" })
+    triggerEvent(element, "input")
+    node.data = "ca"
+
+    await nextFrame()
+    triggerEvent(element, "compositionend", { data: "" })
+
+    await nextFrame()
+    expectDocument("ca\n")
   })
 
-  testIf(config.browser.composesExistingText, "composition events from cursor movement are ignored", (expectDocument) => {
+  testIf(config.browser.composesExistingText, "composition events from cursor movement are ignored", async () => {
     const element = getEditorElement()
     element.editor.insertString("ab ")
 
     element.editor.setSelectedRange(0)
     triggerEvent(element, "compositionstart", { data: "" })
     triggerEvent(element, "compositionupdate", { data: "ab" })
-    defer(() => {
-      element.editor.setSelectedRange(1)
-      triggerEvent(element, "compositionupdate", { data: "ab" })
-      defer(() => {
-        element.editor.setSelectedRange(2)
-        triggerEvent(element, "compositionupdate", { data: "ab" })
-        defer(() => {
-          element.editor.setSelectedRange(3)
-          triggerEvent(element, "compositionend", { data: "ab" })
-          defer(() => expectDocument("ab \n"))
-        })
-      })
-    })
+
+    await nextFrame()
+    element.editor.setSelectedRange(1)
+    triggerEvent(element, "compositionupdate", { data: "ab" })
+
+    await nextFrame()
+
+    element.editor.setSelectedRange(2)
+    triggerEvent(element, "compositionupdate", { data: "ab" })
+
+    await nextFrame()
+    element.editor.setSelectedRange(3)
+    triggerEvent(element, "compositionend", { data: "ab" })
+
+    await nextFrame()
+    expectDocument("ab \n")
   })
 
   // Simulates compositions in Firefox where the final composition data is
   // dispatched as both compositionupdate and compositionend.
-  testIf(config.input.getLevel() === 0, "composition ending with same data as last update", (expectDocument) => {
+  testIf(config.input.getLevel() === 0, "composition ending with same data as last update", async () => {
     const element = getEditorElement()
 
     triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
@@ -184,32 +197,34 @@ testGroup("Composition input", { template: "editor_empty" }, () => {
     const node = document.createTextNode("´")
     insertNode(node)
     selectNode(node)
-    defer(() => {
-      triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
-      triggerEvent(element, "compositionupdate", { data: "é" })
-      triggerEvent(element, "input")
-      node.data = "é"
-      defer(() => {
-        triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
-        triggerEvent(element, "compositionupdate", { data: "éé" })
-        triggerEvent(element, "input")
-        node.data = "éé"
-        defer(() => {
-          triggerEvent(element, "compositionend", { data: "éé" })
-          defer(() => {
-            assert.locationRange({ index: 0, offset: 2 })
-            expectDocument("éé\n")
-          })
-        })
-      })
-    })
+
+    await nextFrame()
+
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
+    triggerEvent(element, "compositionupdate", { data: "é" })
+    triggerEvent(element, "input")
+    node.data = "é"
+
+    await nextFrame()
+
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 229, which: 229 })
+    triggerEvent(element, "compositionupdate", { data: "éé" })
+    triggerEvent(element, "input")
+    node.data = "éé"
+
+    await nextFrame()
+    triggerEvent(element, "compositionend", { data: "éé" })
+
+    await nextFrame()
+    assert.locationRange({ index: 0, offset: 2 })
+    expectDocument("éé\n")
   })
 })
 
-const removeCharacters = function (direction, callback) {
+const removeCharacters = async (direction) => {
   const selection = rangy.getSelection()
   const range = selection.getRangeAt(0)
   range.moveStart("character", direction)
   range.deleteContents()
-  defer(callback)
+  await nextFrame()
 }

--- a/src/test/system/cursor_movement_test.js
+++ b/src/test/system/cursor_movement_test.js
@@ -10,73 +10,69 @@ import {
 } from "test/test_helper"
 
 testGroup("Cursor movement", { template: "editor_empty" }, () => {
-  test("move cursor around attachment", (done) => {
+  test("move cursor around attachment", async () => {
     insertFile(createFile())
     assert.locationRange({ index: 0, offset: 1 })
-    moveCursor("left", () => {
-      assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 1 })
-      moveCursor("left", () => {
-        assert.locationRange({ index: 0, offset: 0 })
-        moveCursor("right", () => {
-          assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 1 })
-          moveCursor("right", () => {
-            assert.locationRange({ index: 0, offset: 1 })
-            done()
-          })
-        })
-      })
-    })
+
+    await moveCursor("left")
+    assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 1 })
+
+    await moveCursor("left")
+    assert.locationRange({ index: 0, offset: 0 })
+
+    await moveCursor("right")
+    assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 1 })
+
+    await moveCursor("right")
+    assert.locationRange({ index: 0, offset: 1 })
   })
 
-  test("move cursor around attachment and text", (done) => {
+  test("move cursor around attachment and text", async () => {
     insertString("a")
     insertFile(createFile())
     insertString("b")
     assert.locationRange({ index: 0, offset: 3 })
-    moveCursor("left", () => {
-      assert.locationRange({ index: 0, offset: 2 })
-      moveCursor("left", () => {
-        assert.locationRange({ index: 0, offset: 1 }, { index: 0, offset: 2 })
-        moveCursor("left", () => {
-          assert.locationRange({ index: 0, offset: 1 })
-          moveCursor("left", () => {
-            assert.locationRange({ index: 0, offset: 0 })
-            done()
-          })
-        })
-      })
-    })
+
+    await moveCursor("left")
+    assert.locationRange({ index: 0, offset: 2 })
+
+    await moveCursor("left")
+    assert.locationRange({ index: 0, offset: 1 }, { index: 0, offset: 2 })
+
+    await moveCursor("left")
+    assert.locationRange({ index: 0, offset: 1 })
+
+    await moveCursor("left")
+    assert.locationRange({ index: 0, offset: 0 })
   })
 
-  test("expand selection over attachment", (done) => {
+  test("expand selection over attachment", async () => {
     insertFile(createFile())
     assert.locationRange({ index: 0, offset: 1 })
-    expandSelection("left", () => {
-      assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 1 })
-      moveCursor("left", () => {
-        assert.locationRange({ index: 0, offset: 0 })
-        expandSelection("right", () => {
-          assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 1 })
-          done()
-        })
-      })
-    })
+
+    await expandSelection("left")
+    assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 1 })
+
+    await moveCursor("left")
+    assert.locationRange({ index: 0, offset: 0 })
+
+    await expandSelection("right")
+    assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 1 })
   })
 
-  test("expand selection over attachment and text", (done) => {
+  test("expand selection over attachment and text", async () => {
     insertString("a")
     insertFile(createFile())
     insertString("b")
     assert.locationRange({ index: 0, offset: 3 })
-    expandSelection("left", () => {
-      assert.locationRange({ index: 0, offset: 2 }, { index: 0, offset: 3 })
-      expandSelection("left", () => {
-        assert.locationRange({ index: 0, offset: 1 }, { index: 0, offset: 3 })
-        expandSelection("left", () => {
-          assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 3 })
-          done()
-        })
-      })
-    })
+
+    await expandSelection("left")
+    assert.locationRange({ index: 0, offset: 2 }, { index: 0, offset: 3 })
+
+    await expandSelection("left")
+    assert.locationRange({ index: 0, offset: 1 }, { index: 0, offset: 3 })
+
+    await expandSelection("left")
+    assert.locationRange({ index: 0, offset: 0 }, { index: 0, offset: 3 })
   })
 })

--- a/src/test/system/custom_element_test.js
+++ b/src/test/system/custom_element_test.js
@@ -372,7 +372,7 @@ testGroup("Custom element API", { template: "editor_empty" }, () => {
 
   // Selenium doesn't seem to focus windows properly in some browsers (FF 47 on OS X)
   // so skip this test when unfocused pending a better solution.
-  testIf(document.hasFocus(), "element triggers custom focus event when autofocusing", (done) => {
+  testIf(document.hasFocus(), "element triggers custom focus event when autofocusing", () => {
     const element = document.createElement("trix-editor")
     element.setAttribute("autofocus", "")
 
@@ -383,9 +383,11 @@ testGroup("Custom element API", { template: "editor_empty" }, () => {
     container.innerHTML = ""
     container.appendChild(element)
 
-    element.addEventListener("trix-initialize", () => {
-      assert.equal(focusEventCount, 1)
-      done()
+    return new Promise((resolve) => {
+      element.addEventListener("trix-initialize", () => {
+        assert.equal(focusEventCount, 1)
+        resolve()
+      })
     })
   })
 

--- a/src/test/system/custom_element_test.js
+++ b/src/test/system/custom_element_test.js
@@ -345,27 +345,24 @@ testGroup("Custom element API", { template: "editor_empty" }, () => {
     element.addEventListener("trix-blur", () => blurEventCount++)
 
     triggerEvent(element, "blur")
-    await nextFrame()
+    await delay(10)
 
     assert.equal(blurEventCount, 1)
     assert.equal(focusEventCount, 0)
 
     triggerEvent(element, "focus")
-
-    await nextFrame()
+    await delay(10)
 
     assert.equal(blurEventCount, 1)
     assert.equal(focusEventCount, 1)
 
     insertImageAttachment()
-
     await delay(20)
 
     await clickElement(element.querySelector("figure"))
 
     const textarea = element.querySelector("textarea")
     textarea.focus()
-
     await nextFrame()
 
     assert.equal(document.activeElement, textarea)

--- a/src/test/system/html_loading_test.js
+++ b/src/test/system/html_loading_test.js
@@ -1,5 +1,6 @@
-import { TEST_IMAGE_URL, after, assert, test, testGroup } from "test/test_helper"
+import { TEST_IMAGE_URL, assert, expectDocument, test, testGroup } from "test/test_helper"
 import { OBJECT_REPLACEMENT_CHARACTER } from "trix/constants"
+import { delay } from "../test_helpers/timing_helpers"
 
 testGroup("HTML loading", () => {
   testGroup("inline elements", { template: "editor_with_styled_content" }, () => {
@@ -17,7 +18,7 @@ testGroup("HTML loading", () => {
 
     for (const name in cases) {
       const details = cases[name]
-      test(name, (expectDocument) => {
+      test(name, () => {
         getEditor().loadHTML(details.html)
         expectDocument(details.expectedDocument)
       })
@@ -25,19 +26,19 @@ testGroup("HTML loading", () => {
   })
 
   testGroup("bold elements", { template: "editor_with_bold_styles" }, () => {
-    test("<strong> with font-weight: 500", (expectDocument) => {
+    test("<strong> with font-weight: 500", () => {
       getEditor().loadHTML("<strong>a</strong>")
       assert.textAttributes([ 0, 1 ], { bold: true })
       expectDocument("a\n")
     })
 
-    test("<span> with font-weight: 600", (expectDocument) => {
+    test("<span> with font-weight: 600", () => {
       getEditor().loadHTML("<span>a</span>")
       assert.textAttributes([ 0, 1 ], { bold: true })
       expectDocument("a\n")
     })
 
-    test("<article> with font-weight: bold", (expectDocument) => {
+    test("<article> with font-weight: bold", () => {
       getEditor().loadHTML("<article>a</article>")
       assert.textAttributes([ 0, 1 ], { bold: true })
       expectDocument("a\n")
@@ -45,7 +46,7 @@ testGroup("HTML loading", () => {
   })
 
   testGroup("styled block elements", { template: "editor_with_block_styles" }, () => {
-    test("<em> in <blockquote> with font-style: italic", (expectDocument) => {
+    test("<em> in <blockquote> with font-style: italic", () => {
       getEditor().loadHTML("<blockquote>a<em>b</em></blockquote>")
       assert.textAttributes([ 0, 1 ], {})
       assert.textAttributes([ 1, 2 ], { italic: true })
@@ -53,7 +54,7 @@ testGroup("HTML loading", () => {
       expectDocument("ab\n")
     })
 
-    test("<strong> in <li> with font-weight: bold", (expectDocument) => {
+    test("<strong> in <li> with font-weight: bold", () => {
       getEditor().loadHTML("<ul><li>a<strong>b</strong></li></ul>")
       assert.textAttributes([ 0, 1 ], {})
       assert.textAttributes([ 1, 2 ], { bold: true })
@@ -61,7 +62,7 @@ testGroup("HTML loading", () => {
       expectDocument("ab\n")
     })
 
-    test("newline in <li> with font-weight: bold", (expectDocument) => {
+    test("newline in <li> with font-weight: bold", () => {
       getEditor().loadHTML("<ul><li>a<br>b</li></ul>")
       assert.textAttributes([ 0, 2 ], {})
       assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
@@ -70,7 +71,7 @@ testGroup("HTML loading", () => {
   })
 
   testGroup("in a table", { template: "editor_in_table" }, () => {
-    test("block elements", (expectDocument) => {
+    test("block elements", () => {
       getEditor().loadHTML("<h1>a</h1><blockquote>b</blockquote>")
       assert.blockAttributes([ 0, 2 ], [ "heading1" ])
       assert.blockAttributes([ 2, 4 ], [ "quote" ])
@@ -79,35 +80,35 @@ testGroup("HTML loading", () => {
   })
 
   testGroup("images", { template: "editor_empty" }, () => {
-    test("without dimensions", (expectDocument) => {
+    test("without dimensions", async () => {
       getEditor().loadHTML(`<img src="${TEST_IMAGE_URL}">`)
-      after(50, () => {
-        const attachment = getDocument().getAttachments()[0]
-        const image = getEditorElement().querySelector("img")
-        assert.equal(attachment.getWidth(), 1)
-        assert.equal(attachment.getHeight(), 1)
-        assert.equal(image.getAttribute("width"), "1")
-        assert.equal(image.getAttribute("height"), "1")
-        expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
-      })
+      await delay(50)
+
+      const attachment = getDocument().getAttachments()[0]
+      const image = getEditorElement().querySelector("img")
+      assert.equal(attachment.getWidth(), 1)
+      assert.equal(attachment.getHeight(), 1)
+      assert.equal(image.getAttribute("width"), "1")
+      assert.equal(image.getAttribute("height"), "1")
+      expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
     })
 
-    test("with dimensions", (expectDocument) => {
+    test("with dimensions", async () => {
       getEditor().loadHTML(`<img src="${TEST_IMAGE_URL}" width="10" height="20">`)
-      after(50, () => {
-        const attachment = getDocument().getAttachments()[0]
-        const image = getEditorElement().querySelector("img")
-        assert.equal(attachment.getWidth(), 10)
-        assert.equal(attachment.getHeight(), 20)
-        assert.equal(image.getAttribute("width"), "10")
-        assert.equal(image.getAttribute("height"), "20")
-        expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
-      })
+      await delay(50)
+
+      const attachment = getDocument().getAttachments()[0]
+      const image = getEditorElement().querySelector("img")
+      assert.equal(attachment.getWidth(), 10)
+      assert.equal(attachment.getHeight(), 20)
+      assert.equal(image.getAttribute("width"), "10")
+      assert.equal(image.getAttribute("height"), "20")
+      expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
     })
   })
 
   testGroup("text after closing tag", { template: "editor_empty" }, () => {
-    test("parses text as separate block", (expectDocument) => {
+    test("parses text as separate block", () => {
       getEditor().loadHTML("<h1>a</h1>b")
       assert.blockAttributes([ 0, 2 ], [ "heading1" ])
       assert.blockAttributes([ 2, 4 ], [])

--- a/src/test/system/html_reparsing_test.js
+++ b/src/test/system/html_reparsing_test.js
@@ -1,31 +1,28 @@
-import { assert, test, testGroup } from "test/test_helper"
+import { assert, expectDocument, test, testGroup } from "test/test_helper"
+import { nextFrame } from "../test_helpers/timing_helpers"
 
 testGroup("HTML Reparsing", { template: "editor_empty" }, () => {
-  test("mutation resulting in identical blocks", (expectDocument) => {
+  test("mutation resulting in identical blocks", async () => {
     const element = getEditorElement()
     element.editor.loadHTML("<ul><li>a</li><li>b</li></ul>")
-    requestAnimationFrame(() => {
-      element.querySelector("li").textContent = "b"
-      requestAnimationFrame(() => {
-        assert.blockAttributes([ 0, 1 ], [ "bulletList", "bullet" ])
-        assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet" ])
-        assert.equal(element.value, "<ul><li>b</li><li>b</li></ul>")
-        expectDocument("b\nb\n")
-      })
-    })
+    await nextFrame()
+    element.querySelector("li").textContent = "b"
+    await nextFrame()
+    assert.blockAttributes([ 0, 1 ], [ "bulletList", "bullet" ])
+    assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet" ])
+    assert.equal(element.value, "<ul><li>b</li><li>b</li></ul>")
+    expectDocument("b\nb\n")
   })
 
-  test("mutation resulting in identical pieces", (expectDocument) => {
+  test("mutation resulting in identical pieces", async () => {
     const element = getEditorElement()
     element.editor.loadHTML("<div><strong>a</strong> <strong>b</strong></div>")
-    requestAnimationFrame(() => {
-      element.querySelector("strong").textContent = "b"
-      requestAnimationFrame(() => {
-        assert.textAttributes([ 0, 1 ], { bold: true })
-        assert.textAttributes([ 2, 3 ], { bold: true })
-        assert.equal(element.value, "<div><strong>b</strong> <strong>b</strong></div>")
-        expectDocument("b b\n")
-      })
-    })
+    await nextFrame()
+    element.querySelector("strong").textContent = "b"
+    await nextFrame()
+    assert.textAttributes([ 0, 1 ], { bold: true })
+    assert.textAttributes([ 2, 3 ], { bold: true })
+    assert.equal(element.value, "<div><strong>b</strong> <strong>b</strong></div>")
+    expectDocument("b b\n")
   })
 })

--- a/src/test/system/html_replacement_test.js
+++ b/src/test/system/html_replacement_test.js
@@ -1,6 +1,7 @@
 import * as config from "trix/config"
 
-import { assert, testGroup, testIf, triggerEvent } from "test/test_helper"
+import { assert, expectDocument, testGroup, testIf, triggerEvent } from "test/test_helper"
+import { nextFrame } from "../test_helpers/timing_helpers"
 
 const test = function() {
   testIf(config.input.getLevel() === 0, ...arguments)
@@ -8,84 +9,77 @@ const test = function() {
 
 testGroup("Level 0 input: HTML replacement", () =>
   testGroup("deleting with command+backspace", { template: "editor_empty" }, () => {
-    test("from the end of a line", function (expectDocument) {
+    test("from the end of a line", async () => {
       getEditor().loadHTML("<div>a</div><blockquote>b</blockquote><div>c</div>")
       getSelectionManager().setLocationRange({ index: 1, offset: 1 })
-      pressCommandBackspace({ replaceText: "b" }, () => {
-        assert.locationRange({ index: 1, offset: 0 })
-        assert.blockAttributes([ 0, 2 ], [])
-        assert.blockAttributes([ 2, 3 ], [ "quote" ])
-        assert.blockAttributes([ 3, 5 ], [])
-        expectDocument("a\n\nc\n")
-      })
+      await pressCommandBackspace({ replaceText: "b" })
+      assert.locationRange({ index: 1, offset: 0 })
+      assert.blockAttributes([ 0, 2 ], [])
+      assert.blockAttributes([ 2, 3 ], [ "quote" ])
+      assert.blockAttributes([ 3, 5 ], [])
+      expectDocument("a\n\nc\n")
     })
 
-    test("in the first block", function (expectDocument) {
+    test("in the first block", async () => {
       getEditor().loadHTML("<div>a</div><blockquote>b</blockquote>")
       getSelectionManager().setLocationRange({ index: 0, offset: 1 })
-      pressCommandBackspace({ replaceText: "a" }, () => {
-        assert.locationRange({ index: 0, offset: 0 })
-        assert.blockAttributes([ 0, 1 ], [])
-        assert.blockAttributes([ 1, 3 ], [ "quote" ])
-        expectDocument("\nb\n")
-      })
+      await pressCommandBackspace({ replaceText: "a" })
+      assert.locationRange({ index: 0, offset: 0 })
+      assert.blockAttributes([ 0, 1 ], [])
+      assert.blockAttributes([ 1, 3 ], [ "quote" ])
+      expectDocument("\nb\n")
     })
 
-    test("from the middle of a line", function (expectDocument) {
+    test("from the middle of a line", async () => {
       getEditor().loadHTML("<div>a</div><blockquote>bc</blockquote><div>d</div>")
       getSelectionManager().setLocationRange({ index: 1, offset: 1 })
-      pressCommandBackspace({ replaceText: "b" }, () => {
-        assert.locationRange({ index: 1, offset: 0 })
-        assert.blockAttributes([ 0, 2 ], [])
-        assert.blockAttributes([ 2, 4 ], [ "quote" ])
-        assert.blockAttributes([ 4, 6 ], [])
-        expectDocument("a\nc\nd\n")
-      })
+      await pressCommandBackspace({ replaceText: "b" })
+      assert.locationRange({ index: 1, offset: 0 })
+      assert.blockAttributes([ 0, 2 ], [])
+      assert.blockAttributes([ 2, 4 ], [ "quote" ])
+      assert.blockAttributes([ 4, 6 ], [])
+      expectDocument("a\nc\nd\n")
     })
 
-    test("from the middle of a line in a multi-line block", function (expectDocument) {
+    test("from the middle of a line in a multi-line block", async () => {
       getEditor().loadHTML("<div>a</div><blockquote>bc<br>d</blockquote><div>e</div>")
       getSelectionManager().setLocationRange({ index: 1, offset: 1 })
-      pressCommandBackspace({ replaceText: "b" }, () => {
-        assert.locationRange({ index: 1, offset: 0 })
-        assert.blockAttributes([ 0, 2 ], [])
-        assert.blockAttributes([ 2, 6 ], [ "quote" ])
-        expectDocument("a\nc\nd\ne\n")
-      })
+      await pressCommandBackspace({ replaceText: "b" })
+      assert.locationRange({ index: 1, offset: 0 })
+      assert.blockAttributes([ 0, 2 ], [])
+      assert.blockAttributes([ 2, 6 ], [ "quote" ])
+      expectDocument("a\nc\nd\ne\n")
     })
 
-    test("from the end of a list item", function (expectDocument) {
+    test("from the end of a list item", async () => {
       getEditor().loadHTML("<ul><li>a</li><li>b</li></ul>")
       getSelectionManager().setLocationRange({ index: 1, offset: 1 })
-      pressCommandBackspace({ replaceText: "b" }, () => {
-        assert.locationRange({ index: 1, offset: 0 })
-        assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
-        assert.blockAttributes([ 2, 4 ], [ "bulletList", "bullet" ])
-        expectDocument("a\n\n")
-      })
+      await pressCommandBackspace({ replaceText: "b" })
+      assert.locationRange({ index: 1, offset: 0 })
+      assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
+      assert.blockAttributes([ 2, 4 ], [ "bulletList", "bullet" ])
+      expectDocument("a\n\n")
     })
 
-    test("a character that is its text node's only data", function (expectDocument) {
+    test("a character that is its text node's only data", async () => {
       getEditor().loadHTML("<div>a<br>b<br><strong>c</strong></div>")
       getSelectionManager().setLocationRange({ index: 0, offset: 3 })
-      pressCommandBackspace({ replaceText: "b" }, () => {
-        assert.locationRange({ index: 0, offset: 2 })
-        expectDocument("a\n\nc\n")
-      })
+      await pressCommandBackspace({ replaceText: "b" })
+      assert.locationRange({ index: 0, offset: 2 })
+      expectDocument("a\n\nc\n")
     })
 
-    test("a formatted word", function (expectDocument) {
+    test("a formatted word", async () => {
       getEditor().loadHTML("<div>a<strong>bc</strong></div>")
       getSelectionManager().setLocationRange({ index: 0, offset: 4 })
-      pressCommandBackspace({ replaceElementWithText: "bc" }, () => {
-        assert.locationRange({ index: 0, offset: 1 })
-        expectDocument("a\n")
-      })
+      await pressCommandBackspace({ replaceElementWithText: "bc" })
+      assert.locationRange({ index: 0, offset: 1 })
+      expectDocument("a\n")
     })
   })
 )
 
-const pressCommandBackspace = function ({ replaceText, replaceElementWithText }, callback) {
+const pressCommandBackspace = async ({ replaceText, replaceElementWithText }) => {
   let previousSibling
   triggerEvent(document.activeElement, "keydown", { charCode: 0, keyCode: 8, which: 8, metaKey: true })
   const range = rangy.getSelection().getRangeAt(0)
@@ -118,7 +112,7 @@ const pressCommandBackspace = function ({ replaceText, replaceElementWithText },
   }
 
   range.select()
-  requestAnimationFrame(callback)
+  await nextFrame()
 }
 
 const getElementWithText = function (text) {

--- a/src/test/system/installation_process_test.js
+++ b/src/test/system/installation_process_test.js
@@ -1,6 +1,7 @@
 import EditorController from "trix/controllers/editor_controller"
 
-import { assert, defer, test, testGroup } from "test/test_helper"
+import { assert, test, testGroup } from "test/test_helper"
+import { nextFrame } from "../test_helpers/timing_helpers"
 
 testGroup("Installation process", { template: "editor_html" }, () => {
   test("element.editorController", () => {
@@ -13,15 +14,14 @@ testGroup("Installation process", { template: "editor_html" }, () => {
     assert.equal(getEditorElement().textContent, "Hello world")
   })
 
-  test("sets value property", (done) =>
-    defer(() => {
-      assert.equal(getEditorElement().value, "<div>Hello world</div>")
-      done()
-    }))
+  test("sets value property", async () => {
+    await nextFrame()
+    assert.equal(getEditorElement().value, "<div>Hello world</div>")
+  })
 })
 
 testGroup("Installation process without specified elements", { template: "editor_empty" }, () =>
-  test("creates identified toolbar and input elements", (done) => {
+  test("creates identified toolbar and input elements", () => {
     const editorElement = getEditorElement()
 
     const toolbarId = editorElement.getAttribute("toolbar")
@@ -35,21 +35,18 @@ testGroup("Installation process without specified elements", { template: "editor
     const inputElement = document.getElementById(inputId)
     assert.ok(inputElement, "input element not assert.ok")
     assert.equal(editorElement.inputElement, inputElement)
-
-    done()
   })
 )
 
 testGroup("Installation process with specified elements", { template: "editor_with_toolbar_and_input" }, () => {
-  test("uses specified elements", (done) => {
+  test("uses specified elements", () => {
     const editorElement = getEditorElement()
     assert.equal(editorElement.toolbarElement, document.getElementById("my_toolbar"))
     assert.equal(editorElement.inputElement, document.getElementById("my_input"))
     assert.equal(editorElement.value, "<div>Hello world</div>")
-    done()
   })
 
-  test("can be cloned", (done) => {
+  test("can be cloned", async () => {
     const originalElement = document.getElementById("my_editor")
     const clonedElement = originalElement.cloneNode(true)
 
@@ -57,12 +54,11 @@ testGroup("Installation process with specified elements", { template: "editor_wi
     parentElement.removeChild(originalElement)
     parentElement.appendChild(clonedElement)
 
-    defer(() => {
-      const editorElement = getEditorElement()
-      assert.equal(editorElement.toolbarElement, document.getElementById("my_toolbar"))
-      assert.equal(editorElement.inputElement, document.getElementById("my_input"))
-      assert.equal(editorElement.value, "<div>Hello world</div>")
-      done()
-    })
+    await nextFrame()
+
+    const editorElement = getEditorElement()
+    assert.equal(editorElement.toolbarElement, document.getElementById("my_toolbar"))
+    assert.equal(editorElement.inputElement, document.getElementById("my_input"))
+    assert.equal(editorElement.value, "<div>Hello world</div>")
   })
 })

--- a/src/test/system/level_2_input_test.js
+++ b/src/test/system/level_2_input_test.js
@@ -2,9 +2,9 @@ import * as config from "trix/config"
 import { OBJECT_REPLACEMENT_CHARACTER } from "trix/constants"
 
 import {
-  after,
   assert,
   clickToolbarButton,
+  expectDocument,
   insertNode,
   insertString,
   isToolbarButtonActive,
@@ -15,6 +15,7 @@ import {
   triggerInputEvent,
   typeCharacters,
 } from "test/test_helper"
+import { delay, nextFrame } from "../test_helpers/timing_helpers"
 
 const test = function() {
   testIf(config.input.getLevel() === 2, ...arguments)
@@ -46,222 +47,219 @@ const recordInputEvent = function (event) {
 }
 
 // Borrowed from https://github.com/web-platform-tests/wpt/blob/master/input-events/input-events-exec-command.html
-const performInputTypeUsingExecCommand = function (command, { inputType, data }, callback) {
+const performInputTypeUsingExecCommand = async (command, { inputType, data }) => {
   inputEvents = []
-  requestAnimationFrame(() => {
-    triggerInputEvent(document.activeElement, "beforeinput", { inputType, data })
-    document.execCommand(command, false, data)
-    assert.equal(inputEvents.length, 2)
-    assert.equal(inputEvents[0].type, "beforeinput")
-    assert.equal(inputEvents[1].type, "input")
-    assert.equal(inputEvents[0].inputType, inputType)
-    assert.equal(inputEvents[0].data, data)
-    requestAnimationFrame(() => requestAnimationFrame(callback))
-  })
+
+  await nextFrame()
+
+  triggerInputEvent(document.activeElement, "beforeinput", { inputType, data })
+  document.execCommand(command, false, data)
+  assert.equal(inputEvents.length, 2)
+  assert.equal(inputEvents[0].type, "beforeinput")
+  assert.equal(inputEvents[1].type, "input")
+  assert.equal(inputEvents[0].inputType, inputType)
+  assert.equal(inputEvents[0].data, data)
+
+  await nextFrame()
+  await nextFrame()
 }
 
 testGroup("Level 2 Input", testOptions, () => {
-  test("insertText", (expectDocument) =>
-    performInputTypeUsingExecCommand("insertText", { inputType: "insertText", data: "abc" }, () =>
-      expectDocument("abc\n")
-    ))
+  test("insertText", async () => {
+    await performInputTypeUsingExecCommand("insertText", { inputType: "insertText", data: "abc" })
+    expectDocument("abc\n")
+  })
 
-  test("insertOrderedList", (expectDocument) => {
+  test("insertOrderedList", async () => {
     insertString("a\nb")
-    performInputTypeUsingExecCommand("insertOrderedList", { inputType: "insertOrderedList" }, () => {
-      assert.blockAttributes([ 0, 2 ], [])
-      assert.blockAttributes([ 2, 4 ], [ "numberList", "number" ])
-      assert.ok(isToolbarButtonActive({ attribute: "number" }))
-      expectDocument("a\nb\n")
-    })
+    await performInputTypeUsingExecCommand("insertOrderedList", { inputType: "insertOrderedList" })
+    assert.blockAttributes([ 0, 2 ], [])
+    assert.blockAttributes([ 2, 4 ], [ "numberList", "number" ])
+    assert.ok(isToolbarButtonActive({ attribute: "number" }))
+    expectDocument("a\nb\n")
   })
 
-  test("insertUnorderedList", (expectDocument) => {
+  test("insertUnorderedList", async () => {
     insertString("a\nb")
-    performInputTypeUsingExecCommand("insertUnorderedList", { inputType: "insertUnorderedList" }, () => {
-      assert.blockAttributes([ 0, 2 ], [])
-      assert.blockAttributes([ 2, 4 ], [ "bulletList", "bullet" ])
-      assert.ok(isToolbarButtonActive({ attribute: "bullet" }))
-      expectDocument("a\nb\n")
-    })
+    await performInputTypeUsingExecCommand("insertUnorderedList", { inputType: "insertUnorderedList" })
+    assert.blockAttributes([ 0, 2 ], [])
+    assert.blockAttributes([ 2, 4 ], [ "bulletList", "bullet" ])
+    assert.ok(isToolbarButtonActive({ attribute: "bullet" }))
+    expectDocument("a\nb\n")
   })
 
-  test("insertLineBreak", (expectDocument) => {
-    clickToolbarButton({ attribute: "quote" }, () => {
-      insertString("abc")
-      performInputTypeUsingExecCommand("insertLineBreak", { inputType: "insertLineBreak" }, () => {
-        performInputTypeUsingExecCommand("insertLineBreak", { inputType: "insertLineBreak" }, () => {
-          assert.blockAttributes([ 0, 6 ], [ "quote" ])
-          expectDocument("abc\n\n\n")
-        })
-      })
-    })
+  test("insertLineBreak", async () => {
+    await clickToolbarButton({ attribute: "quote" })
+    insertString("abc")
+    await performInputTypeUsingExecCommand("insertLineBreak", { inputType: "insertLineBreak" })
+    await performInputTypeUsingExecCommand("insertLineBreak", { inputType: "insertLineBreak" })
+    assert.blockAttributes([ 0, 6 ], [ "quote" ])
+    expectDocument("abc\n\n\n")
   })
 
-  test("insertParagraph", (expectDocument) => {
-    clickToolbarButton({ attribute: "quote" }, () => {
-      insertString("abc")
-      performInputTypeUsingExecCommand("insertParagraph", { inputType: "insertParagraph" }, () => {
-        performInputTypeUsingExecCommand("insertParagraph", { inputType: "insertParagraph" }, () => {
-          assert.blockAttributes([ 0, 4 ], [ "quote" ])
-          assert.blockAttributes([ 4, 5 ], [])
-          expectDocument("abc\n\n")
-        })
-      })
-    })
+  test("insertParagraph", async () => {
+    await clickToolbarButton({ attribute: "quote" })
+    insertString("abc")
+    await performInputTypeUsingExecCommand("insertParagraph", { inputType: "insertParagraph" })
+    await performInputTypeUsingExecCommand("insertParagraph", { inputType: "insertParagraph" })
+
+    assert.blockAttributes([ 0, 4 ], [ "quote" ])
+    assert.blockAttributes([ 4, 5 ], [])
+    expectDocument("abc\n\n")
   })
 
-  test("formatBold", (expectDocument) => {
+  test("formatBold", async () => {
     insertString("abc")
     getComposition().setSelectedRange([ 1, 2 ])
-    performInputTypeUsingExecCommand("bold", { inputType: "formatBold" }, () => {
-      assert.textAttributes([ 0, 1 ], {})
-      assert.textAttributes([ 1, 2 ], { bold: true })
-      assert.textAttributes([ 2, 3 ], {})
-      expectDocument("abc\n")
-    })
+    await performInputTypeUsingExecCommand("bold", { inputType: "formatBold" })
+    assert.textAttributes([ 0, 1 ], {})
+    assert.textAttributes([ 1, 2 ], { bold: true })
+    assert.textAttributes([ 2, 3 ], {})
+    expectDocument("abc\n")
   })
 
-  test("formatItalic", (expectDocument) => {
+  test("formatItalic", async () => {
     insertString("abc")
     getComposition().setSelectedRange([ 1, 2 ])
-    performInputTypeUsingExecCommand("italic", { inputType: "formatItalic" }, () => {
-      assert.textAttributes([ 0, 1 ], {})
-      assert.textAttributes([ 1, 2 ], { italic: true })
-      assert.textAttributes([ 2, 3 ], {})
-      expectDocument("abc\n")
-    })
+    await performInputTypeUsingExecCommand("italic", { inputType: "formatItalic" })
+    assert.textAttributes([ 0, 1 ], {})
+    assert.textAttributes([ 1, 2 ], { italic: true })
+    assert.textAttributes([ 2, 3 ], {})
+    expectDocument("abc\n")
   })
 
-  test("formatStrikeThrough", (expectDocument) => {
+  test("formatStrikeThrough", async () => {
     insertString("abc")
     getComposition().setSelectedRange([ 1, 2 ])
-    performInputTypeUsingExecCommand("strikeThrough", { inputType: "formatStrikeThrough" }, () => {
-      assert.textAttributes([ 0, 1 ], {})
-      assert.textAttributes([ 1, 2 ], { strike: true })
-      assert.textAttributes([ 2, 3 ], {})
-      expectDocument("abc\n")
-    })
+    await performInputTypeUsingExecCommand("strikeThrough", { inputType: "formatStrikeThrough" })
+    assert.textAttributes([ 0, 1 ], {})
+    assert.textAttributes([ 1, 2 ], { strike: true })
+    assert.textAttributes([ 2, 3 ], {})
+    expectDocument("abc\n")
   })
 
   // https://input-inspector.now.sh/profiles/hVXS1cHYFvc2EfdRyTWQ
-  test("correcting a misspelled word in Chrome", (expectDocument) => {
+  test("correcting a misspelled word in Chrome", async () => {
     insertString("onr")
     getComposition().setSelectedRange([ 0, 3 ])
-    requestAnimationFrame(() => {
-      const inputType = "insertReplacementText"
-      const dataTransfer = createDataTransfer({ "text/plain": "one" })
-      const event = createEvent("beforeinput", { inputType, dataTransfer })
-      document.activeElement.dispatchEvent(event)
-      requestAnimationFrame(() => expectDocument("one\n"))
-    })
+    await nextFrame()
+
+    const inputType = "insertReplacementText"
+    const dataTransfer = createDataTransfer({ "text/plain": "one" })
+    const event = createEvent("beforeinput", { inputType, dataTransfer })
+    document.activeElement.dispatchEvent(event)
+    await nextFrame()
+    expectDocument("one\n")
   })
 
   // https://input-inspector.now.sh/profiles/XsZVwKtFxakwnsNs0qnX
-  test("correcting a misspelled word in Safari", (expectDocument) => {
+  test("correcting a misspelled word in Safari", async () => {
     insertString("onr")
     getComposition().setSelectedRange([ 0, 3 ])
-    requestAnimationFrame(() => {
-      const inputType = "insertText"
-      const dataTransfer = createDataTransfer({ "text/plain": "one", "text/html": "one" })
-      const event = createEvent("beforeinput", { inputType, dataTransfer })
-      document.activeElement.dispatchEvent(event)
-      requestAnimationFrame(() => expectDocument("one\n"))
-    })
+    await nextFrame()
+
+    const inputType = "insertText"
+    const dataTransfer = createDataTransfer({ "text/plain": "one", "text/html": "one" })
+    const event = createEvent("beforeinput", { inputType, dataTransfer })
+    document.activeElement.dispatchEvent(event)
+
+    await nextFrame()
+    expectDocument("one\n")
   })
 
   // https://input-inspector.now.sh/profiles/yZlsrfG93QMzp2oyr0BE
-  test("deleting the last character in a composed word on Android", (expectDocument) => {
+  test("deleting the last character in a composed word on Android", async () => {
     insertString("c")
     const element = getEditorElement()
     const textNode = element.firstChild.lastChild
-    selectNode(textNode, () => {
-      triggerInputEvent(element, "beforeinput", { inputType: "insertCompositionText", data: "" })
-      triggerEvent(element, "compositionend", { data: "" })
-      requestAnimationFrame(() => expectDocument("\n"))
-    })
+    await selectNode(textNode)
+    triggerInputEvent(element, "beforeinput", { inputType: "insertCompositionText", data: "" })
+    triggerEvent(element, "compositionend", { data: "" })
+    await nextFrame()
+    expectDocument("\n")
   })
 
-  test("pasting a file", (expectDocument) =>
-    createFile((file) => {
-      const clipboardData = createDataTransfer({ Files: [ file ] })
-      const dataTransfer = createDataTransfer({ Files: [ file ] })
-      paste({ clipboardData, dataTransfer }, () => {
-        const attachments = getDocument().getAttachments()
-        assert.equal(attachments.length, 1)
-        assert.equal(attachments[0].getFilename(), file.name)
-        expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
-      })
-    }))
+  test("pasting a file", async () => {
+    const file = await createFile()
+    const clipboardData = createDataTransfer({ Files: [ file ] })
+    const dataTransfer = createDataTransfer({ Files: [ file ] })
+    await paste({ clipboardData, dataTransfer })
+
+    const attachments = getDocument().getAttachments()
+    assert.equal(attachments.length, 1)
+    assert.equal(attachments[0].getFilename(), file.name)
+    expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
+  })
 
   // "insertFromPaste InputEvent missing pasted files in dataTransfer"
   // - https://bugs.webkit.org/show_bug.cgi?id=194921
-  test("pasting a file in Safari", (expectDocument) =>
-    createFile((file) => {
-      const clipboardData = createDataTransfer({ Files: [ file ] })
-      const dataTransfer = createDataTransfer({ "text/html": `<img src="blob:${location.origin}/531de8">` })
-      paste({ clipboardData, dataTransfer }, () => {
-        const attachments = getDocument().getAttachments()
-        assert.equal(attachments.length, 1)
-        assert.equal(attachments[0].getFilename(), file.name)
-        expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
-      })
-    }))
+  test("pasting a file in Safari", async () => {
+    const file = await createFile()
+
+    const clipboardData = createDataTransfer({ Files: [ file ] })
+    const dataTransfer = createDataTransfer({ "text/html": `<img src="blob:${location.origin}/531de8">` })
+
+    await paste({ clipboardData, dataTransfer })
+    const attachments = getDocument().getAttachments()
+    assert.equal(attachments.length, 1)
+    assert.equal(attachments[0].getFilename(), file.name)
+    expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
+  })
 
   // "insertFromPaste InputEvent missing text/uri-list in dataTransfer for pasted links"
   // - https://bugs.webkit.org/show_bug.cgi?id=196702
-  test("pasting a link in Safari", (expectDocument) =>
-    createFile((file) => {
-      const url = "https://bugs.webkit.org"
-      const text = "WebKit Bugzilla"
-      const clipboardData = createDataTransfer({ URL: url, "text/uri-list": url, "text/plain": text })
-      const dataTransfer = createDataTransfer({ "text/html": `<a href="${url}">${text}</a>`, "text/plain": text })
-      paste({ clipboardData, dataTransfer }, () => {
-        assert.textAttributes([ 0, url.length ], { href: url })
-        expectDocument(`${url}\n`)
-      })
-    }))
+  test("pasting a link in Safari", async () => {
+    await createFile()
+    const url = "https://bugs.webkit.org"
+    const text = "WebKit Bugzilla"
+    const clipboardData = createDataTransfer({ URL: url, "text/uri-list": url, "text/plain": text })
+    const dataTransfer = createDataTransfer({ "text/html": `<a href="${url}">${text}</a>`, "text/plain": text })
+    await paste({ clipboardData, dataTransfer })
+    assert.textAttributes([ 0, url.length ], { href: url })
+    expectDocument(`${url}\n`)
+  })
 
   // Pastes from MS Word include an image of the copied text 🙃
   // https://input-inspector.now.sh/profiles/QWDITsV60dpEVl1SOZg8
-  test("pasting text from MS Word", (expectDocument) =>
-    createFile((file) => {
-      const dataTransfer = createDataTransfer({
-        "text/html": "<span class=\"MsoNormal\">abc</span>",
-        "text/plain": "abc",
-        Files: [ file ],
-      })
+  test("pasting text from MS Word", async () => {
+    const file = await createFile()
+    const dataTransfer = createDataTransfer({
+      "text/html": "<span class=\"MsoNormal\">abc</span>",
+      "text/plain": "abc",
+      Files: [ file ],
+    })
 
-      paste({ dataTransfer }, () => {
-        const attachments = getDocument().getAttachments()
-        assert.equal(attachments.length, 0)
-        expectDocument("abc\n")
-      })
-    }))
+    await paste({ dataTransfer })
+    const attachments = getDocument().getAttachments()
+    assert.equal(attachments.length, 0)
+    expectDocument("abc\n")
+  })
 
   // "beforeinput" event is not fired for Paste and Match Style operations
   // - https://bugs.chromium.org/p/chromium/issues/detail?id=934448
-  test("Paste and Match Style in Chrome", (expectDocument) => {
-    const done = () => expectDocument("a\n\nb\n\nc\n")
-    typeCharacters("a\n\n", () => {
-      const clipboardData = createDataTransfer({ "text/plain": "b\n\nc" })
-      const pasteEvent = createEvent("paste", { clipboardData })
-      if (document.activeElement.dispatchEvent(pasteEvent)) {
-        const node = document.createElement("div")
-        node.innerHTML = "<div>b</div><div><br></div><div>c</div>"
-        insertNode(node, done)
-      } else {
-        requestAnimationFrame(done)
-      }
-    })
+  test("Paste and Match Style in Chrome", async () => {
+    await typeCharacters("a\n\n")
+    const clipboardData = createDataTransfer({ "text/plain": "b\n\nc" })
+    const pasteEvent = createEvent("paste", { clipboardData })
+
+    if (document.activeElement.dispatchEvent(pasteEvent)) {
+      const node = document.createElement("div")
+      node.innerHTML = "<div>b</div><div><br></div><div>c</div>"
+      await insertNode(node)
+    } else {
+      await nextFrame()
+    }
+    expectDocument("a\n\nb\n\nc\n")
   })
 })
 
-const createFile = function (callback) {
-  const canvas = document.createElement("canvas")
-  canvas.toBlob(function (file) {
-    file.name = "image.png"
-    callback(file)
+const createFile = () => {
+  return new Promise((resolve) => {
+    const canvas = document.createElement("canvas")
+    canvas.toBlob((file) => {
+      file.name = "image.png"
+      resolve(file)
+    })
   })
 }
 
@@ -283,12 +281,13 @@ const createEvent = function (type, properties = {}) {
   return event
 }
 
-const paste = function (param = {}, callback) {
+const paste = async (param = {}) => {
   const { dataTransfer, clipboardData } = param
   const pasteEvent = createEvent("paste", { clipboardData: clipboardData || dataTransfer })
   const inputEvent = createEvent("beforeinput", { inputType: "insertFromPaste", dataTransfer })
   if (document.activeElement.dispatchEvent(pasteEvent)) {
     document.activeElement.dispatchEvent(inputEvent)
   }
-  after(60, callback)
+
+  await delay(60)
 }

--- a/src/test/system/list_formatting_test.js
+++ b/src/test/system/list_formatting_test.js
@@ -3,7 +3,7 @@ import * as config from "trix/config"
 import {
   assert,
   clickToolbarButton,
-  defer,
+  expectDocument,
   moveCursor,
   pressKey,
   test,
@@ -12,138 +12,107 @@ import {
   triggerEvent,
   typeCharacters,
 } from "test/test_helper"
+import { nextFrame } from "../test_helpers/timing_helpers"
 
 testGroup("List formatting", { template: "editor_empty" }, () => {
-  test("creating a new list item", (done) => {
-    typeCharacters("a", () => {
-      clickToolbarButton({ attribute: "bullet" }, () => {
-        typeCharacters("\n", () => {
-          assert.locationRange({ index: 1, offset: 0 })
-          assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
-          assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet" ])
-          done()
-        })
-      })
-    })
+  test("creating a new list item", async () => {
+    await typeCharacters("a")
+    await clickToolbarButton({ attribute: "bullet" })
+    await typeCharacters("\n")
+    assert.locationRange({ index: 1, offset: 0 })
+    assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
+    assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet" ])
   })
 
-  test("breaking out of a list", (expectDocument) => {
-    typeCharacters("a", () => {
-      clickToolbarButton({ attribute: "bullet" }, () => {
-        typeCharacters("\n\n", () => {
-          assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
-          assert.blockAttributes([ 2, 3 ], [])
-          expectDocument("a\n\n")
-        })
-      })
-    })
+  test("breaking out of a list", async () => {
+    await typeCharacters("a")
+    await clickToolbarButton({ attribute: "bullet" })
+    await typeCharacters("\n\n")
+    assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
+    assert.blockAttributes([ 2, 3 ], [])
+    expectDocument("a\n\n")
   })
 
-  test("pressing return at the beginning of a non-empty list item", (expectDocument) => {
-    clickToolbarButton({ attribute: "bullet" }, () => {
-      typeCharacters("a\nb", () => {
-        moveCursor("left", () => {
-          pressKey("return", () => {
-            assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
-            assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet" ])
-            assert.blockAttributes([ 3, 5 ], [ "bulletList", "bullet" ])
-            expectDocument("a\n\nb\n")
-          })
-        })
-      })
-    })
+  test("pressing return at the beginning of a non-empty list item", async () => {
+    await clickToolbarButton({ attribute: "bullet" })
+    await typeCharacters("a\nb")
+    await moveCursor("left")
+    await pressKey("return")
+    assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
+    assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet" ])
+    assert.blockAttributes([ 3, 5 ], [ "bulletList", "bullet" ])
+    expectDocument("a\n\nb\n")
   })
 
-  test("pressing tab increases nesting level, tab+shift decreases nesting level", (expectDocument) => {
-    clickToolbarButton({ attribute: "bullet" }, () => {
-      typeCharacters("a", () => {
-        pressKey("return", () => {
-          pressKey("tab", () => {
-            typeCharacters("b", () => {
-              assert.blockAttributes([ 0, 1 ], [ "bulletList", "bullet" ])
-              assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet", "bulletList", "bullet" ])
-              defer(() => {
-                // press shift tab
-                triggerEvent(document.activeElement, "keydown", {
-                  key: "Tab",
-                  charCode: 0,
-                  keyCode: 9,
-                  which: 9,
-                  shiftKey: true,
-                })
-                assert.blockAttributes([ 0, 1 ], [ "bulletList", "bullet" ])
-                assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet" ])
-                expectDocument("a\nb\n")
-              })
-            })
-          })
-        })
-      })
+  test("pressing tab increases nesting level, tab+shift decreases nesting level", async () => {
+    await clickToolbarButton({ attribute: "bullet" })
+    await typeCharacters("a")
+    await pressKey("return")
+    await pressKey("tab")
+    await typeCharacters("b")
+    assert.blockAttributes([ 0, 1 ], [ "bulletList", "bullet" ])
+    assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet", "bulletList", "bullet" ])
+    await nextFrame()
+    // press shift tab
+    triggerEvent(document.activeElement, "keydown", {
+      key: "Tab",
+      charCode: 0,
+      keyCode: 9,
+      which: 9,
+      shiftKey: true,
     })
+    assert.blockAttributes([ 0, 1 ], [ "bulletList", "bullet" ])
+    assert.blockAttributes([ 2, 3 ], [ "bulletList", "bullet" ])
+    expectDocument("a\nb\n")
   })
 
-  testIf(config.input.getLevel() === 0, "pressing shift-return at the end of a list item", (expectDocument) => {
-    clickToolbarButton({ attribute: "bullet" }, () => {
-      typeCharacters("a", () => {
-        const pressShiftReturn = triggerEvent(document.activeElement, "keydown", {
-          charCode: 0,
-          keyCode: 13,
-          which: 13,
-          shiftKey: true,
-        })
-        assert.notOk(pressShiftReturn) // Assert defaultPrevented
-        assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
-        expectDocument("a\n\n")
-      })
+  testIf(config.input.getLevel() === 0, "pressing shift-return at the end of a list item", async () => {
+    await clickToolbarButton({ attribute: "bullet" })
+    await typeCharacters("a")
+    const pressShiftReturn = triggerEvent(document.activeElement, "keydown", {
+      charCode: 0,
+      keyCode: 13,
+      which: 13,
+      shiftKey: true,
     })
+    assert.notOk(pressShiftReturn) // Assert defaultPrevented
+    assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
+    expectDocument("a\n\n")
   })
 
-  test("pressing delete at the beginning of a non-empty nested list item", (expectDocument) => {
-    clickToolbarButton({ attribute: "bullet" }, () => {
-      typeCharacters("a\n", () => {
-        clickToolbarButton({ action: "increaseNestingLevel" }, () => {
-          typeCharacters("b\n", () => {
-            clickToolbarButton({ action: "increaseNestingLevel" }, () => {
-              typeCharacters("c", () => {
-                getSelectionManager().setLocationRange({ index: 1, offset: 0 })
-                getComposition().deleteInDirection("backward")
-                getEditorController().render()
-                defer(() => {
-                  assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
-                  assert.blockAttributes([ 3, 4 ], [ "bulletList", "bullet", "bulletList", "bullet" ])
-                  expectDocument("ab\nc\n")
-                })
-              })
-            })
-          })
-        })
-      })
-    })
+  test("pressing delete at the beginning of a non-empty nested list item", async () => {
+    await clickToolbarButton({ attribute: "bullet" })
+    await typeCharacters("a\n")
+    await clickToolbarButton({ action: "increaseNestingLevel" })
+    await typeCharacters("b\n")
+    await clickToolbarButton({ action: "increaseNestingLevel" })
+    await typeCharacters("c")
+    getSelectionManager().setLocationRange({ index: 1, offset: 0 })
+    getComposition().deleteInDirection("backward")
+    getEditorController().render()
+    await nextFrame()
+    assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
+    assert.blockAttributes([ 3, 4 ], [ "bulletList", "bullet", "bulletList", "bullet" ])
+    expectDocument("ab\nc\n")
   })
 
-  test("decreasing list item's level decreases its nested items level too", (expectDocument) => {
-    clickToolbarButton({ attribute: "bullet" }, () => {
-      typeCharacters("a\n", () => {
-        clickToolbarButton({ action: "increaseNestingLevel" }, () => {
-          typeCharacters("b\n", () => {
-            clickToolbarButton({ action: "increaseNestingLevel" }, () => {
-              typeCharacters("c", () => {
-                getSelectionManager().setLocationRange({ index: 1, offset: 1 })
+  test("decreasing list item's level decreases its nested items level too", async () => {
+    await clickToolbarButton({ attribute: "bullet" })
+    await typeCharacters("a\n")
+    await clickToolbarButton({ action: "increaseNestingLevel" })
+    await typeCharacters("b\n")
+    await clickToolbarButton({ action: "increaseNestingLevel" })
+    await typeCharacters("c")
+    getSelectionManager().setLocationRange({ index: 1, offset: 1 })
 
-                for (let n = 0; n < 3; n++) {
-                  getComposition().deleteInDirection("backward")
-                  getEditorController().render()
-                }
+    for (let n = 0; n < 3; n++) {
+      getComposition().deleteInDirection("backward")
+      getEditorController().render()
+    }
 
-                assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
-                assert.blockAttributes([ 2, 3 ], [])
-                assert.blockAttributes([ 3, 5 ], [ "bulletList", "bullet" ])
-                expectDocument("a\n\nc\n")
-              })
-            })
-          })
-        })
-      })
-    })
+    assert.blockAttributes([ 0, 2 ], [ "bulletList", "bullet" ])
+    assert.blockAttributes([ 2, 3 ], [])
+    assert.blockAttributes([ 3, 5 ], [ "bulletList", "bullet" ])
+    expectDocument("a\n\nc\n")
   })
 })

--- a/src/test/system/mutation_input_test.js
+++ b/src/test/system/mutation_input_test.js
@@ -4,7 +4,7 @@ import {
   TEST_IMAGE_URL,
   assert,
   clickToolbarButton,
-  defer,
+  expectDocument,
   insertNode,
   isToolbarButtonActive,
   testGroup,
@@ -12,6 +12,7 @@ import {
   triggerEvent,
   typeCharacters,
 } from "test/test_helper"
+import { nextFrame } from "../test_helpers/timing_helpers"
 
 const test = function() {
   testIf(config.input.getLevel() === 0, ...arguments)
@@ -28,115 +29,114 @@ testGroup("Mutation input", { template: "editor_empty" }, () => {
     requestAnimationFrame(() => expectDocument("a\nb\n"))
   })
 
-  test("typing a space in formatted text at the end of a block", function (expectDocument) {
+  test("typing a space in formatted text at the end of a block", async () => {
     const element = getEditorElement()
 
-    clickToolbarButton({ attribute: "bold" }, () => {
-      typeCharacters("a", () => {
-        // Press space key
-        triggerEvent(element, "keydown", { charCode: 0, keyCode: 32, which: 32 })
-        triggerEvent(element, "keypress", { charCode: 32, keyCode: 32, which: 32 })
+    await clickToolbarButton({ attribute: "bold" })
+    await typeCharacters("a")
+    // Press space key
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 32, which: 32 })
+    triggerEvent(element, "keypress", { charCode: 32, keyCode: 32, which: 32 })
 
-        const boldElement = element.querySelector("strong")
-        boldElement.appendChild(document.createTextNode(" "))
-        boldElement.appendChild(document.createElement("br"))
+    const boldElement = element.querySelector("strong")
+    boldElement.appendChild(document.createTextNode(" "))
+    boldElement.appendChild(document.createElement("br"))
 
-        requestAnimationFrame(() => {
-          assert.ok(isToolbarButtonActive({ attribute: "bold" }))
-          assert.textAttributes([ 0, 2 ], { bold: true })
-          expectDocument("a \n")
-        })
-      })
+    requestAnimationFrame(() => {
+      assert.ok(isToolbarButtonActive({ attribute: "bold" }))
+      assert.textAttributes([ 0, 2 ], { bold: true })
+      expectDocument("a \n")
     })
   })
 
-  test("typing formatted text after a newline at the end of block", function (expectDocument) {
+  test("typing formatted text after a newline at the end of block", async () => {
     const element = getEditorElement()
     element.editor.insertHTML("<ul><li>a</li><li><br></li></ul>")
     element.editor.setSelectedRange(3)
 
-    clickToolbarButton({ attribute: "bold" }, () => {
-      // Press B key
-      triggerEvent(element, "keydown", { charCode: 0, keyCode: 66, which: 66 })
-      triggerEvent(element, "keypress", { charCode: 98, keyCode: 98, which: 98 })
+    await clickToolbarButton({ attribute: "bold" })
 
-      const node = document.createTextNode("b")
-      const extraBR = element.querySelectorAll("br")[1]
-      extraBR.parentNode.insertBefore(node, extraBR)
-      extraBR.parentNode.removeChild(extraBR)
+    // Press B key
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 66, which: 66 })
+    triggerEvent(element, "keypress", { charCode: 98, keyCode: 98, which: 98 })
 
-      requestAnimationFrame(() => {
-        assert.ok(isToolbarButtonActive({ attribute: "bold" }))
-        assert.textAttributes([ 0, 1 ], {})
-        assert.textAttributes([ 3, 4 ], { bold: true })
-        expectDocument("a\n\nb\n")
-      })
-    })
+    const node = document.createTextNode("b")
+    const extraBR = element.querySelectorAll("br")[1]
+    extraBR.parentNode.insertBefore(node, extraBR)
+    extraBR.parentNode.removeChild(extraBR)
+
+    await nextFrame()
+
+    assert.ok(isToolbarButtonActive({ attribute: "bold" }))
+    assert.textAttributes([ 0, 1 ], {})
+    assert.textAttributes([ 3, 4 ], { bold: true })
+    expectDocument("a\n\nb\n")
   })
 
-  test("typing an emoji after a newline at the end of block", function (expectDocument) {
+  test("typing an emoji after a newline at the end of block", async () => {
     const element = getEditorElement()
 
-    typeCharacters("\n", () => {
-      // Tap 👏🏻 on iOS
-      triggerEvent(element, "keydown", { charCode: 0, keyCode: 0, which: 0, key: "👏🏻" })
-      triggerEvent(element, "keypress", { charCode: 128079, keyCode: 128079, which: 128079, key: "👏🏻" })
+    await typeCharacters("\n")
 
-      const node = document.createTextNode("👏🏻")
-      const extraBR = element.querySelectorAll("br")[1]
-      extraBR.parentNode.insertBefore(node, extraBR)
-      extraBR.parentNode.removeChild(extraBR)
+    // Tap 👏🏻 on iOS
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 0, which: 0, key: "👏🏻" })
+    triggerEvent(element, "keypress", { charCode: 128079, keyCode: 128079, which: 128079, key: "👏🏻" })
 
-      requestAnimationFrame(() => expectDocument("\n👏🏻\n"))
-    })
+    const node = document.createTextNode("👏🏻")
+    const extraBR = element.querySelectorAll("br")[1]
+    extraBR.parentNode.insertBefore(node, extraBR)
+    extraBR.parentNode.removeChild(extraBR)
+
+    await nextFrame()
+    expectDocument("\n👏🏻\n")
   })
 
-  test("backspacing an attachment at the beginning of an otherwise empty document", function (expectDocument) {
+  test("backspacing an attachment at the beginning of an otherwise empty document", async () => {
     const element = getEditorElement()
     element.editor.loadHTML(`<img src="${TEST_IMAGE_URL}" width="10" height="10">`)
 
-    requestAnimationFrame(() => {
-      element.editor.setSelectedRange([ 0, 1 ])
-      triggerEvent(element, "keydown", { charCode: 0, keyCode: 8, which: 8 })
+    await nextFrame()
 
-      element.firstElementChild.innerHTML = "<br>"
+    element.editor.setSelectedRange([ 0, 1 ])
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 8, which: 8 })
 
-      requestAnimationFrame(() => {
-        assert.locationRange({ index: 0, offset: 0 })
-        expectDocument("\n")
-      })
-    })
+    element.firstElementChild.innerHTML = "<br>"
+
+    await nextFrame()
+
+    assert.locationRange({ index: 0, offset: 0 })
+    expectDocument("\n")
   })
 
-  test("backspacing a block comment node", function (expectDocument) {
+  test("backspacing a block comment node", async (expectDocument) => {
     const element = getEditorElement()
     element.editor.loadHTML("<blockquote>a</blockquote><div>b</div>")
-    defer(() => {
-      element.editor.setSelectedRange(2)
-      triggerEvent(element, "keydown", { charCode: 0, keyCode: 8, which: 8 })
-      const commentNode = element.lastChild.firstChild
-      commentNode.parentNode.removeChild(commentNode)
-      defer(() => {
-        assert.locationRange({ index: 0, offset: 1 })
-        expectDocument("ab\n")
-      })
-    })
+
+    await nextFrame()
+
+    element.editor.setSelectedRange(2)
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 8, which: 8 })
+    const commentNode = element.lastChild.firstChild
+    commentNode.parentNode.removeChild(commentNode)
+
+    await nextFrame()
+
+    assert.locationRange({ index: 0, offset: 1 })
+    expectDocument("ab\n")
   })
 
-  test("typing formatted text with autocapitalization on", function (expectDocument) {
+  test("typing formatted text with autocapitalization on", async () => {
     const element = getEditorElement()
 
-    clickToolbarButton({ attribute: "bold" }, () => {
-      // Type "b", autocapitalize to "B"
-      triggerEvent(element, "keydown", { charCode: 0, keyCode: 66, which: 66 })
-      triggerEvent(element, "keypress", { charCode: 98, keyCode: 98, which: 98 })
-      triggerEvent(element, "textInput", { data: "B" })
+    await clickToolbarButton({ attribute: "bold" })
+    // Type "b", autocapitalize to "B"
+    triggerEvent(element, "keydown", { charCode: 0, keyCode: 66, which: 66 })
+    triggerEvent(element, "keypress", { charCode: 98, keyCode: 98, which: 98 })
+    triggerEvent(element, "textInput", { data: "B" })
 
-      insertNode(document.createTextNode("B"), () => {
-        assert.ok(isToolbarButtonActive({ attribute: "bold" }))
-        assert.textAttributes([ 0, 1 ], { bold: true })
-        expectDocument("B\n")
-      })
-    })
+    await insertNode(document.createTextNode("B"))
+    assert.ok(isToolbarButtonActive({ attribute: "bold" }))
+    assert.textAttributes([ 0, 1 ], { bold: true })
+    expectDocument("B\n")
   })
 })

--- a/src/test/system/text_formatting_test.js
+++ b/src/test/system/text_formatting_test.js
@@ -9,6 +9,7 @@ import {
   clickToolbarDialogButton,
   collapseSelection,
   expandSelection,
+  expectDocument,
   fixtures,
   insertString,
   insertText,
@@ -26,252 +27,185 @@ import {
 } from "test/test_helper"
 
 testGroup("Text formatting", { template: "editor_empty" }, () => {
-  test("applying attributes to text", (done) => {
-    typeCharacters("abc", () => {
-      expandSelection("left", () => {
-        clickToolbarButton({ attribute: "bold" }, () => {
-          assert.textAttributes([ 0, 2 ], {})
-          assert.textAttributes([ 2, 3 ], { bold: true })
-          assert.textAttributes([ 3, 4 ], { blockBreak: true })
-          done()
-        })
-      })
-    })
+  test("applying attributes to text", async () => {
+    await typeCharacters("abc")
+    await expandSelection("left")
+    await clickToolbarButton({ attribute: "bold" })
+    assert.textAttributes([ 0, 2 ], {})
+    assert.textAttributes([ 2, 3 ], { bold: true })
+    assert.textAttributes([ 3, 4 ], { blockBreak: true })
   })
 
-  test("applying a link to text", (done) => {
-    typeCharacters("abc", () => {
-      moveCursor("left", () => {
-        expandSelection("left", () => {
-          clickToolbarButton({ attribute: "href" }, () => {
-            assert.ok(isToolbarDialogActive({ attribute: "href" }))
-            typeInToolbarDialog("http://example.com", { attribute: "href" }, () => {
-              assert.textAttributes([ 0, 1 ], {})
-              assert.textAttributes([ 1, 2 ], { href: "http://example.com" })
-              assert.textAttributes([ 2, 3 ], {})
-              done()
-            })
-          })
-        })
-      })
-    })
+  test("applying a link to text", async () => {
+    await typeCharacters("abc")
+    await moveCursor("left")
+    await expandSelection("left")
+    await clickToolbarButton({ attribute: "href" })
+    assert.ok(isToolbarDialogActive({ attribute: "href" }))
+    await typeInToolbarDialog("http://example.com", { attribute: "href" })
+    assert.textAttributes([ 0, 1 ], {})
+    assert.textAttributes([ 1, 2 ], { href: "http://example.com" })
+    assert.textAttributes([ 2, 3 ], {})
   })
 
-  test("inserting a link", (expectDocument) => {
-    typeCharacters("a", () => {
-      clickToolbarButton({ attribute: "href" }, () => {
-        assert.ok(isToolbarDialogActive({ attribute: "href" }))
-        typeInToolbarDialog("http://example.com", { attribute: "href" }, () => {
-          assert.textAttributes([ 0, 1 ], {})
-          assert.textAttributes([ 1, 19 ], { href: "http://example.com" })
-          expectDocument("ahttp://example.com\n")
-        })
-      })
-    })
+  test("inserting a link", async () => {
+    await typeCharacters("a")
+    await clickToolbarButton({ attribute: "href" })
+    assert.ok(isToolbarDialogActive({ attribute: "href" }))
+    await typeInToolbarDialog("http://example.com", { attribute: "href" })
+    assert.textAttributes([ 0, 1 ], {})
+    assert.textAttributes([ 1, 19 ], { href: "http://example.com" })
+    expectDocument("ahttp://example.com\n")
   })
 
-  test("editing a link", (done) => {
+  test("editing a link", async () => {
     insertString("a")
     const text = Text.textForStringWithAttributes("bc", { href: "http://example.com" })
     insertText(text)
     insertString("d")
-    moveCursor({ direction: "left", times: 2 }, () => {
-      clickToolbarButton({ attribute: "href" }, () => {
-        assert.ok(isToolbarDialogActive({ attribute: "href" }))
-        assert.locationRange({ index: 0, offset: 1 }, { index: 0, offset: 3 })
-        typeInToolbarDialog("http://example.org", { attribute: "href" }, () => {
-          assert.textAttributes([ 0, 1 ], {})
-          assert.textAttributes([ 1, 3 ], { href: "http://example.org" })
-          assert.textAttributes([ 3, 4 ], {})
-          done()
-        })
-      })
-    })
+    await moveCursor({ direction: "left", times: 2 })
+    await clickToolbarButton({ attribute: "href" })
+    assert.ok(isToolbarDialogActive({ attribute: "href" }))
+    assert.locationRange({ index: 0, offset: 1 }, { index: 0, offset: 3 })
+    await typeInToolbarDialog("http://example.org", { attribute: "href" })
+    assert.textAttributes([ 0, 1 ], {})
+    assert.textAttributes([ 1, 3 ], { href: "http://example.org" })
+    assert.textAttributes([ 3, 4 ], {})
   })
 
-  test("removing a link", (done) => {
+  test("removing a link", async () => {
     const text = Text.textForStringWithAttributes("ab", { href: "http://example.com" })
     insertText(text)
     assert.textAttributes([ 0, 2 ], { href: "http://example.com" })
-    expandSelection({ direction: "left", times: 2 }, () => {
-      clickToolbarButton({ attribute: "href" }, () => {
-        clickToolbarDialogButton({ method: "removeAttribute" }, () => {
-          assert.textAttributes([ 0, 2 ], {})
-          done()
-        })
-      })
-    })
+    await expandSelection({ direction: "left", times: 2 })
+    await clickToolbarButton({ attribute: "href" })
+    await clickToolbarDialogButton({ method: "removeAttribute" })
+    await assert.textAttributes([ 0, 2 ], {})
   })
 
-  test("selecting an attachment disables text formatting", (done) => {
+  test("selecting an attachment disables text formatting", async () => {
     const text = fixtures["file attachment"].document.getBlockAtIndex(0).getTextWithoutBlockBreak()
     insertText(text)
-    typeCharacters("a", () => {
-      assert.notOk(isToolbarButtonDisabled({ attribute: "bold" }))
-      expandSelection("left", () => {
-        assert.notOk(isToolbarButtonDisabled({ attribute: "bold" }))
-        expandSelection("left", () => {
-          assert.ok(isToolbarButtonDisabled({ attribute: "bold" }))
-          done()
-        })
-      })
-    })
+    await typeCharacters("a")
+    assert.notOk(isToolbarButtonDisabled({ attribute: "bold" }))
+    await expandSelection("left")
+    assert.notOk(isToolbarButtonDisabled({ attribute: "bold" }))
+    await expandSelection("left")
+    assert.ok(isToolbarButtonDisabled({ attribute: "bold" }))
   })
 
-  test("selecting an attachment deactivates toolbar dialog", (done) => {
+  test("selecting an attachment deactivates toolbar dialog", async () => {
     const text = fixtures["file attachment"].document.getBlockAtIndex(0).getTextWithoutBlockBreak()
     insertText(text)
-    clickToolbarButton({ attribute: "href" }, () => {
-      assert.ok(isToolbarDialogActive({ attribute: "href" }))
-      clickElement(getEditorElement().querySelector("figure"), () => {
-        assert.notOk(isToolbarDialogActive({ attribute: "href" }))
-        assert.ok(isToolbarButtonDisabled({ attribute: "href" }))
-        done()
-      })
-    })
+    await clickToolbarButton({ attribute: "href" })
+    assert.ok(isToolbarDialogActive({ attribute: "href" }))
+    await clickElement(getEditorElement().querySelector("figure"))
+    assert.notOk(isToolbarDialogActive({ attribute: "href" }))
+    assert.ok(isToolbarButtonDisabled({ attribute: "href" }))
   })
 
-  test("typing over a selected attachment does not apply disabled formatting attributes", function (expectDocument) {
+  test("typing over a selected attachment does not apply disabled formatting attributes", async () => {
     const text = fixtures["file attachment"].document.getBlockAtIndex(0).getTextWithoutBlockBreak()
     insertText(text)
-    expandSelection("left", () => {
-      assert.ok(isToolbarButtonDisabled({ attribute: "bold" }))
-      typeCharacters("a", () => {
-        assert.textAttributes([ 0, 1 ], {})
-        expectDocument("a\n")
-      })
-    })
+    await expandSelection("left")
+    assert.ok(isToolbarButtonDisabled({ attribute: "bold" }))
+    await typeCharacters("a")
+    assert.textAttributes([ 0, 1 ], {})
+    expectDocument("a\n")
   })
 
-  test("applying a link to an attachment with a host-provided href", (done) => {
+  test("applying a link to an attachment with a host-provided href", async () => {
     const text = fixtures["file attachment"].document.getBlockAtIndex(0).getTextWithoutBlockBreak()
     insertText(text)
-    typeCharacters("a", () => {
-      assert.notOk(isToolbarButtonDisabled({ attribute: "href" }))
-      expandSelection("left", () => {
-        assert.notOk(isToolbarButtonDisabled({ attribute: "href" }))
-        expandSelection("left", () => {
-          assert.ok(isToolbarButtonDisabled({ attribute: "href" }))
-          done()
-        })
-      })
-    })
+    await typeCharacters("a")
+    assert.notOk(isToolbarButtonDisabled({ attribute: "href" }))
+    await expandSelection("left")
+    assert.notOk(isToolbarButtonDisabled({ attribute: "href" }))
+    await expandSelection("left")
+    assert.ok(isToolbarButtonDisabled({ attribute: "href" }))
   })
 
-  test("typing after a link", (done) => {
-    typeCharacters("ab", () => {
-      expandSelection({ direction: "left", times: 2 }, () => {
-        clickToolbarButton({ attribute: "href" }, () => {
-          typeInToolbarDialog("http://example.com", { attribute: "href" }, () => {
-            collapseSelection("right", () => {
-              assert.locationRange({ index: 0, offset: 2 })
-              typeCharacters("c", () => {
-                assert.textAttributes([ 0, 2 ], { href: "http://example.com" })
-                assert.textAttributes([ 2, 3 ], {})
-                moveCursor("left", () => {
-                  assert.notOk(isToolbarButtonActive({ attribute: "href" }))
-                  moveCursor("left", () => {
-                    assert.ok(isToolbarButtonActive({ attribute: "href" }))
-                    done()
-                  })
-                })
-              })
-            })
-          })
-        })
-      })
-    })
+  test("typing after a link", async () => {
+    await typeCharacters("ab")
+    await expandSelection({ direction: "left", times: 2 })
+    await clickToolbarButton({ attribute: "href" })
+    await typeInToolbarDialog("http://example.com", { attribute: "href" })
+    await collapseSelection("right")
+    assert.locationRange({ index: 0, offset: 2 })
+    await typeCharacters("c")
+    assert.textAttributes([ 0, 2 ], { href: "http://example.com" })
+    assert.textAttributes([ 2, 3 ], {})
+    await moveCursor("left")
+    assert.notOk(isToolbarButtonActive({ attribute: "href" }))
+    await moveCursor("left")
+    assert.ok(isToolbarButtonActive({ attribute: "href" }))
   })
 
-  test("applying formatting and then typing", (done) => {
-    typeCharacters("a", () => {
-      clickToolbarButton({ attribute: "bold" }, () => {
-        typeCharacters("bcd", () => {
-          clickToolbarButton({ attribute: "bold" }, () => {
-            typeCharacters("e", () => {
-              assert.textAttributes([ 0, 1 ], {})
-              assert.textAttributes([ 1, 4 ], { bold: true })
-              assert.textAttributes([ 4, 5 ], {})
-              done()
-            })
-          })
-        })
-      })
-    })
+  test("applying formatting and then typing", async () => {
+    await typeCharacters("a")
+    await clickToolbarButton({ attribute: "bold" })
+    await typeCharacters("bcd")
+    await clickToolbarButton({ attribute: "bold" })
+    await typeCharacters("e")
+    assert.textAttributes([ 0, 1 ], {})
+    assert.textAttributes([ 1, 4 ], { bold: true })
+    assert.textAttributes([ 4, 5 ], {})
   })
 
-  test("applying formatting and then moving the cursor away", (done) => {
-    typeCharacters("abc", () => {
-      moveCursor("left", () => {
-        assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
-        clickToolbarButton({ attribute: "bold" }, () => {
-          assert.ok(isToolbarButtonActive({ attribute: "bold" }))
-          moveCursor("right", () => {
-            assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
-            moveCursor("left", () => {
-              assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
-              assert.textAttributes([ 0, 3 ], {})
-              assert.textAttributes([ 3, 4 ], { blockBreak: true })
-              done()
-            })
-          })
-        })
-      })
-    })
+  test("applying formatting and then moving the cursor away", async () => {
+    await typeCharacters("abc")
+    await moveCursor("left")
+    assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
+    await clickToolbarButton({ attribute: "bold" })
+    assert.ok(isToolbarButtonActive({ attribute: "bold" }))
+    await moveCursor("right")
+    assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
+    await moveCursor("left")
+    assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
+    assert.textAttributes([ 0, 3 ], {})
+    assert.textAttributes([ 3, 4 ], { blockBreak: true })
   })
 
-  test("applying formatting to an unfocused editor", (done) => {
+  test("applying formatting to an unfocused editor", async () => {
     const input = makeElement("input", { type: "text" })
     document.body.appendChild(input)
     input.focus()
 
-    clickToolbarButton({ attribute: "bold" }, () => {
-      typeCharacters("a", () => {
-        assert.textAttributes([ 0, 1 ], { bold: true })
-        document.body.removeChild(input)
-        done()
-      })
-    })
+    await clickToolbarButton({ attribute: "bold" })
+    await typeCharacters("a")
+    assert.textAttributes([ 0, 1 ], { bold: true })
+    document.body.removeChild(input)
   })
 
-  test("editing formatted text", (done) => {
-    clickToolbarButton({ attribute: "bold" }, () => {
-      typeCharacters("ab", () => {
-        clickToolbarButton({ attribute: "bold" }, () => {
-          typeCharacters("c", () => {
-            assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
-            moveCursor("left", () => {
-              assert.ok(isToolbarButtonActive({ attribute: "bold" }))
-              moveCursor("left", () => {
-                assert.ok(isToolbarButtonActive({ attribute: "bold" }))
-                typeCharacters("Z", () => {
-                  assert.ok(isToolbarButtonActive({ attribute: "bold" }))
-                  assert.textAttributes([ 0, 3 ], { bold: true })
-                  assert.textAttributes([ 3, 4 ], {})
-                  assert.textAttributes([ 4, 5 ], { blockBreak: true })
-                  moveCursor("right", () => {
-                    assert.ok(isToolbarButtonActive({ attribute: "bold" }))
-                    moveCursor("right", () => {
-                      assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
-                      done()
-                    })
-                  })
-                })
-              })
-            })
-          })
-        })
-      })
-    })
+  test("editing formatted text", async () => {
+    await clickToolbarButton({ attribute: "bold" })
+    await typeCharacters("ab")
+    await clickToolbarButton({ attribute: "bold" })
+    await typeCharacters("c")
+    assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
+    await moveCursor("left")
+    assert.ok(isToolbarButtonActive({ attribute: "bold" }))
+    await moveCursor("left")
+    assert.ok(isToolbarButtonActive({ attribute: "bold" }))
+    await typeCharacters("Z")
+    assert.ok(isToolbarButtonActive({ attribute: "bold" }))
+    assert.textAttributes([ 0, 3 ], { bold: true })
+    assert.textAttributes([ 3, 4 ], {})
+    assert.textAttributes([ 4, 5 ], { blockBreak: true })
+    await moveCursor("right")
+    assert.ok(isToolbarButtonActive({ attribute: "bold" }))
+    await moveCursor("right")
+    assert.notOk(isToolbarButtonActive({ attribute: "bold" }))
   })
 
-  testIf(config.input.getLevel() === 0, "key command activates toolbar button", (done) => {
-    typeToolbarKeyCommand({ attribute: "bold" }, () => {
-      assert.ok(isToolbarButtonActive({ attribute: "bold" }))
-      done()
-    })
+  testIf(config.input.getLevel() === 0, "key command activates toolbar button", async () => {
+    await typeToolbarKeyCommand({ attribute: "bold" })
+    assert.ok(isToolbarButtonActive({ attribute: "bold" }))
   })
 
-  test("backspacing newline after text", (expectDocument) =>
-    typeCharacters("a\n", () => pressKey("backspace", () => expectDocument("a\n"))))
+  test("backspacing newline after text", async () => {
+    await typeCharacters("a\n")
+    await pressKey("backspace")
+    expectDocument("a\n")
+  })
 })

--- a/src/test/system/undo_test.js
+++ b/src/test/system/undo_test.js
@@ -8,89 +8,61 @@ import {
   typeCharacters,
 } from "test/test_helper"
 
-testGroup("Undo/Redo", { template: "editor_empty" }, () => {
-  test("typing and undoing", (done) => {
+testGroup("Undo/Redo", { template: "editor_empty" }, async () => {
+  test("typing and undoing", async () => {
     const first = getDocument().copy()
-    typeCharacters("abc", () => {
-      assert.notOk(getDocument().isEqualTo(first))
-      clickToolbarButton({ action: "undo" }, () => {
-        assert.ok(getDocument().isEqualTo(first))
-        done()
-      })
-    })
+    await typeCharacters("abc")
+    assert.notOk(getDocument().isEqualTo(first))
+    await clickToolbarButton({ action: "undo" })
+    assert.ok(getDocument().isEqualTo(first))
   })
 
-  test("typing, formatting, typing, and undoing", (done) => {
+  test("typing, formatting, typing, and undoing", async () => {
     const first = getDocument().copy()
-    typeCharacters("abc", () => {
-      const second = getDocument().copy()
-      clickToolbarButton({ attribute: "bold" }, () => {
-        typeCharacters("def", () => {
-          const third = getDocument().copy()
-          clickToolbarButton({ action: "undo" }, () => {
-            assert.ok(getDocument().isEqualTo(second))
-            clickToolbarButton({ action: "undo" }, () => {
-              assert.ok(getDocument().isEqualTo(first))
-              clickToolbarButton({ action: "redo" }, () => {
-                assert.ok(getDocument().isEqualTo(second))
-                clickToolbarButton({ action: "redo" }, () => {
-                  assert.ok(getDocument().isEqualTo(third))
-                  done()
-                })
-              })
-            })
-          })
-        })
-      })
-    })
+    await typeCharacters("abc")
+    const second = getDocument().copy()
+    await clickToolbarButton({ attribute: "bold" })
+    await typeCharacters("def")
+    const third = getDocument().copy()
+    await clickToolbarButton({ action: "undo" })
+    assert.ok(getDocument().isEqualTo(second))
+    await clickToolbarButton({ action: "undo" })
+    assert.ok(getDocument().isEqualTo(first))
+    await clickToolbarButton({ action: "redo" })
+    assert.ok(getDocument().isEqualTo(second))
+    await clickToolbarButton({ action: "redo" })
+    assert.ok(getDocument().isEqualTo(third))
   })
 
-  test("formatting changes are batched by location range", (done) => {
-    typeCharacters("abc", () => {
-      const first = getDocument().copy()
-      expandSelection("left", () => {
-        clickToolbarButton({ attribute: "bold" }, () => {
-          clickToolbarButton({ attribute: "italic" }, () => {
-            const second = getDocument().copy()
-            moveCursor("left", () => {
-              expandSelection("left", () => {
-                clickToolbarButton({ attribute: "italic" }, () => {
-                  const third = getDocument().copy()
-                  clickToolbarButton({ action: "undo" }, () => {
-                    assert.ok(getDocument().isEqualTo(second))
-                    clickToolbarButton({ action: "undo" }, () => {
-                      assert.ok(getDocument().isEqualTo(first))
-                      clickToolbarButton({ action: "redo" }, () => {
-                        assert.ok(getDocument().isEqualTo(second))
-                        clickToolbarButton({ action: "redo" }, () => {
-                          assert.ok(getDocument().isEqualTo(third))
-                          done()
-                        })
-                      })
-                    })
-                  })
-                })
-              })
-            })
-          })
-        })
-      })
-    })
+  test("formatting changes are batched by location range", async () => {
+    await typeCharacters("abc")
+    const first = getDocument().copy()
+    await expandSelection("left")
+    await clickToolbarButton({ attribute: "bold" })
+    await clickToolbarButton({ attribute: "italic" })
+    const second = getDocument().copy()
+    await moveCursor("left")
+    await expandSelection("left")
+    await clickToolbarButton({ attribute: "italic" })
+    const third = getDocument().copy()
+    await clickToolbarButton({ action: "undo" })
+    assert.ok(getDocument().isEqualTo(second))
+    await clickToolbarButton({ action: "undo" })
+    assert.ok(getDocument().isEqualTo(first))
+    await clickToolbarButton({ action: "redo" })
+    assert.ok(getDocument().isEqualTo(second))
+    await clickToolbarButton({ action: "redo" })
+    assert.ok(getDocument().isEqualTo(third))
   })
 
-  test("block formatting are undoable", (done) => {
-    typeCharacters("abc", () => {
-      const first = getDocument().copy()
-      clickToolbarButton({ attribute: "heading1" }, () => {
-        const second = getDocument().copy()
-        clickToolbarButton({ action: "undo" }, () => {
-          assert.ok(getDocument().isEqualTo(first))
-          clickToolbarButton({ action: "redo" }, () => {
-            assert.ok(getDocument().isEqualTo(second))
-            done()
-          })
-        })
-      })
-    })
+  test("block formatting are undoable", async () => {
+    await typeCharacters("abc")
+    const first = getDocument().copy()
+    await clickToolbarButton({ attribute: "heading1" })
+    const second = getDocument().copy()
+    await clickToolbarButton({ action: "undo" })
+    assert.ok(getDocument().isEqualTo(first))
+    clickToolbarButton({ action: "redo" })
+    assert.ok(getDocument().isEqualTo(second))
   })
 })

--- a/src/test/test_helpers/assertions.js
+++ b/src/test/test_helpers/assertions.js
@@ -52,4 +52,9 @@ assert.documentHTMLEqual = function (trixDocument, html) {
 
 const getHTML = (trixDocument) => DocumentView.render(trixDocument).innerHTML
 
+export const expectDocument = (expectedDocumentValue, element) => {
+  if (!element) element = getEditorElement()
+  assert.equal(element.editor.getDocument().toString(), expectedDocumentValue)
+}
+
 export { assert, getHTML }

--- a/src/test/test_helpers/editor_helpers.js
+++ b/src/test/test_helpers/editor_helpers.js
@@ -56,4 +56,5 @@ export const replaceDocument = function (document) {
   render()
 }
 
+
 const render = () => getEditorController().render()

--- a/src/test/test_helpers/fixtures/fixtures.js
+++ b/src/test/test_helpers/fixtures/fixtures.js
@@ -40,17 +40,12 @@ export { TEST_IMAGE_URL }
 const { css } = config
 
 const createDocument = function (...parts) {
-  const blocks = (() => {
-    const result = []
+  const blocks = parts.map((part) => {
+    const [ string, textAttributes, blockAttributes ] = Array.from(part)
+    const text = Text.textForStringWithAttributes(string, textAttributes)
+    return new Block(text, blockAttributes)
+  })
 
-    Array.from(parts).forEach((part) => {
-      const [ string, textAttributes, blockAttributes ] = Array.from(part)
-      const text = Text.textForStringWithAttributes(string, textAttributes)
-      result.push(new Block(text, blockAttributes))
-    })
-
-    return result
-  })()
   return new Document(blocks)
 }
 

--- a/src/test/test_helpers/input_helpers.js
+++ b/src/test/test_helpers/input_helpers.js
@@ -1,5 +1,5 @@
 import * as config from "trix/config"
-import { defer } from "trix/core/helpers"
+import { delay, nextFrame } from "./timing_helpers"
 import { triggerEvent } from "./event_helpers"
 import {
   collapseSelection,
@@ -37,12 +37,11 @@ export const triggerInputEvent = function (element, type, properties = {}) {
   }
 }
 
-export const pasteContent = function (contentType, value, callback) {
+export const pasteContent = async (contentType, value) => {
   let data
 
   if (typeof contentType === "object") {
     data = contentType
-    callback = value
   } else {
     data = { [contentType]: value }
   }
@@ -64,9 +63,7 @@ export const pasteContent = function (contentType, value, callback) {
 
   triggerEvent(document.activeElement, "paste", { testClipboardData })
 
-  if (callback) {
-    requestAnimationFrame (callback)
-  }
+  await nextFrame()
 }
 
 export const createFile = function (properties = {}) {
@@ -82,50 +79,47 @@ export const createFile = function (properties = {}) {
   return file
 }
 
-export const typeCharacters = function (string, callback) {
-  let characters, typeNextCharacter
-  if (Array.isArray(string)) {
-    characters = string
-  } else {
-    characters = string.split("")
+export const typeCharacters = async (string) => {
+  const characters = Array.isArray(string) ? string : string.split("")
+
+  const typeNextCharacter = async () => {
+    await nextFrame()
+    const character = characters.shift()
+    if (character == null) return
+
+    switch (character) {
+      case "\n":
+        await pressKey("return")
+        await typeNextCharacter()
+        break
+      case "\b":
+        await pressKey("backspace")
+        await typeNextCharacter()
+        break
+      default:
+        await typeCharacterInElement(character, document.activeElement)
+        await typeNextCharacter()
+    }
   }
 
-  return (typeNextCharacter = () =>
-    defer(function () {
-      const character = characters.shift()
-      if (character != null) {
-        switch (character) {
-          case "\n":
-            return pressKey("return", typeNextCharacter)
-          case "\b":
-            return pressKey("backspace", typeNextCharacter)
-          default:
-            return typeCharacterInElement(character, document.activeElement, typeNextCharacter)
-        }
-      } else {
-        return callback()
-      }
-    }))()
+  await typeNextCharacter()
 }
 
-export const pressKey = function (keyName, callback) {
+export const pressKey = async (keyName) => {
   const element = document.activeElement
   const code = keyCodes[keyName]
   const properties = { which: code, keyCode: code, charCode: 0, key: capitalize(keyName) }
 
-  if (!triggerEvent(element, "keydown", properties)) {
-    return callback()
-  }
+  if (!triggerEvent(element, "keydown", properties)) return
 
-  return simulateKeypress(keyName, () => {
-    defer(() => {
-      triggerEvent(element, "keyup", properties)
-      defer(callback)
-    })
-  })
+  await simulateKeypress(keyName)
+  await nextFrame()
+
+  triggerEvent(element, "keyup", properties)
+  await nextFrame()
 }
 
-export const startComposition = function (data, callback) {
+export const startComposition = async (data) => {
   const element = document.activeElement
   triggerEvent(element, "compositionstart", { data: "" })
   triggerInputEvent(element, "beforeinput", { inputType: "insertCompositionText", data })
@@ -134,10 +128,10 @@ export const startComposition = function (data, callback) {
 
   const node = document.createTextNode(data)
   insertNode(node)
-  selectNode(node, callback)
+  await selectNode(node)
 }
 
-export const updateComposition = function (data, callback) {
+export const updateComposition = async (data) => {
   const element = document.activeElement
   triggerInputEvent(element, "beforeinput", { inputType: "insertCompositionText", data })
   triggerEvent(element, "compositionupdate", { data })
@@ -145,10 +139,10 @@ export const updateComposition = function (data, callback) {
 
   const node = document.createTextNode(data)
   insertNode(node)
-  selectNode(node, callback)
+  await selectNode(node)
 }
 
-export const endComposition = function (data, callback) {
+export const endComposition = async (data) => {
   const element = document.activeElement
   triggerInputEvent(element, "beforeinput", { inputType: "insertCompositionText", data })
   triggerEvent(element, "compositionupdate", { data })
@@ -156,27 +150,27 @@ export const endComposition = function (data, callback) {
   const node = document.createTextNode(data)
   insertNode(node)
   selectNode(node)
-  collapseSelection("right", function () {
-    triggerEvent(element, "input")
-    triggerEvent(element, "compositionend", { data })
-    requestAnimationFrame (callback)
-  })
+  await collapseSelection("right")
+
+  triggerEvent(element, "input")
+  triggerEvent(element, "compositionend", { data })
+
+  await nextFrame()
 }
 
-export const clickElement = function (element, callback) {
+export const clickElement = async (element) => {
   if (triggerEvent(element, "mousedown")) {
-    defer(function () {
-      if (triggerEvent(element, "mouseup")) {
-        defer(function () {
-          triggerEvent(element, "click")
-          defer(callback)
-        })
-      }
-    })
+    await nextFrame()
+
+    if (triggerEvent(element, "mouseup")) {
+      await nextFrame()
+      triggerEvent(element, "click")
+      await nextFrame()
+    }
   }
 }
 
-export const dragToCoordinates = function (coordinates, callback) {
+export const dragToCoordinates = async (coordinates) => {
   const element = document.activeElement
 
   // IE only allows writing "text" to DataTransfer
@@ -218,10 +212,10 @@ export const dragToCoordinates = function (coordinates, callback) {
   const domRange = createDOMRangeFromPoint(clientX, clientY)
   triggerInputEvent(element, "beforeinput", { inputType: "insertFromDrop", ranges: [ domRange ] })
 
-  defer(callback)
+  await nextFrame()
 }
 
-export const mouseDownOnElementAndMove = function (element, distance, callback) {
+export const mouseDownOnElementAndMove = async (element, distance) => {
   const coordinates = getElementCoordinates(element)
   triggerEvent(element, "mousedown", coordinates)
 
@@ -231,81 +225,75 @@ export const mouseDownOnElementAndMove = function (element, distance, callback) 
   })
 
   const dragSpeed = 20
+  await delay(dragSpeed)
 
-  return after(dragSpeed, function () {
-    let drag
-    let offset = 0
-    return (drag = () => {
-      if (++offset <= distance) {
-        triggerEvent(element, "mousemove", destination(offset))
-        return after(dragSpeed, drag)
-      } else {
-        triggerEvent(element, "mouseup", destination(distance))
-        return after(dragSpeed, callback)
-      }
-    })()
-  })
+  let offset = 0
+  const drag = async () => {
+    if (++offset <= distance) {
+      triggerEvent(element, "mousemove", destination(offset))
+      await delay(dragSpeed)
+      drag()
+    } else {
+      triggerEvent(element, "mouseup", destination(distance))
+      await delay(dragSpeed)
+    }
+  }
+
+  drag()
 }
 
-const typeCharacterInElement = function (character, element, callback) {
+const typeCharacterInElement = async (character, element) => {
   const charCode = character.charCodeAt(0)
   const keyCode = character.toUpperCase().charCodeAt(0)
 
-  if (!triggerEvent(element, "keydown", { keyCode, charCode: 0 })) {
-    return callback()
-  }
+  if (!triggerEvent(element, "keydown", { keyCode, charCode: 0 })) return
 
-  defer(function () {
-    if (!triggerEvent(element, "keypress", { keyCode: charCode, charCode })) {
-      return callback()
-    }
-    triggerInputEvent(element, "beforeinput", { inputType: "insertText", data: character })
-    return insertCharacter(character, function () {
-      triggerEvent(element, "input")
+  await nextFrame()
 
-      defer(function () {
-        triggerEvent(element, "keyup", { keyCode, charCode: 0 })
-        return callback()
-      })
-    })
-  })
+  if (!triggerEvent(element, "keypress", { keyCode: charCode, charCode })) return
+
+  triggerInputEvent(element, "beforeinput", { inputType: "insertText", data: character })
+
+  await insertCharacter(character)
+  triggerEvent(element, "input")
+  await nextFrame()
+
+  triggerEvent(element, "keyup", { keyCode, charCode: 0 })
 }
 
-const insertCharacter = function (character, callback) {
+const insertCharacter = async (character) => {
   const node = document.createTextNode(character)
-  return insertNode(node, callback)
+  await insertNode(node)
 }
 
-const simulateKeypress = function (keyName, callback) {
+const simulateKeypress = async (keyName) => {
   switch (keyName) {
     case "backspace":
-      return deleteInDirection("left", callback)
+      await deleteInDirection("left")
+      break
     case "delete":
-      return deleteInDirection("right", callback)
+      await deleteInDirection("right")
+      break
     case "return":
-      defer(function () {
-        triggerInputEvent(document.activeElement, "beforeinput", { inputType: "insertParagraph" })
-        const node = document.createElement("br")
-        return insertNode(node, callback)
-      })
+      await nextFrame()
+      triggerInputEvent(document.activeElement, "beforeinput", { inputType: "insertParagraph" })
+      await insertNode(document.createElement("br"))
   }
 }
 
-const deleteInDirection = function (direction, callback) {
+const deleteInDirection = async (direction) => {
   if (selectionIsCollapsed()) {
     getComposition().expandSelectionInDirection(direction === "left" ? "backward" : "forward")
-    defer(function () {
-      const inputType = direction === "left" ? "deleteContentBackward" : "deleteContentForward"
-      triggerInputEvent(document.activeElement, "beforeinput", { inputType })
-      defer(function () {
-        deleteSelection()
-        return callback()
-      })
-    })
+    await nextFrame()
+
+    const inputType = direction === "left" ? "deleteContentBackward" : "deleteContentForward"
+    triggerInputEvent(document.activeElement, "beforeinput", { inputType })
+
+    await nextFrame()
+    deleteSelection()
   } else {
     triggerInputEvent(document.activeElement, "beforeinput", { inputType: "deleteContentBackward" })
     deleteSelection()
-    return callback()
   }
 }
 

--- a/src/test/test_helpers/input_helpers.js
+++ b/src/test/test_helpers/input_helpers.js
@@ -83,7 +83,7 @@ export const typeCharacters = async (string) => {
   const characters = Array.isArray(string) ? string : string.split("")
 
   const typeNextCharacter = async () => {
-    await nextFrame()
+    await delay(10)
     const character = characters.shift()
     if (character == null) return
 
@@ -103,6 +103,7 @@ export const typeCharacters = async (string) => {
   }
 
   await typeNextCharacter()
+  await delay(10)
 }
 
 export const pressKey = async (keyName) => {

--- a/src/test/test_helpers/timing_helpers.js
+++ b/src/test/test_helpers/timing_helpers.js
@@ -1,0 +1,11 @@
+export function nextFrame() {
+  return new Promise(requestAnimationFrame)
+}
+
+export function nextIdle() {
+  return new Promise(window.requestIdleCallback || setTimeout)
+}
+
+export function delay(ms = 1) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/src/test/test_helpers/toolbar_helpers.js
+++ b/src/test/test_helpers/toolbar_helpers.js
@@ -1,12 +1,12 @@
 import { triggerEvent } from "./event_helpers"
 import { selectionChangeObserver } from "trix/observers/selection_change_observer"
-import { nextFrame } from "./timing_helpers"
+import { delay, nextFrame } from "./timing_helpers"
 
 export const clickToolbarButton = async (selector) => {
   selectionChangeObserver.update()
   const button = getToolbarButton(selector)
   triggerEvent(button, "mousedown")
-  await nextFrame()
+  await delay(5)
 }
 
 export const typeToolbarKeyCommand = async (selector) => {

--- a/src/test/test_helpers/toolbar_helpers.js
+++ b/src/test/test_helpers/toolbar_helpers.js
@@ -1,28 +1,28 @@
-import { defer } from "trix/core/helpers"
 import { triggerEvent } from "./event_helpers"
 import { selectionChangeObserver } from "trix/observers/selection_change_observer"
+import { nextFrame } from "./timing_helpers"
 
-export const clickToolbarButton = function (selector, callback) {
+export const clickToolbarButton = async (selector) => {
   selectionChangeObserver.update()
   const button = getToolbarButton(selector)
   triggerEvent(button, "mousedown")
-  defer(callback)
+  await nextFrame()
 }
 
-export const typeToolbarKeyCommand = function (selector, callback) {
+export const typeToolbarKeyCommand = async (selector) => {
   const button = getToolbarButton(selector)
   const { trixKey } = button.dataset
   if (trixKey) {
     const keyCode = trixKey.toUpperCase().charCodeAt(0)
     triggerEvent(getEditorElement(), "keydown", { keyCode, charCode: 0, metaKey: true, ctrlKey: true })
   }
-  defer(callback)
+  await nextFrame()
 }
 
-export const clickToolbarDialogButton = function ({ method }, callback) {
+export const clickToolbarDialogButton = async ({ method }) => {
   const button = getToolbarElement().querySelector(`[data-trix-dialog] [data-trix-method='${method}']`)
   triggerEvent(button, "click")
-  defer(callback)
+  await nextFrame()
 }
 
 export const isToolbarButtonActive = function (selector) {
@@ -32,13 +32,13 @@ export const isToolbarButtonActive = function (selector) {
 
 export const isToolbarButtonDisabled = (selector) => getToolbarButton(selector).disabled
 
-export const typeInToolbarDialog = function (string, { attribute }, callback) {
+export const typeInToolbarDialog = async (string, { attribute }) => {
   const dialog = getToolbarDialog({ attribute })
   const input = dialog.querySelector(`[data-trix-input][name='${attribute}']`)
   const button = dialog.querySelector("[data-trix-method='setAttribute']")
   input.value = string
   triggerEvent(button, "click")
-  defer(callback)
+  await nextFrame()
 }
 
 export const isToolbarDialogActive = function (selector) {

--- a/src/test/unit/html_parser_test.js
+++ b/src/test/unit/html_parser_test.js
@@ -1,6 +1,5 @@
 import {
   TEST_IMAGE_URL,
-  after,
   assert,
   createCursorTarget,
   eachFixture,
@@ -12,6 +11,7 @@ import {
 
 import * as config from "trix/config"
 import HTMLParser from "trix/models/html_parser"
+import { delay } from "../test_helpers/timing_helpers"
 
 const cursorTargetLeft = createCursorTarget("left").outerHTML
 const cursorTargetRight = createCursorTarget("right").outerHTML
@@ -229,7 +229,7 @@ testGroup("HTMLParser", () => {
     assert.documentHTMLEqual(HTMLParser.parse(html).getDocument(), expectedHTML)
   })
 
-  test("sanitizes unsafe html", (done) => {
+  test("sanitizes unsafe html", async () => {
     window.unsanitized = []
     HTMLParser.parse(`
       <img onload="window.unsanitized.push('img.onload');" src="${TEST_IMAGE_URL}">
@@ -238,11 +238,9 @@ testGroup("HTMLParser", () => {
         window.unsanitized.push('script tag');
       </script>`)
 
-    after(20, () => {
-      assert.deepEqual(window.unsanitized, [])
-      delete window.unsanitized
-      done()
-    })
+    await delay(20)
+    assert.deepEqual(window.unsanitized, [])
+    delete window.unsanitized
   })
 
   test("forbids href attributes with javascript: protocol", () => {
@@ -262,7 +260,7 @@ testGroup("HTMLParser", () => {
     assert.documentHTMLEqual(HTMLParser.parse(html).getDocument(), expectedHTML)
   })
 
-  test("parses attachment caption from large html string", (done) => {
+  test("parses attachment caption from large html string", () => {
     let { html } = fixtures["image attachment with edited caption"]
 
     for (let i = 1; i <= 30; i++) {
@@ -273,8 +271,6 @@ testGroup("HTMLParser", () => {
       const attachmentPiece = HTMLParser.parse(html).getDocument().getAttachmentPieces()[0]
       assert.equal(attachmentPiece.getCaption(), "Example")
     }
-
-    done()
   })
 
   test("parses foreground color when configured", () => {

--- a/src/test/unit/mutation_observer_test.js
+++ b/src/test/unit/mutation_observer_test.js
@@ -1,6 +1,7 @@
-import { assert, defer, test, testGroup } from "test/test_helper"
+import { assert, test, testGroup } from "test/test_helper"
 
 import MutationObserver from "trix/observers/mutation_observer"
+import { nextFrame } from "../test_helpers/timing_helpers"
 
 let observer = null
 let element = null
@@ -26,85 +27,69 @@ const uninstall = () => {
   summaries = []
 }
 
-const observerTest = (name, options = {}, callback) =>
-  test(name, (done) => {
+const observerTest = (name, options = {}, callback) => {
+  test(name, async () => {
     install(options.html)
-    callback(() => {
-      uninstall()
-      done()
-    })
+    await callback()
+    uninstall()
   })
+}
 
 testGroup("MutationObserver", () => {
-  observerTest("add character", { html: "a" }, (done) => {
+  observerTest("add character", { html: "a" }, async () => {
     element.firstChild.data += "b"
-    defer(() => {
-      assert.equal(summaries.length, 1)
-      assert.deepEqual(summaries[0], { textAdded: "b" })
-      done()
-    })
+    await nextFrame()
+
+    assert.equal(summaries.length, 1)
+    assert.deepEqual(summaries[0], { textAdded: "b" })
   })
 
-  observerTest("remove character", { html: "ab" }, (done) => {
+  observerTest("remove character", { html: "ab" }, async () => {
     element.firstChild.data = "a"
-    defer(() => {
-      assert.equal(summaries.length, 1)
-      assert.deepEqual(summaries[0], { textDeleted: "b" })
-      done()
-    })
+    await nextFrame()
+    assert.equal(summaries.length, 1)
+    assert.deepEqual(summaries[0], { textDeleted: "b" })
   })
 
-  observerTest("replace character", { html: "ab" }, (done) => {
+  observerTest("replace character", { html: "ab" }, async () => {
     element.firstChild.data = "ac"
-    defer(() => {
-      assert.equal(summaries.length, 1)
-      assert.deepEqual(summaries[0], { textAdded: "c", textDeleted: "b" })
-      done()
-    })
+    await nextFrame()
+    assert.equal(summaries.length, 1)
+    assert.deepEqual(summaries[0], { textAdded: "c", textDeleted: "b" })
   })
 
-  observerTest("add <br>", { html: "a" }, (done) => {
+  observerTest("add <br>", { html: "a" }, async () => {
     element.appendChild(document.createElement("br"))
-    defer(() => {
-      assert.equal(summaries.length, 1)
-      assert.deepEqual(summaries[0], { textAdded: "\n" })
-      done()
-    })
+    await nextFrame()
+    assert.equal(summaries.length, 1)
+    assert.deepEqual(summaries[0], { textAdded: "\n" })
   })
 
-  observerTest("remove <br>", { html: "a<br>" }, (done) => {
+  observerTest("remove <br>", { html: "a<br>" }, async () => {
     element.removeChild(element.lastChild)
-    defer(() => {
-      assert.equal(summaries.length, 1)
-      assert.deepEqual(summaries[0], { textDeleted: "\n" })
-      done()
-    })
+    await nextFrame()
+    assert.equal(summaries.length, 1)
+    assert.deepEqual(summaries[0], { textDeleted: "\n" })
   })
 
-  observerTest("remove block comment", { html: "<div><!--block-->a</div>" }, (done) => {
+  observerTest("remove block comment", { html: "<div><!--block-->a</div>" }, async () => {
     element.firstChild.removeChild(element.firstChild.firstChild)
-    defer(() => {
-      assert.equal(summaries.length, 1)
-      assert.deepEqual(summaries[0], { textDeleted: "\n" })
-      done()
-    })
+    await nextFrame()
+    assert.equal(summaries.length, 1)
+    assert.deepEqual(summaries[0], { textDeleted: "\n" })
   })
 
-  observerTest("remove formatted element", { html: "a<strong>b</strong>" }, (done) => {
+  observerTest("remove formatted element", { html: "a<strong>b</strong>" }, async () => {
     element.removeChild(element.lastChild)
-    defer(() => {
-      assert.equal(summaries.length, 1)
-      assert.deepEqual(summaries[0], { textDeleted: "b" })
-      done()
-    })
+    await nextFrame()
+    assert.equal(summaries.length, 1)
+    assert.deepEqual(summaries[0], { textDeleted: "b" })
   })
 
-  observerTest("remove nested formatted elements", { html: "a<strong>b<em>c</em></strong>" }, (done) => {
+  observerTest("remove nested formatted elements", { html: "a<strong>b<em>c</em></strong>" }, async () => {
     element.removeChild(element.lastChild)
-    defer(() => {
-      assert.equal(summaries.length, 1)
-      assert.deepEqual(summaries[0], { textDeleted: "bc" })
-      done()
-    })
+    await nextFrame()
+    assert.equal(summaries.length, 1)
+    assert.deepEqual(summaries[0], { textDeleted: "bc" })
   })
 })


### PR DESCRIPTION
Avoids deep nesting, especially when some async events, like inputs in tests, are performed in sequence.

The nesting was never very readable, but since we moved away from coffeescript it became even messier with the added closing curly brackets.

Note that I've replaced most calls to `defer(callback)` with `await nextFrame()`. However, `defer`[ is implemented](https://github.com/basecamp/trix/blob/7ff9d32c0ac286b778b0808973bc52322c4b6606/src/trix/core/helpers/functions.js#L1) as a 1ms delay while `nextFrame` is [just calling](https://github.com/basecamp/trix/blob/7ff9d32c0ac286b778b0808973bc52322c4b6606/src/test/test_helpers/timing_helpers.js#L1-L3) `requestAnimationFrame`. They should be roughly equivalent but there might be slight differences that can make the some tests flaky. I suggest patching those tests adjusting the delay if we see they are flaky.