### PR TITLE
Ignore multiple `start()` calls

### DIFF
--- a/src/trix/trix.js
+++ b/src/trix/trix.js
@@ -10,6 +10,16 @@ import * as operations from "trix/operations"
 import * as elements from "trix/elements"
 import * as filters from "trix/filters"
 
+let started = false
+
+function start() {
+  if (!started) {
+    customElements.define("trix-toolbar", elements.TrixToolbarElement)
+    customElements.define("trix-editor", elements.TrixEditorElement)
+    started = true
+  }
+}
+
 const Trix = {
   VERSION: version,
   config,
@@ -21,10 +31,7 @@ const Trix = {
   operations,
   elements,
   filters,
-  start: () => {
-    customElements.define("trix-toolbar", elements.TrixToolbarElement)
-    customElements.define("trix-editor", elements.TrixEditorElement)
-  }
+  start
 }
 
 window.Trix = Trix


### PR DESCRIPTION
This makes duplicate `Trix.start()` calls harmless, so that clients don't need to keep track of whether they have previously called it. Previously calling `start()` a second time raised an error.

This makes it easier for clients that delay importing Trix until it's needed, and may have `Trix.start()` calls in multiple places.