### PR TITLE
fix(attachment): allow captions to be deleted

### DIFF
--- a/src/trix/controllers/attachment_editor_controller.js
+++ b/src/trix/controllers/attachment_editor_controller.js
@@ -58,7 +58,7 @@ export default class AttachmentEditorController extends BasicObject {
   // Private
 
   savePendingCaption() {
-    if (this.pendingCaption) {
+    if (this.pendingCaption != null) {
       const caption = this.pendingCaption
       this.pendingCaption = null
       if (caption) {


### PR DESCRIPTION
This worked in v1.3.5 but it was removed in https://github.com/basecamp/trix/commit/7f742dc1afc502689fcb5c16f235d5088c6462fe#diff-e002f6f45c988abee91b7486a2bf15b07762e0d230d3d279847a7098cd7ab5abL69-R68 which I believe was a mistake: `""` is an empty caption that in v1.3.5 would restore the default caption (`""` is not loosely equal to `null`) but since v2 it does nothing (`""` is falsy).
