### PR TITLE
Show output on the development page

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -8,9 +8,27 @@
     <link rel="icon" href="data:,">
     <link rel="stylesheet" type="text/css" href="trix.css">
     <style type="text/css">
+      * {
+        box-sizing: border-box;
+      }
+
       main {
         margin: 20px auto;
         max-width: 700px;
+      }
+
+      #output {
+        margin: 1rem 0 0;
+      }
+
+      #output textarea {
+        width: 100%;
+        height: 6rem;
+        resize: vertical;
+        font-family: monospace;
+        border-radius: 5px;
+        border: solid 1px #444;
+        padding: 10px;
       }
     </style>
     <script type="module" src="trix.esm.js"></script>
@@ -56,7 +74,11 @@
   </head>
   <body>
     <main>
-      <trix-editor autofocus class="trix-content"></trix-editor>
+      <trix-editor autofocus class="trix-content" input="input"></trix-editor>
+      <details id="output">
+        <summary>Output</summary>
+        <textarea readonly id="input"></textarea>
+      </details>
     </main>
   </body>
 </html>


### PR DESCRIPTION
Adds an extra pane to show the current HTML of the editor, which can be handy during development.

<img width="1177" alt="Screenshot 2022-10-27 at 13 14 44" src="https://user-images.githubusercontent.com/1186763/198281807-a4308ca1-263f-4a0d-87cb-a4b149a84afb.png">
