### PR TITLE
Read the csp meta tag nonce attribute and fall back to content

### DIFF
--- a/src/trix/core/helpers/custom_elements.js
+++ b/src/trix/core/helpers/custom_elements.js
@@ -17,7 +17,7 @@ const insertStyleElementForTagName = function(tagName) {
   return element
 }
 
-const getCSPNonce = function () {
+const getCSPNonce = function() {
   const element = getMetaElement("trix-csp-nonce") || getMetaElement("csp-nonce")
   if (element) {
     const { nonce, content } = element

--- a/src/trix/core/helpers/custom_elements.js
+++ b/src/trix/core/helpers/custom_elements.js
@@ -17,10 +17,11 @@ const insertStyleElementForTagName = function(tagName) {
   return element
 }
 
-const getCSPNonce = function() {
+const getCSPNonce = function () {
   const element = getMetaElement("trix-csp-nonce") || getMetaElement("csp-nonce")
   if (element) {
-    return element.getAttribute("content")
+    const { nonce, content } = element
+    return nonce == "" ? content : nonce
   }
 }
 


### PR DESCRIPTION
This PR allows Trix to support rails/rails#51729. This changes Trix to read the meta tag's nonce attribute first and fall back to the content attribute.

As described in rails/rails#51580 (comment) this makes it harder to extract the nonce value.

Similar to hotwired/turbo#1254
