### PR TITLE
Guard against Samsung keyboard triggering a re-render when the cursor moves

### DIFF
--- a/src/trix/config/browser.js
+++ b/src/trix/config/browser.js
@@ -3,8 +3,10 @@ export default {
   // Introduced in Chrome 65: https://bugs.chromium.org/p/chromium/issues/detail?id=764439#c9
   composesExistingText: /Android.*Chrome/.test(navigator.userAgent),
 
-  // On Android 13 Samsung keyboards emit a composition event when moving the cursor
-  composesOnCursorMove: (function() {
+  // Android 13, especially on Samsung keyboards, emits extra compositionend and beforeinput events
+  // that can make the input handler lose the the current selection or enter an infinite input -> render -> input
+  // loop.
+  recentAndroid: (function() {
     const androidVersionMatch = navigator.userAgent.match(/android\s([0-9]+.*Chrome)/i)
     return androidVersionMatch && parseInt(androidVersionMatch[1]) > 12
   })(),

--- a/src/trix/config/browser.js
+++ b/src/trix/config/browser.js
@@ -5,10 +5,8 @@ export default {
 
   // On Android 13 Samsung keyboards emit a composition event when moving the cursor
   composesOnCursorMove: (function() {
-    const samsungAndroid = /Android.*SM-.*Chrome/.test(navigator.userAgent)
-    const androidVersionMatch = navigator.userAgent.match(/android\s([0-9]+)/i)
-
-    return samsungAndroid && androidVersionMatch && parseInt(androidVersionMatch[1]) > 12
+    const androidVersionMatch = navigator.userAgent.match(/android\s([0-9]+.*Chrome)/i)
+    return androidVersionMatch && parseInt(androidVersionMatch[1]) > 12
   })(),
 
   // IE 11 activates resizing handles on editable elements that have "layout"

--- a/src/trix/config/browser.js
+++ b/src/trix/config/browser.js
@@ -1,3 +1,6 @@
+const androidVersionMatch = navigator.userAgent.match(/android\s([0-9]+.*Chrome)/i)
+const androidVersion = androidVersionMatch && parseInt(androidVersionMatch[1])
+
 export default {
   // Android emits composition events when moving the cursor through existing text
   // Introduced in Chrome 65: https://bugs.chromium.org/p/chromium/issues/detail?id=764439#c9
@@ -6,10 +9,8 @@ export default {
   // Android 13, especially on Samsung keyboards, emits extra compositionend and beforeinput events
   // that can make the input handler lose the the current selection or enter an infinite input -> render -> input
   // loop.
-  recentAndroid: (function() {
-    const androidVersionMatch = navigator.userAgent.match(/android\s([0-9]+.*Chrome)/i)
-    return androidVersionMatch && parseInt(androidVersionMatch[1]) > 12
-  })(),
+  recentAndroid: androidVersion && androidVersion > 12,
+  samsungAndroid: androidVersion && navigator.userAgent.match(/Android.*SM-/),
 
   // IE 11 activates resizing handles on editable elements that have "layout"
   forcesObjectResizing: /Trident.*rv:11/.test(navigator.userAgent),

--- a/src/trix/config/browser.js
+++ b/src/trix/config/browser.js
@@ -15,15 +15,6 @@ export default {
   // IE 11 activates resizing handles on editable elements that have "layout"
   forcesObjectResizing: /Trident.*rv:11/.test(navigator.userAgent),
   // https://www.w3.org/TR/input-events-1/ + https://www.w3.org/TR/input-events-2/
-  supportsInputEvents: (function() {
-    if (typeof InputEvent === "undefined") {
-      return false
-    }
-    for (const property of [ "data", "getTargetRanges", "inputType" ]) {
-      if (!(property in InputEvent.prototype)) {
-        return false
-      }
-    }
-    return true
-  })(),
+  supportsInputEvents: typeof InputEvent !== "undefined" &&
+    [ "data", "getTargetRanges", "inputType" ].every(prop => prop in InputEvent.prototype),
 }

--- a/src/trix/config/browser.js
+++ b/src/trix/config/browser.js
@@ -2,6 +2,15 @@ export default {
   // Android emits composition events when moving the cursor through existing text
   // Introduced in Chrome 65: https://bugs.chromium.org/p/chromium/issues/detail?id=764439#c9
   composesExistingText: /Android.*Chrome/.test(navigator.userAgent),
+
+  // On Android 13 Samsung keyboards emit a composition event when moving the cursor
+  composesOnCursorMove: (function() {
+    const samsungAndroid = /Android.*SM-.*Chrome/.test(navigator.userAgent)
+    const androidVersionMatch = navigator.userAgent.match(/android\s([0-9]+)/i)
+
+    return samsungAndroid && androidVersionMatch && parseInt(androidVersionMatch[1]) > 12
+  })(),
+
   // IE 11 activates resizing handles on editable elements that have "layout"
   forcesObjectResizing: /Trident.*rv:11/.test(navigator.userAgent),
   // https://www.w3.org/TR/input-events-1/ + https://www.w3.org/TR/input-events-2/

--- a/src/trix/controllers/level_2_input_controller.js
+++ b/src/trix/controllers/level_2_input_controller.js
@@ -82,7 +82,7 @@ export default class Level2InputController extends InputController {
     },
 
     input(event) {
-      return selectionChangeObserver.reset()
+      if (!emittedBySamsungKeyboard(event)) selectionChangeObserver.reset()
     },
 
     dragstart(event) {
@@ -613,7 +613,9 @@ const pointFromEvent = (event) => ({
 // Samsung keyboard running in a webview emits insertText events
 // with composed true, in addition to composition events, let's ignore those
 const guardAgainstSpuriousAndroidEvents = (event) => {
-  return config.browser.recentAndroid &&
-    event.inputType === "insertText" &&
-    event.composed && event.data !== ". "
+  return emittedBySamsungKeyboard(event) && event.data !== ". "
+}
+
+const emittedBySamsungKeyboard = (event) => {
+  return config.browser.samsungAndroid && event.inputType === "insertText" && !event.sourceCapabilities
 }

--- a/src/trix/controllers/level_2_input_controller.js
+++ b/src/trix/controllers/level_2_input_controller.js
@@ -1,5 +1,6 @@
 import { getAllAttributeNames, squishBreakableWhitespace } from "trix/core/helpers"
 import InputController from "trix/controllers/input_controller"
+import * as config from "trix/config"
 
 import { dataTransferIsPlainText, keyEventIsKeyboardCommand, objectsAreEqual } from "trix/core/helpers"
 
@@ -136,7 +137,7 @@ export default class Level2InputController extends InputController {
     compositionend(event) {
       if (this.composing) {
         this.composing = false
-        return this.scheduleRender()
+        if (!config.browser.composesOnCursorMove) this.scheduleRender()
       }
     },
   }

--- a/src/trix/controllers/level_2_input_controller.js
+++ b/src/trix/controllers/level_2_input_controller.js
@@ -71,10 +71,13 @@ export default class Level2InputController extends InputController {
     },
 
     beforeinput(event) {
+      if (guardAgainstSpuriousAndroidEvents(event)) return
+
       const handler = this.constructor.inputTypes[event.inputType]
+
       if (handler) {
         this.withEvent(event, handler)
-        return this.scheduleRender()
+        this.scheduleRender()
       }
     },
 
@@ -137,7 +140,7 @@ export default class Level2InputController extends InputController {
     compositionend(event) {
       if (this.composing) {
         this.composing = false
-        if (!config.browser.composesOnCursorMove) this.scheduleRender()
+        if (!config.browser.recentAndroid) this.scheduleRender()
       }
     },
   }
@@ -606,3 +609,11 @@ const pointFromEvent = (event) => ({
   x: event.clientX,
   y: event.clientY,
 })
+
+// Samsung keyboard running in a webview emits insertText events
+// with composed true, in addition to composition events, let's ignore those
+const guardAgainstSpuriousAndroidEvents = (event) => {
+  return config.browser.recentAndroid &&
+    event.inputType === "insertText" &&
+    event.composed && event.data !== ". "
+}


### PR DESCRIPTION
On Android 13 with recent versions of the Samsung keyboard a `compositionend` event triggers when the user moves the cursor to a different line. If we re-render the document exactly at that moment we lose the selection range and the cursor comes back to where it was, instead of the place where the user tapped on.


https://user-images.githubusercontent.com/150107/203074957-b2c03f96-8757-4ce2-9e8c-a70de6b29388.mp4

Notice that I can not feature detect the Samsung keyboard so I'm skipping the rendering in all Samsung devices with Android version >= 13. This doesn't seem an issue because when a composition ends there's always `compositionupdate` and `input` events that update the DOM.

