### PR TITLE
Only run test on SauceLabs when SAUCE_ACCESS_KEY is set

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,7 +29,7 @@ const config = {
 
 /* eslint camelcase: "off",  */
 
-if (process.env.CI) {
+if (process.env.SAUCE_ACCESS_KEY) {
   config.customLaunchers = {
     sl_chrome_latest: {
       base: "SauceLabs",


### PR DESCRIPTION
Allows forks to run tests on GitHub Actions without having to have access to the SauceLabs secret.

Ref. https://github.com/basecamp/trix/pull/1072#issuecomment-1917429747