### PR TITLE
Fix problem with iOS beta 8 suggestions

### DIFF
--- a/src/trix/controllers/level_2_input_controller.js
+++ b/src/trix/controllers/level_2_input_controller.js
@@ -524,7 +524,7 @@ export default class Level2InputController extends InputController {
       this.delegate?.inputControllerWillPerformTyping()
     }
     const perform = () => this.responder?.deleteInDirection(direction)
-    const domRange = this.getTargetDOMRange({ minLength: 2 })
+    const domRange = this.getTargetDOMRange({ minLength: this.composing ? 1 : 2 })
     if (domRange) {
       return this.withTargetDOMRange(domRange, perform)
     } else {


### PR DESCRIPTION
iOS beta 8 renders a preview of the suggestion that messes up with text composing in Trix. You may end up with misspelled words when typing in the suggested term. For example:

1. Type: "kno".
2. iOS suggests "know". 
3. Type: "w"

The final word is "knww".

The problem is the system that handles `compositionend` events, which relies on deleting the composed text. When that only has one character, we default to performing a regular delete operation. The problem with the new iOS dimmed suggestions is that this matches the interaction of typing in the last character in a suggestion, and it results in Trix wrongly deleting legit content when discarding the suggestion.

This solution relaxes the condition to rely on the range when there is a length of one when the editor is in composing mode.