### PR TITLE
Fix copy/paste images in Chrome

### DIFF
--- a/src/test/system/level_2_input_test.js
+++ b/src/test/system/level_2_input_test.js
@@ -219,6 +219,21 @@ testGroup("Level 2 Input", testOptions, () => {
     expectDocument(`${url}\n`)
   })
 
+  // Pastes from Google Chrome include text/html + a file, we want the file!
+  // https://input-inspector.javan.us/profiles/r1s8c7DqbOQXXjz76mj0
+  test("pasting image copied from Google Chrome", async () => {
+    const file = await createFile()
+    const clipboardData = createDataTransfer({
+      "text/html": "<meta charset=\"utf-8\"><img src=\"https://www.google.com/images/branding/googlelogo/2x/googlelogo_light_color_272x92dp.png\" alt=\"Google\"/>",
+      Files: [ file ],
+    })
+
+    await paste({ clipboardData })
+    const attachments = getDocument().getAttachments()
+    assert.equal(attachments.length, 1)
+    expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
+  })
+
   // Pastes from MS Word include an image of the copied text 🙃
   // https://input-inspector.now.sh/profiles/QWDITsV60dpEVl1SOZg8
   test("pasting text from MS Word", async () => {

--- a/src/trix/controllers/level_2_input_controller.js
+++ b/src/trix/controllers/level_2_input_controller.js
@@ -40,7 +40,7 @@ export default class Level2InputController extends InputController {
       // https://bugs.webkit.org/show_bug.cgi?id=194921
       let paste
       const href = event.clipboardData?.getData("URL")
-      if (pasteEventHasFilesOnly(event)) {
+      if (pasteEventHasAFile(event)) {
         event.preventDefault()
         return this.attachFiles(event.clipboardData.files)
 
@@ -577,10 +577,10 @@ const staticRangeToRange = function(staticRange) {
 
 const dragEventHasFiles = (event) => Array.from(event.dataTransfer?.types || []).includes("Files")
 
-const pasteEventHasFilesOnly = function(event) {
+const pasteEventHasAFile = function(event) {
   const clipboard = event.clipboardData
   if (clipboard) {
-    return clipboard.types.includes("Files") && clipboard.types.length === 1 && clipboard.files.length >= 1
+    return clipboard.types.includes("Files") && clipboard.types.length <= 2 && clipboard.files.length >= 1
   }
 }
 


### PR DESCRIPTION
This is an updated version of https://github.com/basecamp/trix/pull/1000 for the move to ES6.