### PR TITLE
Content Not Refreshed Correctly when Modifying Pasted Content in Callbacks

### DIFF
--- a/src/trix/controllers/level_2_input_controller.js
+++ b/src/trix/controllers/level_2_input_controller.js
@@ -53,7 +53,7 @@ export default class Level2InputController extends InputController {
         }
         this.delegate?.inputControllerWillPaste(paste)
         this.responder?.insertString(paste.string)
-        this.render()
+        this.requestRender()
         return this.delegate?.inputControllerDidPaste(paste)
 
         // https://bugs.webkit.org/show_bug.cgi?id=196702
@@ -65,7 +65,7 @@ export default class Level2InputController extends InputController {
         }
         this.delegate?.inputControllerWillPaste(paste)
         this.responder?.insertHTML(paste.html)
-        this.render()
+        this.requestRender()
         return this.delegate?.inputControllerDidPaste(paste)
       }
     },


### PR DESCRIPTION
Fixes #1103.

When [pasting plain text content](https://github.com/basecamp/trix/blob/v2.0.7/src/trix/controllers/level_2_input_controller.js#L48) or a [URL](https://github.com/basecamp/trix/blob/v2.0.7/src/trix/controllers/level_2_input_controller.js#L60), if you modify the content in a `trix-change` or `trix-paste` callback, the changes aren't reflected in the editor after the paste is finished.  The changes are reflected later if you start to type in the editor.

This pull request updates how the render is performed to match other areas like [this](https://github.com/basecamp/trix/blob/v2.0.7/src/trix/controllers/level_0_input_controller.js#L178).