### PR TITLE
Prevent mutation XSS vulnerability

### DIFF
--- a/src/test/system/pasting_test.js
+++ b/src/test/system/pasting_test.js
@@ -67,6 +67,7 @@ testGroup("Pasting", { template: "editor_empty" }, () => {
       "text/html": `\
         <img onload="window.unsanitized.push('img.onload');" src="${TEST_IMAGE_URL}">
         <img onerror="window.unsanitized.push('img.onerror');" src="data:image/gif;base64,TOTALLYBOGUS">
+        <form><math><mtext></form><form><mglyph><style></math><img src onerror="window.unsanitized.push('img.onerror');">
         <script>
           window.unsanitized.push('script tag');
         </script>`,

--- a/src/trix/models/html_sanitizer.js
+++ b/src/trix/models/html_sanitizer.js
@@ -4,7 +4,7 @@ import { nodeIsAttachmentElement, removeNode, tagName, walkTree } from "trix/cor
 
 const DEFAULT_ALLOWED_ATTRIBUTES = "style href src width height class".split(" ")
 const DEFAULT_FORBIDDEN_PROTOCOLS = "javascript:".split(" ")
-const DEFAULT_FORBIDDEN_ELEMENTS = "script iframe".split(" ")
+const DEFAULT_FORBIDDEN_ELEMENTS = "script iframe form".split(" ")
 
 export default class HTMLSanitizer extends BasicObject {
   static sanitize(html, options) {


### PR DESCRIPTION
It is currently possible to bypass Trix HTML sanitization process pasting carefully crafted HTML that exploits mutation XSS vulnerabilities in the HTML spec.

A full explanation of the vulnerability can be found here:

https://research.securitum.com/mutation-xss-via-mathml-mutation-dompurify-2-0-17-bypass/

Note that the bogus HTML will go away as soon as Trix re-renders its document model, but still, it will allow JS execution for a short period of time.

A way to patch this vulnerability is to clean up form elements on HTML paste. As mentioned before, those elements would be striped away once Trix re-renders its document model anyway, so there's no legit case to include them in the first place.