### PR TITLE
Allow intercepting attachment toolbar creation

### DIFF
--- a/src/test/system/attachment_test.js
+++ b/src/test/system/attachment_test.js
@@ -41,6 +41,23 @@ testGroup("Attachments", { template: "editor_with_image" }, () => {
     expectDocument("ab\n")
   })
 
+  test("intercepting attachment toolbar creation", async () => {
+    function insertToolbarButton(event) {
+      const { toolbar, attachment } = event
+
+      assert.ok(toolbar.matches(".attachment__toolbar"))
+      assert.equal(attachment.getContentType(), "image")
+
+      toolbar.querySelector(".trix-button-group").insertAdjacentHTML("beforeend", "<button class=\"new-button\">👍</button>")
+    }
+
+    getEditorElement().addEventListener("trix-attachment-before-toolbar", insertToolbarButton, { once: true })
+
+    await clickElement(getFigure())
+
+    assert.ok(getEditorElement().querySelector(".trix-button-group .new-button"))
+  })
+
   test("editing an image caption", async () => {
     await delay(20)
 

--- a/src/trix/controllers/attachment_editor_controller.js
+++ b/src/trix/controllers/attachment_editor_controller.js
@@ -3,7 +3,7 @@ import { removeNode } from "trix/core/helpers"
 import * as config from "trix/config"
 import BasicObject from "trix/core/basic_object"
 
-import { defer, handleEvent, makeElement, tagName } from "trix/core/helpers"
+import { defer, handleEvent, makeElement, tagName, triggerEvent } from "trix/core/helpers"
 const { lang, css, keyNames } = config
 
 const undoable = function(fn) {
@@ -147,6 +147,8 @@ export default class AttachmentEditorController extends BasicObject {
       matchingSelector: "[data-trix-action]",
       withCallback: this.didClickActionButton,
     })
+
+    triggerEvent("trix-attachment-before-toolbar", { onElement: this.element, attributes: { toolbar: element, attachment: this.attachment } })
 
     return {
       do: () => this.element.appendChild(element),


### PR DESCRIPTION
There are cases where applications want to customize the attachment toolbar UI to add additional functionality. To allow this, we add a new `trix-attachment-before-toolbar` event which fires when an attachment is selected in the editor, before its toolbar is displayed. Applications can listen for this event, and alter or extend the toolbar as necessary.

The event contains the follow attributes:

- `attachment` - the `Attachment` instance corresponding to the item that is being selected.
- `toolbar` - the element containing the toolbar UI. Applications can modify this element and its children as necessary.