### PR TITLE
Integrate with `ElementInternals`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,29 +55,37 @@ Like an HTML `<textarea>`, `<trix-editor>` accepts `autofocus` and `placeholder`
 
 ## Integrating With Forms
 
-To submit the contents of a `<trix-editor>` with a form, first define a hidden input field in the form and assign it an `id`. Then reference that `id` in the editor’s `input` attribute.
+To label a `<trix-editor>` element, render the element with an `[id]` attribute, then render a `<label>` element with a `[for]` attribute that corresponds to the `[id]`:
+
+```html
+<label for="editor">Editor</label>
+<trix-editor id="editor"></trix-editor>
+```
+
+To submit the contents of a `<trix-editor>` with a `<form>`, render the element with a `[name]` attribute and its initial value as its inner HTML.
 
 ```html
 <form …>
-  <input id="x" type="hidden" name="content">
-  <trix-editor input="x"></trix-editor>
+  <trix-editor name="content"></trix-editor>
 </form>
 ```
 
-Trix will automatically update the value of the hidden input field with each change to the editor.
+To associate the element with a `<form>` that isn't an ancestor, render the element with a `[form]` attribute that references the `<form>` element by its `[id]`:
+
+```html
+<form id="a-form-element" …></form>
+<trix-editor name="content" form="a-form-element"></trix-editor>
+```
 
 ## Populating With Stored Content
 
-To populate a `<trix-editor>` with stored content, include that content in the associated input element’s `value` attribute.
+To populate a `<trix-editor>` with stored content, include that content as HTML inside the element’s inner HTML.
 
 ```html
 <form …>
-  <input id="x" value="Editor content goes here" type="hidden" name="content">
-  <trix-editor input="x"></trix-editor>
+  <trix-editor input="x">Editor content goes here</trix-editor>
 </form>
 ```
-
-Always use an associated input element to safely populate an editor. Trix won’t load any HTML content inside a `<trix-editor>…</trix-editor>` tag.
 
 ## Styling Formatted Content
 

--- a/assets/index.html
+++ b/assets/index.html
@@ -41,6 +41,11 @@
         Trix.Inspector.install(event.target);
       });
 
+      document.addEventListener("trix-change", function(event) {
+        var input = document.getElementById("input")
+        input.value = event.target.value
+      })
+
       document.addEventListener("trix-attachment-add", function(event) {
         var attachment = event.attachment;
         if (attachment.file) {
@@ -72,7 +77,8 @@
   </head>
   <body>
     <main>
-      <trix-editor autofocus class="trix-content" input="input"></trix-editor>
+      <label for="editor">Input</label>
+      <trix-editor autofocus id="editor" class="trix-content"></trix-editor>
       <details id="output">
         <summary>Output</summary>
         <textarea readonly id="input"></textarea>

--- a/src/test/system/custom_element_test.js
+++ b/src/test/system/custom_element_test.js
@@ -442,7 +442,7 @@ testGroup("Custom element API", { template: "editor_empty" }, () => {
 
   test("editor resets to its original value on form reset", async () => {
     const element = getEditorElement()
-    const { form } = element.inputElement
+    const { form } = element
 
     await typeCharacters("hello")
     form.reset()
@@ -451,7 +451,7 @@ testGroup("Custom element API", { template: "editor_empty" }, () => {
 
   test("editor resets to last-set value on form reset", async () => {
     const element = getEditorElement()
-    const { form } = element.inputElement
+    const { form } = element
 
     element.value = "hi"
     await typeCharacters("hello")
@@ -461,7 +461,7 @@ testGroup("Custom element API", { template: "editor_empty" }, () => {
 
   test("editor respects preventDefault on form reset", async () => {
     const element = getEditorElement()
-    const { form } = element.inputElement
+    const { form } = element
     const preventDefault = (event) => event.preventDefault()
 
     await typeCharacters("hello")
@@ -473,27 +473,24 @@ testGroup("Custom element API", { template: "editor_empty" }, () => {
   })
 })
 
+testGroup("HTML sanitization", { template: "editor_unsafe_html" }, () => {
+  test("editor sanitizes initial value", async () => {
+    const element = getEditorElement()
+
+    expectDocument("safe\n")
+
+    assert.equal(element.innerHTML, "<div><!--block-->safe</div>")
+  })
+})
+
 testGroup("<label> support", { template: "editor_with_labels" }, () => {
   test("associates all label elements", () => {
-    const labels = [ document.getElementById("label-1"), document.getElementById("label-3") ]
-    assert.deepEqual(getEditorElement().labels, labels)
-  })
+    const element = getEditorElement()
+    const labels = Array.from(element.labels)
+    const controls = labels.map((label) => label.control)
 
-  test("focuses when <label> clicked", () => {
-    document.getElementById("label-1").click()
-    assert.equal(getEditorElement(), document.activeElement)
-  })
-
-  test("focuses when <label> descendant clicked", () => {
-    document.getElementById("label-1").querySelector("span").click()
-    assert.equal(getEditorElement(), document.activeElement)
-  })
-
-  test("does not focus when <label> controls another element", () => {
-    const label = document.getElementById("label-2")
-    assert.notEqual(getEditorElement(), label.control)
-    label.click()
-    assert.notEqual(getEditorElement(), document.activeElement)
+    assert.deepEqual(labels, [ document.getElementById("label-1"), document.getElementById("label-3") ])
+    assert.deepEqual(controls, [ element, element ])
   })
 })
 
@@ -505,8 +502,8 @@ testGroup("form property references its <form>", { template: "editors_with_forms
   })
 
   test("transitively accesses its related <input> element's <form>", () => {
-    const form = document.getElementById("input-form")
-    const editor = document.getElementById("editor-with-input-form")
+    const form = document.getElementById("attribute-form")
+    const editor = document.getElementById("editor-with-attribute-form")
     assert.equal(editor.form, form)
   })
 

--- a/src/test/system/installation_process_test.js
+++ b/src/test/system/installation_process_test.js
@@ -21,7 +21,7 @@ testGroup("Installation process", { template: "editor_html" }, () => {
 })
 
 testGroup("Installation process without specified elements", { template: "editor_empty" }, () =>
-  test("creates identified toolbar and input elements", () => {
+  test("creates identified toolbar", () => {
     const editorElement = getEditorElement()
 
     const toolbarId = editorElement.getAttribute("toolbar")
@@ -29,12 +29,6 @@ testGroup("Installation process without specified elements", { template: "editor
     const toolbarElement = document.getElementById(toolbarId)
     assert.ok(toolbarElement, "toolbar element not assert.ok")
     assert.equal(editorElement.toolbarElement, toolbarElement)
-
-    const inputId = editorElement.getAttribute("input")
-    assert.ok(/trix-input-\d+/.test(inputId), `input id not assert.ok ${JSON.stringify(inputId)}`)
-    const inputElement = document.getElementById(inputId)
-    assert.ok(inputElement, "input element not assert.ok")
-    assert.equal(editorElement.inputElement, inputElement)
   })
 )
 
@@ -42,7 +36,6 @@ testGroup("Installation process with specified elements", { template: "editor_wi
   test("uses specified elements", () => {
     const editorElement = getEditorElement()
     assert.equal(editorElement.toolbarElement, document.getElementById("my_toolbar"))
-    assert.equal(editorElement.inputElement, document.getElementById("my_input"))
     assert.equal(editorElement.value, "<div>Hello world</div>")
   })
 
@@ -58,7 +51,6 @@ testGroup("Installation process with specified elements", { template: "editor_wi
 
     const editorElement = getEditorElement()
     assert.equal(editorElement.toolbarElement, document.getElementById("my_toolbar"))
-    assert.equal(editorElement.inputElement, document.getElementById("my_input"))
     assert.equal(editorElement.value, "<div>Hello world</div>")
   })
 })

--- a/src/test/test_helpers/fixtures/editor_html.js
+++ b/src/test/test_helpers/fixtures/editor_html.js
@@ -1,3 +1,3 @@
 export default () =>
-  `<input id="my_input" type="hidden" value="&lt;div&gt;Hello world&lt;/div&gt;">
-  <trix-editor input="my_input" autofocus placeholder="Say hello..."></trix-editor>`
+  `<trix-editor autofocus placeholder="Say hello..."><div>Hello world</div></trix-editor>
+  `

--- a/src/test/test_helpers/fixtures/editor_unsafe_html.js
+++ b/src/test/test_helpers/fixtures/editor_unsafe_html.js
@@ -1,0 +1,2 @@
+export default () => `<trix-editor autofocus><div>safe</div><script>alert("unsafe")</script></trix-editor>
+`

--- a/src/test/test_helpers/fixtures/editor_with_image.js
+++ b/src/test/test_helpers/fixtures/editor_with_image.js
@@ -1,5 +1,4 @@
 import { TEST_IMAGE_URL } from "./test_image_url"
 
 export default () =>
-  `<trix-editor input="my_input" autofocus placeholder="Say hello..."></trix-editor>
-  <input id="my_input" type="hidden" value="ab&lt;img src=&quot;${TEST_IMAGE_URL}&quot; width=&quot;10&quot; height=&quot;10&quot;&gt;">`
+  `<trix-editor autofocus placeholder="Say hello...">ab<img src="${TEST_IMAGE_URL}" width="10" height="10"></trix-editor>`

--- a/src/test/test_helpers/fixtures/editor_with_toolbar_and_input.js
+++ b/src/test/test_helpers/fixtures/editor_with_toolbar_and_input.js
@@ -1,6 +1,5 @@
 export default () =>
   `<ul id="my_editor">
     <li><trix-toolbar id="my_toolbar"></trix-toolbar></li>
-    <li><trix-editor toolbar="my_toolbar" input="my_input" autofocus placeholder="Say hello..."></trix-editor></li>
-    <li><input id="my_input" type="hidden" value="&lt;div&gt;Hello world&lt;/div&gt;"></li>
+    <li><trix-editor toolbar="my_toolbar" autofocus placeholder="Say hello..."><div>Hello world</div></trix-editor></li>
   </ul>`

--- a/src/test/test_helpers/fixtures/editors_with_forms.js
+++ b/src/test/test_helpers/fixtures/editors_with_forms.js
@@ -3,9 +3,7 @@ export default () =>
     <trix-editor id="editor-with-ancestor-form"></trix-editor>
   </form>
 
-  <form id="input-form">
-    <input type="hidden" id="hidden-input">
-  </form>
-  <trix-editor id="editor-with-input-form" input="hidden-input"></trix-editor>
+  <form id="attribute-form"></form>
+  <trix-editor id="editor-with-attribute-form" form="attribute-form"></trix-editor>
 
   <trix-editor id="editor-with-no-form"></trix-editor>`

--- a/src/test/test_helpers/fixtures/fixtures.js
+++ b/src/test/test_helpers/fixtures/fixtures.js
@@ -11,6 +11,7 @@ import StringPiece from "trix/models/string_piece"
 import editorDefaultAriaLabel from "./editor_default_aria_label"
 import editorEmpty from "./editor_empty"
 import editorHtml from "./editor_html"
+import editorUnsafeHtml from "./editor_unsafe_html"
 import editorInTable from "./editor_in_table"
 import editorWithBlockStyles from "./editor_with_block_styles"
 import editorWithBoldStyles from "./editor_with_bold_styles"
@@ -25,6 +26,7 @@ export const fixtureTemplates = {
   "editor_default_aria_label": editorDefaultAriaLabel,
   "editor_empty": editorEmpty,
   "editor_html": editorHtml,
+  "editor_unsafe_html": editorUnsafeHtml,
   "editor_in_table": editorInTable,
   "editor_with_block_styles": editorWithBlockStyles,
   "editor_with_bold_styles": editorWithBoldStyles,

--- a/src/trix/controllers/editor_controller.js
+++ b/src/trix/controllers/editor_controller.js
@@ -503,7 +503,7 @@ export default class EditorController extends Controller {
   updateInputElement() {
     const element = this.compositionController.getSerializableElement()
     const value = serializeToContentType(element, "text/html")
-    return this.editorElement.setInputElementValue(value)
+    return this.editorElement.setFormValue(value)
   }
 
   notifyEditorElement(message, data) {


### PR DESCRIPTION
Closes [#1023][]

Replace the requirement for an `<input type="hidden">` element with direct `<form>` integration through built-in support for [ElementInternals][].

According to the [Form-associated custom elements][] section of [More capable form controls][], various behaviors that the `<trix-editor>` element was recreating are provided out of the box.

For example, the `<input type="hidden">`-`[input]` attribute pairing can be achieved through [ElementInternals.setFormValue][]. Similarly, the `<label>` element support can be achieved through
[ElementInternals.labels][].

TODO before merging:
---

- [ ] Control through browser feature-detection and a `Trix.config.editor` object
- [ ] Open a PR against `rails/rails` to make Action Text integrate with configuration in a backwards-compatible way (excluding `<input type="hidden">`, rendering content into `<trix-editor>` inner HTML, etc)

TODO after merging:
---

- [ ] Integrate with [ElementInternals.willValidate](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/willValidate), [ElementInternals.validity](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/validity), [ElementInternals.validationMessage](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/validationMessage)
- [ ] [Form callbacks](https://web.dev/articles/more-capable-form-controls#lifecycle_callbacks) like `void formDisabledCallback(disabled)` to support `[disabled]`
- [ ] [Instance properties included from ARIA](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals#instance_properties_included_from_aria)

[#1023]: https://github.com/basecamp/trix/issues/1023
[ElementInternals]: https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals
[Form-associated custom elements]: https://web.dev/articles/more-capable-form-controls#form-associated_custom_elements
[More capable form controls]: https://web.dev/articles/more-capable-form-controls
[ElementInternals.setFormValue]: https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/setFormValue
[ElementInternals.labels]: https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/labels