### PR TITLE
Simplify SelectionChangeObserver update logic

### DIFF
--- a/src/trix/observers/selection_change_observer.js
+++ b/src/trix/observers/selection_change_observer.js
@@ -43,26 +43,13 @@ export default class SelectionChangeObserver extends BasicObject {
   }
 
   update() {
-    const domRange = getDOMRange()
-    const caretMove = window.getSelection().type === "Caret"
-
-    if (!domRangesAreEqual(domRange, this.domRange) || caretMove) {
-      this.domRange = domRange
-      return this.notifySelectionManagersOfSelectionChange()
-    }
+    this.notifySelectionManagersOfSelectionChange()
   }
 
   reset() {
-    this.domRange = null
-    return this.update()
+    this.update()
   }
 }
-
-const domRangesAreEqual = (left, right) =>
-  left?.startContainer === right?.startContainer &&
-  left?.startOffset === right?.startOffset &&
-  left?.endContainer === right?.endContainer &&
-  left?.endOffset === right?.endOffset
 
 export const selectionChangeObserver = new SelectionChangeObserver()
 

--- a/src/trix/observers/selection_change_observer.js
+++ b/src/trix/observers/selection_change_observer.js
@@ -7,18 +7,13 @@ export default class SelectionChangeObserver extends BasicObject {
   constructor() {
     super(...arguments)
     this.update = this.update.bind(this)
-    this.run = this.run.bind(this)
     this.selectionManagers = []
   }
 
   start() {
     if (!this.started) {
       this.started = true
-      if ("onselectionchange" in document) {
-        return document.addEventListener("selectionchange", this.update, true)
-      } else {
-        return this.run()
-      }
+      document.addEventListener("selectionchange", this.update, true)
     }
   }
 
@@ -60,15 +55,6 @@ export default class SelectionChangeObserver extends BasicObject {
   reset() {
     this.domRange = null
     return this.update()
-  }
-
-  // Private
-
-  run() {
-    if (this.started) {
-      this.update()
-      return requestAnimationFrame(this.run)
-    }
   }
 }
 

--- a/src/trix/observers/selection_change_observer.js
+++ b/src/trix/observers/selection_change_observer.js
@@ -1,6 +1,3 @@
-/* eslint-disable
-    id-length,
-*/
 import BasicObject from "trix/core/basic_object"
 
 export default class SelectionChangeObserver extends BasicObject {
@@ -32,7 +29,7 @@ export default class SelectionChangeObserver extends BasicObject {
   }
 
   unregisterSelectionManager(selectionManager) {
-    this.selectionManagers = this.selectionManagers.filter((s) => s !== selectionManager)
+    this.selectionManagers = this.selectionManagers.filter((sm) => sm !== selectionManager)
     if (this.selectionManagers.length === 0) {
       return this.stop()
     }


### PR DESCRIPTION
This introduces some changes to simplify `SelectionChangeObserver`. The main motivation for the changes is to fix some bugs that came up in iOS 17, but the end result should be simpler logic too.

Firstly, this removes the fallback to polling for selection changes when `selectionchange` event is not available. The `selectionchange` API has been available in all browsers for a long time now. The last browsers to add support for it were Firefox in version 52, and Chrome for Android, both in 2017.

Secondly, it removes a condition to check if the selected for DOM range has changed since the last time the `SelectionChangeObserver` was called. This check causes problems on Safari 17 when you drag the cursor to select text. Safari weirdly reports the selection range as being collapsed, even when you select multiple characters. This, in turn, causes the `SelectionManager` to think that the selection is collapsed and not trying to find where it ends. The end result for the user is that they can not apply formatting or links to the whole selected text.

This is ultimately a Safari bug, but it's not clear that we need to check for DOM range equality in the first place. We only do this because the original implementation of the `SelectionChangeObserver` used polling to check for selection changes, instead of relying on the `selectionchange` event. Now that we're using the `selectionchange` event, we can assume that if a selection change event fires, the selection has changed.
