### PR TITLE
Include trix and inspectors in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "style": "dist/trix.css",
   "files": [
     "dist/*.css",
-    "dist/*.js"
+    "dist/*.js",
+    "src/{inspector,trix}/*.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Follow up on https://github.com/basecamp/trix/pull/1041 where ```src``` was removed from ```.npmignore``` but not included in the files section of ```package.json```.