### PR TITLE
Show placeholder text when it's empty

### DIFF
--- a/src/trix/elements/trix_editor_element.js
+++ b/src/trix/elements/trix_editor_element.js
@@ -110,7 +110,7 @@ installDefaultCSSForTagName("trix-editor", `\
     display: block;
 }
 
-%t:empty:not(:focus)::before {
+%t:empty::before {
     content: attr(placeholder);
     color: graytext;
     cursor: text;


### PR DESCRIPTION
Show placeholder text when it's empty, not just when it's not in focus.