### PR TITLE
Add default word-break to trix-content

### DIFF
--- a/assets/trix/stylesheets/content.scss
+++ b/assets/trix/stylesheets/content.scss
@@ -4,6 +4,8 @@ $quote-padding-start: 0.6em;
 
 .trix-content {
   line-height: 1.5;
+  overflow-wrap: break-word;
+  word-break: break-word;
 
   * {
     box-sizing: border-box;


### PR DESCRIPTION
Fix for https://github.com/basecamp/trix/issues/1125