### PR TITLE
Avoid duplicate component registrations

### DIFF
--- a/src/trix/elements/trix_toolbar_element.coffee
+++ b/src/trix/elements/trix_toolbar_element.coffee
@@ -1,25 +1,26 @@
-Trix.registerElement "trix-toolbar",
-  defaultCSS: """
-    %t {
-      display: block;
-    }
+if not customElements.get("trix-toolbar")
+  Trix.registerElement "trix-toolbar",
+    defaultCSS: """
+      %t {
+        display: block;
+      }
 
-    %t {
-      white-space: nowrap;
-    }
+      %t {
+        white-space: nowrap;
+      }
 
-    %t [data-trix-dialog] {
-      display: none;
-    }
+      %t [data-trix-dialog] {
+        display: none;
+      }
 
-    %t [data-trix-dialog][data-trix-active] {
-      display: block;
-    }
+      %t [data-trix-dialog][data-trix-active] {
+        display: block;
+      }
 
-    %t [data-trix-dialog] [data-trix-validate]:invalid {
-      background-color: #ffdddd;
-    }
-  """
+      %t [data-trix-dialog] [data-trix-validate]:invalid {
+        background-color: #ffdddd;
+      }
+    """
 
   # Element lifecycle
 


### PR DESCRIPTION
I've been running into duplicate component registration errors on migration from an incremental Stencil based projects with trix-integration to a React based project with the same trix integration. This can easily be avoided with the following code changes.