### PR TITLE
Normalize lone CRs as new lines

### DIFF
--- a/src/test/system/pasting_test.js
+++ b/src/test/system/pasting_test.js
@@ -60,6 +60,16 @@ testGroup("Pasting", { template: "editor_empty" }, () => {
     expectDocument("a\nb\nc\n")
   })
 
+  test("paste plain text with CR", async () => {
+    await pasteContent("text/plain", "a\rb\rc")
+    expectDocument("a\nb\nc\n")
+  })
+
+  test("paste html with CR", async () => {
+    await pasteContent("text/html", "<div>a<br></div>\r<div>b<br></div>\r<div>c<br></div>")
+    expectDocument("a\nb\nc\n")
+  })
+
   test("paste unsafe html", async () => {
     window.unsanitized = []
     const pasteData = {

--- a/src/trix/core/helpers/strings.js
+++ b/src/trix/core/helpers/strings.js
@@ -8,7 +8,7 @@ import UTF16String from "trix/core/utilities/utf16_string"
 export const normalizeSpaces = (string) =>
   string.replace(new RegExp(`${ZERO_WIDTH_SPACE}`, "g"), "").replace(new RegExp(`${NON_BREAKING_SPACE}`, "g"), " ")
 
-export const normalizeNewlines = (string) => string.replace(/\r\n/g, "\n")
+export const normalizeNewlines = (string) => string.replace(/\r\n?/g, "\n")
 
 export const breakableWhitespacePattern = new RegExp(`[^\\S${NON_BREAKING_SPACE}]`)
 


### PR DESCRIPTION
One of our users ran into a scenario where copying content from [Skype](https://www.skype.com/en/) into a Trix editor in Chrome would record line breaks as a lone `\r` character. This results in the line breaks being omitted because we're not normalizing `\r` into a new line.

We already normalize `\r\n` as a `\n` character. This change makes it so we also normalize `\r` into `\n`.

Here's the contents of my clipboard after trying copying from Skype myself:
```
{
  "text/plain": "José, 02:19 PM\rTest message #1\rContent in a new line\r\rJosé, 02:19 PM\rTest message #2\rContent in another new line"
}
```

https://3.basecamp.com/2914079/buckets/27/card_tables/cards/6628261881