### PR TITLE
Fix inlining NON_BREAKING_SPACE

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,9 @@ const defaultConfig = {
 
 const terserConfig = terser({
   mangle: true,
-  compress: true,
+  compress: {
+    reduce_vars: false // eslint-disable-line
+  },
   format: {
     comments: function (node, comment) {
       const text = comment.value


### PR DESCRIPTION
This should fix #1061 

This fixes issue where during compress step of rollup/terser-plugin, NON_BREAKING_SPACE constant is inlined as " " (normal, breaking space).

Because of this issue, there may be a case where putting space is not possible.

I had to disable ESLint rule since this is what `terser` actually expects as a option.