### PR TITLE
Allow custom HTML attributes in blocks

### DIFF
--- a/src/inspector/templates/document.js
+++ b/src/inspector/templates/document.js
@@ -13,6 +13,10 @@ window.JST["trix/inspector/templates/document"] = function() {
         Attributes: ${JSON.stringify(block.attributes)}
       </div>
 
+      <div class="htmlAttributes">
+        HTML Attributes: ${JSON.stringify(block.htmlAttributes)}
+      </div>
+
       <div class="text">
         <div class="title">
           Text: ${text.id}, Pieces: ${pieces.length}, Length: ${text.getLength()}

--- a/src/test/test_helpers/fixtures/fixtures.js
+++ b/src/test/test_helpers/fixtures/fixtures.js
@@ -41,9 +41,9 @@ const { css } = config
 
 const createDocument = function (...parts) {
   const blocks = parts.map((part) => {
-    const [ string, textAttributes, blockAttributes ] = Array.from(part)
+    const [ string, textAttributes, blockAttributes, htmlAttributes = {} ] = Array.from(part)
     const text = Text.textForStringWithAttributes(string, textAttributes)
-    return new Block(text, blockAttributes)
+    return new Block(text, blockAttributes, htmlAttributes)
   })
 
   return new Document(blocks)
@@ -190,6 +190,12 @@ export const fixtures = {
   "code with newline": {
     document: createDocument([ "12\n3", {}, [ "code" ] ]),
     html: `<pre>${blockComment}12\n3</pre>`,
+  },
+
+  "code with custom language": {
+    document: createDocument([ "puts \"Hello world!\"", {}, [ "code" ], { "language": "ruby" } ]),
+    html: `<pre language="ruby">${blockComment}puts "Hello world!"</pre>`,
+    serializedHTML: "<pre language=\"ruby\">puts \"Hello world!\"</pre>"
   },
 
   "multiple blocks with block comments in their text": {

--- a/src/test/unit/html_parser_test.js
+++ b/src/test/unit/html_parser_test.js
@@ -17,7 +17,7 @@ const cursorTargetLeft = createCursorTarget("left").outerHTML
 const cursorTargetRight = createCursorTarget("right").outerHTML
 
 testGroup("HTMLParser", () => {
-  eachFixture((name, { html, serializedHTML, document }) => {
+  eachFixture((name, { html, document }) => {
     test(name, () => {
       const parsedDocument = HTMLParser.parse(html).getDocument()
       assert.documentHTMLEqual(parsedDocument.copyUsingObjectsFromDocument(document), html)

--- a/src/trix/config/block_attributes.js
+++ b/src/trix/config/block_attributes.js
@@ -16,6 +16,7 @@ const attributes = {
   code: {
     tagName: "pre",
     terminal: true,
+    htmlAttributes: [ "language" ],
     text: {
       plaintext: true,
     },

--- a/src/trix/models/block.js
+++ b/src/trix/models/block.js
@@ -5,19 +5,21 @@ import {
   arraysAreEqual,
   getBlockConfig,
   getListAttributeNames,
+  objectsAreEqual,
   spliceArray,
 } from "trix/core/helpers"
 
 export default class Block extends TrixObject {
   static fromJSON(blockJSON) {
     const text = Text.fromJSON(blockJSON.text)
-    return new this(text, blockJSON.attributes)
+    return new this(text, blockJSON.attributes, blockJSON.htmlAttributes)
   }
 
-  constructor(text, attributes) {
+  constructor(text, attributes, htmlAttributes) {
     super(...arguments)
     this.text = applyBlockBreakToText(text || new Text())
     this.attributes = attributes || []
+    this.htmlAttributes = htmlAttributes || {}
   }
 
   isEmpty() {
@@ -27,11 +29,11 @@ export default class Block extends TrixObject {
   isEqualTo(block) {
     if (super.isEqualTo(block)) return true
 
-    return this.text.isEqualTo(block?.text) && arraysAreEqual(this.attributes, block?.attributes)
+    return this.text.isEqualTo(block?.text) && arraysAreEqual(this.attributes, block?.attributes) && objectsAreEqual(this.htmlAttributes, block?.htmlAttributes)
   }
 
   copyWithText(text) {
-    return new Block(text, this.attributes)
+    return new Block(text, this.attributes, this.htmlAttributes)
   }
 
   copyWithoutText() {
@@ -39,7 +41,7 @@ export default class Block extends TrixObject {
   }
 
   copyWithAttributes(attributes) {
-    return new Block(this.text, attributes)
+    return new Block(this.text, attributes, this.htmlAttributes)
   }
 
   copyWithoutAttributes() {
@@ -58,6 +60,11 @@ export default class Block extends TrixObject {
   addAttribute(attribute) {
     const attributes = this.attributes.concat(expandAttribute(attribute))
     return this.copyWithAttributes(attributes)
+  }
+
+  addHTMLAttribute(attribute, value) {
+    const htmlAttributes = Object.assign({}, this.htmlAttributes, { [attribute]: value })
+    return new Block(this.text, this.attributes, htmlAttributes)
   }
 
   removeAttribute(attribute) {
@@ -173,6 +180,7 @@ export default class Block extends TrixObject {
     return {
       text: this.text,
       attributes: this.attributes,
+      htmlAttributes: this.htmlAttributes,
     }
   }
 

--- a/src/trix/models/composition.js
+++ b/src/trix/models/composition.js
@@ -341,6 +341,16 @@ export default class Composition extends BasicObject {
     }
   }
 
+  setHTMLAtributeAtPosition(position, attributeName, value) {
+    const block = this.document.getBlockAtPosition(position)
+    const allowedHTMLAttributes = getBlockConfig(block.getLastAttribute())?.htmlAttributes
+
+    if (block && allowedHTMLAttributes?.includes(attributeName)) {
+      const newDocument = this.document.setHTMLAttributeAtPosition(position, attributeName, value)
+      this.setDocument(newDocument)
+    }
+  }
+
   setTextAttribute(attributeName, value) {
     const selectedRange = this.getSelectedRange()
     if (!selectedRange) return

--- a/src/trix/models/document.js
+++ b/src/trix/models/document.js
@@ -282,6 +282,12 @@ export default class Document extends TrixObject {
     return this.removeAttributeAtRange(attribute, range)
   }
 
+  setHTMLAttributeAtPosition(position, name, value) {
+    const block = this.getBlockAtPosition(position)
+    const updatedBlock = block.addHTMLAttribute(name, value)
+    return this.replaceBlock(block, updatedBlock)
+  }
+
   insertBlockBreakAtRange(range) {
     let blocks
     range = normalizeRange(range)

--- a/src/trix/models/editor.js
+++ b/src/trix/models/editor.js
@@ -137,6 +137,11 @@ export default class Editor {
     return this.composition.removeCurrentAttribute(name)
   }
 
+  // HTML attributes
+  setHTMLAtributeAtPosition(position, name, value) {
+    this.composition.setHTMLAtributeAtPosition(position, name, value)
+  }
+
   // Nesting level
 
   canDecreaseNestingLevel() {

--- a/src/trix/models/html_sanitizer.js
+++ b/src/trix/models/html_sanitizer.js
@@ -2,7 +2,7 @@ import BasicObject from "trix/core/basic_object"
 
 import { nodeIsAttachmentElement, removeNode, tagName, walkTree } from "trix/core/helpers"
 
-const DEFAULT_ALLOWED_ATTRIBUTES = "style href src width height class".split(" ")
+const DEFAULT_ALLOWED_ATTRIBUTES = "style href src width height language class".split(" ")
 const DEFAULT_FORBIDDEN_PROTOCOLS = "javascript:".split(" ")
 const DEFAULT_FORBIDDEN_ELEMENTS = "script iframe form".split(" ")
 

--- a/src/trix/views/block_view.js
+++ b/src/trix/views/block_view.js
@@ -46,7 +46,8 @@ export default class BlockView extends ObjectView {
     let className
     const attributeName = this.attributes[depth]
 
-    const { tagName, htmlAttributes } = getBlockConfig(attributeName)
+    const { tagName, htmlAttributes = [] } = getBlockConfig(attributeName)
+
     if (depth === 0 && this.block.isRTL()) {
       Object.assign(attributes, { dir: "rtl" })
     }

--- a/src/trix/views/block_view.js
+++ b/src/trix/views/block_view.js
@@ -42,18 +42,25 @@ export default class BlockView extends ObjectView {
   }
 
   createContainerElement(depth) {
-    let attributes, className
+    const attributes = {}
+    let className
     const attributeName = this.attributes[depth]
 
-    const { tagName } = getBlockConfig(attributeName)
+    const { tagName, htmlAttributes } = getBlockConfig(attributeName)
     if (depth === 0 && this.block.isRTL()) {
-      attributes = { dir: "rtl" }
+      Object.assign(attributes, { dir: "rtl" })
     }
 
     if (attributeName === "attachmentGallery") {
       const size = this.block.getBlockBreakPosition()
       className = `${css.attachmentGallery} ${css.attachmentGallery}--${size}`
     }
+
+    Object.entries(this.block.htmlAttributes).forEach(([ name, value ]) => {
+      if (htmlAttributes.includes(name)) {
+        attributes[name] = value
+      }
+    })
 
     return makeElement({ tagName, className, attributes })
   }


### PR DESCRIPTION
In particular, keeps the assigned language attribute assigned to code blocks. This is useful for syntax highlighting libraries that use the language attribute to determine the language of the code block.