### PR TITLE
Fix bug with dictation on iOS 18+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trix",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "A rich text editor for everyday writing",
   "main": "dist/trix.umd.min.js",
   "module": "dist/trix.esm.min.js",

--- a/src/trix/controllers/level_2_input_controller.js
+++ b/src/trix/controllers/level_2_input_controller.js
@@ -73,6 +73,11 @@ export default class Level2InputController extends InputController {
     beforeinput(event) {
       const handler = this.constructor.inputTypes[event.inputType]
 
+      // Handles bug with Siri dictation on iOS 18+.
+      if (!event.inputType) {
+        this.render()
+      }
+
       if (handler) {
         this.withEvent(event, handler)
         this.scheduleRender()


### PR DESCRIPTION
Dictation on iOS does not trigger composition events (https://bugs.webkit.org/show_bug.cgi?id=261764). Instead, it triggers `beforeinput` events with `insertText`. During the dictation phase, it keeps the range anchored to the cursor, and iOS may modify past text as new text adds context.

Once dictation is stopped, it starts sending `insertText` events with word fragments. When a past fragment is altered, iOS sends a `beforeinput` event where `inputType` is null. In this case, perform a synchronous render operation to set the editor to the correct state. Otherwise, scheduled render requests can process invalid ranges and mess with the editor contents.