### PR TITLE
allow to add a classname for inline text attributes

### DIFF
--- a/src/trix/views/piece_view.js
+++ b/src/trix/views/piece_view.js
@@ -107,6 +107,12 @@ export default class PieceView extends ObjectView {
         element.style[key] = value
       }
     }
+
+    if (this.attributes.classList) {
+      if (!element) { element = makeElement("span") }
+      element.classList.add(...this.attributes.classList)
+    }
+
     return element
   }
 


### PR DESCRIPTION
This was opened in https://github.com/basecamp/trix/pull/855 but seems abandoned since the migration from CoffeeScript to JavaScript. 

Adds support for specifying a `className` option to custom text attributes.

```js
Trix.config.textAttributes.background = {
  className: 'background-color',
  inheritable: false,
}
```

