### PR TITLE
Update Loading and Saving Editor State Readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Serialize an editor’s state with `JSON.stringify` and restore saved state with
 localStorage["editorState"] = JSON.stringify(element.editor)
 
 // Restore editor state from local storage
-element.editor.loadJSON({document: JSON.parse(localStorage["editorState"])})
+element.editor.loadJSON(JSON.parse(localStorage["editorState"]))
 ```
 
 ## Observing Editor Changes


### PR DESCRIPTION
the `document` outer key wrapper is dumped when you `JSON.stringify` `editor`, so adding it again when restoring is redundent.