### PR TITLE
Limit accept attachment file types, fix missing id and make Trix compatible with modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If you don’t want to accept dropped or pasted files, call `preventDefault()` o
 
 ## Limiting Accept Attachment File Types
 
-Trix automatically aceept all file types as an attachment. You can configure it with the `trix-attachment-accept` attribute, which takes a comma-separated list of allowed file extensions or MIME types.
+Trix accepts all file types as an attachment by default. You can configure it with the `trix-attachment-accept` attribute, which takes a comma-separated list of allowed file extensions or MIME types.
 
 ```html
 <trix-editor trix-attachment-accept="image/png, image/jpg, image/jpeg"></trix-editor>

--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ To store attachments, listen for the `trix-attachment-add` event. Upload the att
 
 If you don’t want to accept dropped or pasted files, call `preventDefault()` on the `trix-file-accept` event, which Trix dispatches just before the `trix-attachment-add` event.
 
+## Limiting Accept Attachment File Types
+
+Trix automatically aceept all file types as an attachment. You can configure it with the `trix-attachment-accept` attribute, which takes a comma-separated list of allowed file extensions or MIME types.
+
+```html
+<trix-editor trix-attachment-accept="image/png, image/jpg, image/jpeg"></trix-editor>
+```
+
+```html
+<trix-editor trix-attachment-accept=".png, .jpg, .jpeg"></trix-editor>
+```
+
+```html
+<trix-editor trix-attachment-accept="image/*"></trix-editor>
+```
+
 # Editing Text Programmatically
 
 You can manipulate a Trix editor programmatically through the `Trix.Editor` interface, available on each `<trix-editor>` element through its `editor` property.

--- a/src/trix/config/input.js
+++ b/src/trix/config/input.js
@@ -3,6 +3,7 @@ import { makeElement, removeNode } from "trix/core/helpers/dom"
 
 const input = {
   level2Enabled: true,
+  fileInputId: `trix-file-input-${Date.now().toString(16)}`,
 
   getLevel() {
     if (this.level2Enabled && browser.supportsInputEvents) {

--- a/src/trix/config/input.js
+++ b/src/trix/config/input.js
@@ -4,6 +4,7 @@ import { makeElement, removeNode } from "trix/core/helpers/dom"
 const input = {
   level2Enabled: true,
   fileInputId: `trix-file-input-${Date.now().toString(16)}`,
+  acceptedFileTypes: "*",
 
   getLevel() {
     if (this.level2Enabled && browser.supportsInputEvents) {
@@ -12,11 +13,13 @@ const input = {
       return 0
     }
   },
-  pickFiles(callback) {
-    const input = makeElement("input", { type: "file", multiple: true, hidden: true, id: this.fileInputId })
+  pickFiles(editorController) {
+    const editorElement = editorController.element
+    const acceptTypes = editorElement.getAttribute("trix-attachment-accept") || this.acceptedFileTypes
+    const input = makeElement("input", { type: "file", multiple: true, hidden: true, id: this.fileInputId, accept: acceptTypes })
 
     input.addEventListener("change", () => {
-      callback(input.files)
+      editorController.insertFiles(input.files)
       removeNode(input)
     })
 

--- a/src/trix/config/input.js
+++ b/src/trix/config/input.js
@@ -24,7 +24,7 @@ const input = {
     })
 
     removeNode(document.getElementById(this.fileInputId))
-    document.body.appendChild(input)
+    editorElement.parentNode.appendChild(input)
     input.click()
   }
 }

--- a/src/trix/controllers/editor_controller.js
+++ b/src/trix/controllers/editor_controller.js
@@ -64,7 +64,7 @@ export default class EditorController extends Controller {
         return true
       },
       perform() {
-        return config.input.pickFiles(this.editor.insertFiles)
+        return config.input.pickFiles(this.editor)
       },
     },
   }


### PR DESCRIPTION
## Context
While integrating Trix, I found a conflict if I wanted to attach files and Trix was inside a modal, as discussed in issue #1039. Additionally, I needed to restrict the attached files to only images. During debugging, I also noticed that the input element was missing an ID, a problem previously reported in issue #1088 by @chadrschroeder. To address this, I monkey-patched it in our implementation and decided to create this pull request.

## Changes
1. Add an option to limit the file types when attaching a file.
2. Inserting the input file at the same level as the `trix-editor` instead of doing it at the end of the body
3. Add the missing `fileInputId` based on #1089 

To solve 2 and 3 I had to use the `editorController` instance as an argument of the `pickFiles` function instead of just using the callback.
Let me know if you consider that not all the changes are needed or if there are any issues with the code.

## How it works

Trix will still accept all file types as an attachment by default, but now a `trix-attachment-accept` attribute is available, which takes a comma-separated list of allowed file extensions or MIME types.

```html
<trix-editor trix-attachment-accept="image/png, image/jpg, image/jpeg"></trix-editor>
```

```html
<trix-editor trix-attachment-accept=".png, .jpg, .jpeg"></trix-editor>
```

```html
<trix-editor trix-attachment-accept="image/*"></trix-editor>
```
