### PR TITLE
Pass invoking element as event data

### DIFF
--- a/src/trix/controllers/editor_controller.js
+++ b/src/trix/controllers/editor_controller.js
@@ -374,8 +374,8 @@ export default class EditorController extends Controller {
     }
   }
 
-  toolbarDidInvokeAction(actionName) {
-    return this.invokeAction(actionName)
+  toolbarDidInvokeAction(actionName, invokingElement) {
+    return this.invokeAction(actionName, invokingElement)
   }
 
   toolbarDidToggleAttribute(attributeName) {
@@ -448,9 +448,9 @@ export default class EditorController extends Controller {
     }
   }
 
-  invokeAction(actionName) {
+  invokeAction(actionName, invokingElement) {
     if (this.actionIsExternal(actionName)) {
-      return this.notifyEditorElement("action-invoke", { actionName })
+      return this.notifyEditorElement("action-invoke", { actionName, invokingElement })
     } else {
       return this.actions[actionName]?.perform?.call(this)
     }

--- a/src/trix/controllers/toolbar_controller.js
+++ b/src/trix/controllers/toolbar_controller.js
@@ -64,7 +64,7 @@ export default class ToolbarController extends BasicObject {
     if (this.getDialog(actionName)) {
       return this.toggleDialog(actionName)
     } else {
-      return this.delegate?.toolbarDidInvokeAction(actionName)
+      return this.delegate?.toolbarDidInvokeAction(actionName, element)
     }
   }
 


### PR DESCRIPTION
Given toolbar buttons that triggers an external action like:

```html
<button type="button" data-trix-action="x-insert-token" data-token="{{ user.name }}">Insert name</button>
<button type="button" data-trix-action="x-insert-token" data-token="{{ user.email }}">Insert email</button>
 ```

Trix will call `trix-action-invoke` with `event.actionName` of `x-insert-token`.

We can register behavior to handle this event:

```js
addEventListener('trix-action-invoke', function (event) {
  if (event.actionName == 'x-insert-token') {
    event.target.editor.insertString("Testing!")
  }
})
```

But only the `actionName` is sent in `event`, there appears to be no way to get a reference to the invoking element. In this case, we need that reference to read the `data-token` attribute so we could then write:

```js
if (event.actionName == 'x-insert-token') {
  const token = event.invokingElement.getAttribute("data-token")
  event.target.editor.insertString(token)
}
```

This PR changes `invokeAction` to pass along the `invokingElement` for toolbar external actions.

Currently, you can work around this by using something like Stimulus to process the button click as an action and then get a reference to the Trix editor instance, but this change would support this kind of extension directly using Trix primitives and concepts.

I did not see any tests around this event functionality so I have omitted them. Happy to take a stab if that helps!