### PR TITLE
Request render after insertReplacementText

### DIFF
--- a/src/trix/controllers/level_2_input_controller.js
+++ b/src/trix/controllers/level_2_input_controller.js
@@ -443,7 +443,8 @@ export default class Level2InputController extends InputController {
     },
 
     insertReplacementText() {
-      return this.insertString(this.event.dataTransfer.getData("text/plain"), { updatePosition: false })
+      this.insertString(this.event.dataTransfer.getData("text/plain"), { updatePosition: false })
+      this.requestRender()
     },
 
     insertText() {


### PR DESCRIPTION
The `insertReplacementText` text comes from an autocorrected word. If we don't request a render, the cursor will be in the wrong place and the document doesn't update until the user types more characters.

Fixes https://github.com/basecamp/trix/issues/1119