### PR TITLE
Restore detection of text direction on Chrome

### DIFF
--- a/src/test/unit.js
+++ b/src/test/unit.js
@@ -1,4 +1,5 @@
 import "test/unit/attachment_test"
+import "test/unit/bidi_test"
 import "test/unit/block_test"
 import "test/unit/composition_test"
 import "test/unit/document_test"

--- a/src/test/unit/bidi_test.js
+++ b/src/test/unit/bidi_test.js
@@ -1,0 +1,9 @@
+import { assert, test, testGroup } from "test/test_helper"
+import { getDirection } from "trix/core/helpers"
+
+testGroup("BIDI", () => {
+  test("detects text direction", () => {
+    assert.equal(getDirection("abc"), "ltr")
+    assert.equal(getDirection("אבג"), "rtl")
+  })
+})

--- a/src/trix/core/helpers/bidi.js
+++ b/src/trix/core/helpers/bidi.js
@@ -6,8 +6,10 @@ const RTL_PATTERN =
 
 export const getDirection = (function() {
   const input = makeElement("input", { dir: "auto", name: "x", dirName: "x.dir" })
+  const textArea = makeElement("textarea", { dir: "auto", name: "y", dirName: "y.dir" })
   const form = makeElement("form")
   form.appendChild(input)
+  form.appendChild(textArea)
 
   const supportsDirName = (function() {
     try {
@@ -27,8 +29,8 @@ export const getDirection = (function() {
 
   if (supportsDirName) {
     return function(string) {
-      input.value = string
-      return new FormData(form).get(input.dirName)
+      input.value = textArea.value = string
+      return new FormData(form).get(textArea.dirName)
     }
   } else if (supportsDirSelector) {
     return function(string) {

--- a/src/trix/core/helpers/bidi.js
+++ b/src/trix/core/helpers/bidi.js
@@ -13,7 +13,7 @@ export const getDirection = (function() {
 
   const supportsDirName = (function() {
     try {
-      return new FormData(form).has(input.dirName)
+      return new FormData(form).has(textArea.dirName)
     } catch (error) {
       return false
     }
@@ -29,7 +29,7 @@ export const getDirection = (function() {
 
   if (supportsDirName) {
     return function(string) {
-      input.value = textArea.value = string
+      textArea.value = string
       return new FormData(form).get(textArea.dirName)
     }
   } else if (supportsDirSelector) {


### PR DESCRIPTION
Chrome recently changed (or broke) the `dirname` support for `input`, and it doesn't set the direction on the containing form. This results in the RTL text to align left.

This PR adds a `textarea` to restore the behaviour on Chrome. We still need the `input` to support the `:dir(rtl|ltr)` pseudo-class query for Firefox.

Fixes https://github.com/basecamp/trix/issues/1059