### PR TITLE
[WIP] add required attribute to trix-editor

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -17,6 +17,18 @@
         max-width: 700px;
       }
 
+      div {
+        margin-bottom: 1rem;
+
+        label {
+          display: block;
+        }
+
+        textarea {
+          width: 100%;
+        }
+      }
+
       #output {
         margin: 1rem 0 0;
       }
@@ -72,7 +84,21 @@
   </head>
   <body>
     <main>
-      <trix-editor autofocus class="trix-content" input="input"></trix-editor>
+      <form>
+        <h1>Form with required textarea field</h1>
+        <div>
+          <trix-editor autofocus required class="trix-content" input="input"></trix-editor>
+        </div>
+
+        <div>
+          <label for="comments">Your comments</label>
+          <textarea id="comments" required></textarea>
+        </div>
+
+        <div>
+          <input type="submit" />
+        </div>
+      </form>
       <details id="output">
         <summary>Output</summary>
         <textarea readonly id="input"></textarea>

--- a/src/trix/elements/trix_editor_element.js
+++ b/src/trix/elements/trix_editor_element.js
@@ -25,6 +25,14 @@ const autofocus = function(element) {
   }
 }
 
+const makeRequired = function(element) {
+  if (element.hasAttribute("required")) {
+    // element.inputElement.removeAttribute("readonly")
+    element.inputElement.required = true
+    console.log("input", element.inputElement)
+  }
+}
+
 const makeEditable = function(element) {
   if (element.hasAttribute("contenteditable")) {
     return
@@ -257,6 +265,7 @@ export default class TrixEditorElement extends HTMLElement {
   connectedCallback() {
     if (!this.hasAttribute("data-trix-internal")) {
       makeEditable(this)
+      makeRequired(this)
       addAccessibilityRole(this)
       ensureAriaLabel(this)
 


### PR DESCRIPTION
Closes https://github.com/basecamp/trix/issues/1143

# Context
`<trix-editor>` currently accepts `autofocus` and `placeholder` attributes, but not a `required` attribute. This PR aims to add that in.

This PR is still in progress. I'm stuck because even though I've set `required` to `true` on the `inputElement`, the validation is not triggered. I'm not sure what's missing here, so any help would be appreciated. The `inputElement` currently has a `readonly` attribute; I tried removing that, but it made no difference.

To make manual testing easier I've updated `assets/index.html` with an example of a plain `textarea` that's `required`. The validation gets triggered on this field alright, but not on the `trix-editor`.

# Changes
- added a `makeRequired` function to `trix_editor_element.js`
- set `required` to `true` on the `inputElement`, when the `required` attribute is present on `trix-editor`