### PR TITLE
Fix caret move on iOS 17

### DIFF
--- a/src/trix/observers/selection_change_observer.js
+++ b/src/trix/observers/selection_change_observer.js
@@ -49,7 +49,9 @@ export default class SelectionChangeObserver extends BasicObject {
 
   update() {
     const domRange = getDOMRange()
-    if (!domRangesAreEqual(domRange, this.domRange)) {
+    const caretMove = window.getSelection().type === "Caret"
+
+    if (!domRangesAreEqual(domRange, this.domRange) || caretMove) {
       this.domRange = domRange
       return this.notifySelectionManagersOfSelectionChange()
     }


### PR DESCRIPTION
There's an issue with iOS 17 where if you move the caret and then press backwards, for example because you made a typo, the caret will jump to its previous position. This is because on the onselectionchange event the event handler doesn't see the caret move as a new DOM range. It thinks the DOM range is the same as before and doesn't notify the registered observers.

If we receive an onselectionchange event and the selection type is "Caret" that means the caret moved and we should notify the observers, regardless of whether the DOM range is the same as before.