### PR TITLE
Replace hidden `<input>` with `ElementInternals` integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,31 @@ import Trix from "trix"
 Trix.elements.TrixEditorElement.formAssociated = false
 ```
 
+When Trix is configured to be compatible with `ElementInternals`, it is also
+capable of functioning without an `<input type="hidden">` element. To configure
+a `<trix-editor>` element to skip creating its `<input type="hidden">`, set the
+element's `willCreateInput = false`:
+
+```js
+addEventListener("before-trix-initialize", (event) => {
+  const trixEditor = event.target
+
+  trixEditor.willCreateInput = false
+})
+```
+
+> [!NOTE]
+> Trix will *always* use an associated `<input type="hidden">` element when the
+> `[input]` attribute is set. To migrate to `<input>`-free support, set
+> `willCreateInput = false`, then render the `<trix-editor>` without the
+> `[input]` attribute.
+
+> [!WARNING]
+> In the absence of an `<input type="hidden">` element, the `<trix-editor>`
+> element's value will not be included in `<form>` element submissions unless it
+> is rendered with a `[name]` attribute. Set the `[name]` attribute to the same
+> value that the `<input type="hidden">` element would have.
+
 ## Invoking Internal Trix Actions
 
 Internal actions are defined in `controllers/editor_controller.js` and consist of:

--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -13380,27 +13380,42 @@ $\
   }();
   installDefaultCSSForTagName("trix-editor", "%t {\n    display: block;\n}\n\n%t:empty::before {\n    content: attr(placeholder);\n    color: graytext;\n    cursor: text;\n    pointer-events: none;\n    white-space: pre-line;\n}\n\n%t a[contenteditable=false] {\n    cursor: text;\n}\n\n%t img {\n    max-width: 100%;\n    height: auto;\n}\n\n%t ".concat(attachmentSelector, " figcaption textarea {\n    resize: none;\n}\n\n%t ").concat(attachmentSelector, " figcaption textarea.trix-autoresize-clone {\n    position: absolute;\n    left: -9999px;\n    max-height: 0px;\n}\n\n%t ").concat(attachmentSelector, " figcaption[data-trix-placeholder]:empty::before {\n    content: attr(data-trix-placeholder);\n    color: graytext;\n}\n\n%t [data-trix-cursor-target] {\n    display: ").concat(cursorTargetStyles.display, " !important;\n    width: ").concat(cursorTargetStyles.width, " !important;\n    padding: 0 !important;\n    margin: 0 !important;\n    border: none !important;\n}\n\n%t [data-trix-cursor-target=left] {\n    vertical-align: top !important;\n    margin-left: -1px !important;\n}\n\n%t [data-trix-cursor-target=right] {\n    vertical-align: bottom !important;\n    margin-right: -1px !important;\n}"));
   var _internals = /*#__PURE__*/new WeakMap();
+  var _formDisabled = /*#__PURE__*/new WeakMap();
   var _validate = /*#__PURE__*/new WeakSet();
   class ElementInternalsDelegate {
     constructor(element) {
       _classPrivateMethodInitSpec(this, _validate);
+      _defineProperty(this, "value", "");
       _classPrivateFieldInitSpec(this, _internals, {
+        writable: true,
+        value: void 0
+      });
+      _classPrivateFieldInitSpec(this, _formDisabled, {
         writable: true,
         value: void 0
       });
       this.element = element;
       _classPrivateFieldSet(this, _internals, element.attachInternals());
+      _classPrivateFieldSet(this, _formDisabled, false);
     }
     connectedCallback() {
       _classPrivateMethodGet(this, _validate, _validate2).call(this);
     }
     disconnectedCallback() {}
+    get form() {
+      return _classPrivateFieldGet(this, _internals).form;
+    }
+    get name() {
+      return this.element.getAttribute("name");
+    }
+    set name(value) {
+      this.element.setAttribute("name", value);
+    }
     get labels() {
       return _classPrivateFieldGet(this, _internals).labels;
     }
     get disabled() {
-      var _this$element$inputEl;
-      return (_this$element$inputEl = this.element.inputElement) === null || _this$element$inputEl === void 0 ? void 0 : _this$element$inputEl.disabled;
+      return _classPrivateFieldGet(this, _formDisabled) || this.element.hasAttribute("disabled");
     }
     set disabled(value) {
       this.element.toggleAttribute("disabled", value);
@@ -13421,8 +13436,13 @@ $\
     get willValidate() {
       return _classPrivateFieldGet(this, _internals).willValidate;
     }
+    formDisabledCallback(disabled) {
+      _classPrivateFieldSet(this, _formDisabled, disabled);
+    }
     setFormValue(value) {
+      this.value = value;
       _classPrivateMethodGet(this, _validate, _validate2).call(this);
+      _classPrivateFieldGet(this, _internals).setFormValue(this.element.disabled ? undefined : this.value);
     }
     checkValidity() {
       return _classPrivateFieldGet(this, _internals).checkValidity();
@@ -13509,6 +13529,17 @@ $\
       }
       return labels;
     }
+    get form() {
+      console.warn("This browser does not support the .form property for trix-editor elements.");
+      return null;
+    }
+    get name() {
+      console.warn("This browser does not support the .name property for trix-editor elements.");
+      return null;
+    }
+    set name(value) {
+      console.warn("This browser does not support the .name property for trix-editor elements.");
+    }
     get disabled() {
       console.warn("This browser does not support the [disabled] attribute for trix-editor elements.");
       return false;
@@ -13535,6 +13566,7 @@ $\
       console.warn("This browser does not support the willValidate property for trix-editor elements.");
       return false;
     }
+    formDisabledCallback(value) {}
     setFormValue(value) {}
     checkValidity() {
       console.warn("This browser does not support checkValidity() for trix-editor elements.");
@@ -13556,6 +13588,7 @@ $\
         writable: true,
         value: void 0
       });
+      this.willCreateInput = true;
       _classPrivateFieldSet(this, _delegate, this.constructor.formAssociated ? new ElementInternalsDelegate(this) : new LegacyDelegate(this));
     }
 
@@ -13573,9 +13606,22 @@ $\
       return _classPrivateFieldGet(this, _delegate).labels;
     }
     get disabled() {
-      return _classPrivateFieldGet(this, _delegate).disabled;
+      const {
+        inputElement
+      } = this;
+      if (inputElement) {
+        return inputElement.disabled;
+      } else {
+        return _classPrivateFieldGet(this, _delegate).disabled;
+      }
     }
     set disabled(value) {
+      const {
+        inputElement
+      } = this;
+      if (inputElement) {
+        inputElement.disabled = value;
+      }
       _classPrivateFieldGet(this, _delegate).disabled = value;
     }
     get required() {
@@ -13613,14 +13659,20 @@ $\
       }
     }
     get form() {
-      var _this$inputElement;
-      return (_this$inputElement = this.inputElement) === null || _this$inputElement === void 0 ? void 0 : _this$inputElement.form;
+      const {
+        inputElement
+      } = this;
+      if (inputElement) {
+        return inputElement.form;
+      } else {
+        return _classPrivateFieldGet(this, _delegate).form;
+      }
     }
     get inputElement() {
       if (this.hasAttribute("input")) {
         var _this$ownerDocument2;
         return (_this$ownerDocument2 = this.ownerDocument) === null || _this$ownerDocument2 === void 0 ? void 0 : _this$ownerDocument2.getElementById(this.getAttribute("input"));
-      } else if (this.parentNode) {
+      } else if (this.parentNode && this.willCreateInput) {
         const inputId = "trix-input-".concat(this.trixId);
         this.setAttribute("input", inputId);
         const element = makeElement("input", {
@@ -13638,12 +13690,34 @@ $\
       return (_this$editorControlle = this.editorController) === null || _this$editorControlle === void 0 ? void 0 : _this$editorControlle.editor;
     }
     get name() {
-      var _this$inputElement2;
-      return (_this$inputElement2 = this.inputElement) === null || _this$inputElement2 === void 0 ? void 0 : _this$inputElement2.name;
+      const {
+        inputElement
+      } = this;
+      if (inputElement) {
+        return inputElement.name;
+      } else {
+        return _classPrivateFieldGet(this, _delegate).name;
+      }
+    }
+    set name(value) {
+      const {
+        inputElement
+      } = this;
+      if (inputElement) {
+        inputElement.name = value;
+      } else {
+        _classPrivateFieldGet(this, _delegate).name = value;
+      }
     }
     get value() {
-      var _this$inputElement3;
-      return (_this$inputElement3 = this.inputElement) === null || _this$inputElement3 === void 0 ? void 0 : _this$inputElement3.value;
+      const {
+        inputElement
+      } = this;
+      if (inputElement) {
+        return inputElement.value;
+      } else {
+        return _classPrivateFieldGet(this, _delegate).value;
+      }
     }
     set value(defaultValue) {
       var _this$editor;
@@ -13670,10 +13744,13 @@ $\
       }
     }
     setFormValue(value) {
-      if (this.inputElement) {
-        this.inputElement.value = value;
-        _classPrivateFieldGet(this, _delegate).setFormValue(value);
+      const {
+        inputElement
+      } = this;
+      if (inputElement) {
+        inputElement.value = value;
       }
+      _classPrivateFieldGet(this, _delegate).setFormValue(value);
     }
 
     // Element lifecycle
@@ -13729,10 +13806,14 @@ $\
       _classPrivateFieldGet(this, _delegate).setCustomValidity(validationMessage);
     }
     formDisabledCallback(disabled) {
-      if (this.inputElement) {
-        this.inputElement.disabled = disabled;
+      const {
+        inputElement
+      } = this;
+      if (inputElement) {
+        inputElement.disabled = disabled;
       }
       this.toggleAttribute("contenteditable", !disabled);
+      _classPrivateFieldGet(this, _delegate).formDisabledCallback(disabled);
     }
     formResetCallback() {
       this.reset();

--- a/src/test/test_helpers/test_helpers.js
+++ b/src/test/test_helpers/test_helpers.js
@@ -1,7 +1,7 @@
 import { fixtureTemplates } from "test/test_helpers/fixtures/fixtures"
 import { removeNode } from "trix/core/helpers"
 
-const setFixtureHTML = function (html, container = "form") {
+export const setFixtureHTML = function (html, container = "form") {
   let element = document.getElementById("trix-container")
   if (element != null) removeNode(element)
 
@@ -9,7 +9,9 @@ const setFixtureHTML = function (html, container = "form") {
   element.id = "trix-container"
   element.innerHTML = html
 
-  return document.body.insertAdjacentElement("afterbegin", element)
+  document.body.insertAdjacentElement("afterbegin", element)
+
+  return waitForTrixInit()
 }
 
 export const testGroup = function (name, options, callback) {
@@ -25,8 +27,7 @@ export const testGroup = function (name, options, callback) {
     window.focus()
 
     if (template != null) {
-      setFixtureHTML(fixtureTemplates[template](), container)
-      await waitForTrixInit()
+      await setFixtureHTML(fixtureTemplates[template](), container)
     }
 
     if (setup) setup()


### PR DESCRIPTION
The successful migration to utilize [Element Internals][] stopped short
of removing Trix's dependency on an associated `<input type="hidden">`
element to store its state. Prior to integration with
`ElementInternals`, Trix relied on the `<input>` for the sake of having
its value serialized into a form submission. That is no longer
necessary.

When Trix is configured to be compatible with `ElementInternals`, it is
also capable of functioning without an `<input type="hidden">` element.
To configure a `<trix-editor>` element to skip creating its `<input
type="hidden">`, set the element's `willCreateInput = false`:

```js
addEventListener("before-trix-initialize", (event) => {
  const trixEditor = event.target

  trixEditor.willCreateInput = false
})
```

Trix will *always* use an associated `<input type="hidden">` element
when the `[input]` attribute is set, regardless of its `willCreateInput`
property. To migrate to `<input>`-free support, render the
`<trix-editor>` without the `[input]` attribute.

In the absence of an `<input type="hidden">` element, the
`<trix-editor>` element's value will not be included in `<form>` element
submissions unless it is rendered with a `[name]` attribute. Set the
`[name]` attribute to the same value that the `<input type="hidden">`
element would have.

Additional considerations
---

For the sake of backwards compatibility, the default `willCreateInput` value is `true`. This preserves existing behavior. After a suitable amount of time passes (no fewer than one minor version release), the `willCreateInput` default value could be changed to `!TrixEditorElement.formAssociated`, so that supporting Element Internals means defaulting to an `<input>`-free version of Trix. 

Action Text integration should remain unchanged. At the time of this
submission, Rails automatically renders an `<input type="hidden">`
element that is paired with the `<trix-editor>` element through its
`[input]` attribute.

[Element Internals]: https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals

