### PR TITLE
Sanitize HTML content in data-trix-* attributes 

### DIFF
--- a/src/test/system/pasting_test.js
+++ b/src/test/system/pasting_test.js
@@ -104,6 +104,21 @@ testGroup("Pasting", { template: "editor_empty" }, () => {
     delete window.unsanitized
   })
 
+  test("paste data-trix-attachment unsafe html", async () => {
+    window.unsanitized = []
+    const pasteData = {
+      "text/plain": "x",
+      "text/html": `\
+      copy<div data-trix-attachment="{&quot;contentType&quot;:&quot;text/html&quot;,&quot;content&quot;:&quot;&lt;img src=1 onerror=window.unsanitized.push(1)&gt;HELLO123&quot;}"></div>me
+      `,
+    }
+
+    await pasteContent(pasteData)
+    await delay(20)
+    assert.deepEqual(window.unsanitized, [])
+    delete window.unsanitized
+  })
+
   test("prefers plain text when html lacks formatting", async () => {
     const pasteData = {
       "text/html": "<meta charset='utf-8'>a\nb",

--- a/src/trix/models/html_parser.js
+++ b/src/trix/models/html_parser.js
@@ -40,7 +40,13 @@ const blockForAttributes = (attributes = {}, htmlAttributes = {}) => {
 
 const parseTrixDataAttribute = (element, name) => {
   try {
-    return JSON.parse(element.getAttribute(`data-trix-${name}`))
+    const data = JSON.parse(element.getAttribute(`data-trix-${name}`))
+
+    if (data.contentType === "text/html" && data.content) {
+      data.content = HTMLSanitizer.sanitize(data.content).getHTML()
+    }
+
+    return data
   } catch (error) {
     return {}
   }


### PR DESCRIPTION
Prevents XSS attacks by crafting a malicious HTML content in the `data-trix-*` attributes.