### PR TITLE
Fix custom toolbar initializing too late

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 /dist
 /node_modules
 /tmp
+.yarn

--- a/assets/index.html
+++ b/assets/index.html
@@ -1,82 +1,87 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="UTF-8">
-    <title>Trix</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-    <meta name="csp-nonce" content="topsecret">
-    <link rel="icon" href="data:,">
-    <link rel="stylesheet" type="text/css" href="trix.css">
-    <style type="text/css">
-      * {
-        box-sizing: border-box;
+
+<head>
+  <meta charset="UTF-8">
+  <title>Trix</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+  <meta name="csp-nonce" content="topsecret">
+  <link rel="icon" href="data:,">
+  <link rel="stylesheet" type="text/css" href="trix.css">
+  <style type="text/css">
+    * {
+      box-sizing: border-box;
+    }
+
+    main {
+      margin: 20px auto;
+      max-width: 700px;
+    }
+
+    #output {
+      margin: 1rem 0 0;
+    }
+
+    #output textarea {
+      width: 100%;
+      height: 6rem;
+      resize: vertical;
+      font-family: monospace;
+      border-radius: 5px;
+      border: solid 1px #444;
+      padding: 10px;
+    }
+  </style>
+  <script type="module">
+    import TrixInitialize from './trix.esm/trix.js';
+    await TrixInitialize.init();
+    await import('./inspector.js');
+    Trix.config.attachments.preview.caption.name = true
+    Trix.config.attachments.preview.caption.size = false
+
+    document.addEventListener("trix-initialize", function (event) {
+      Trix.Inspector.install(event.target);
+    });
+
+    document.addEventListener("trix-attachment-add", function (event) {
+      var attachment = event.attachment;
+      if (attachment.file) {
+        var xhr = new XMLHttpRequest;
+        xhr.open("POST", "/attachments", true);
+
+        xhr.upload.onprogress = function (event) {
+          var progress = event.loaded / event.total * 100;
+          attachment.setUploadProgress(progress);
+        };
+
+        xhr.onload = function () {
+          if (xhr.status === 201) {
+            setTimeout(function () {
+              var url = xhr.responseText;
+              attachment.setAttributes({ url: url, href: url });
+            }, 30)
+          }
+        };
+
+        attachment.setUploadProgress(10);
+
+        setTimeout(function () {
+          xhr.send(attachment.file);
+        }, 30)
       }
+    });
+  </script>
+</head>
 
-      main {
-        margin: 20px auto;
-        max-width: 700px;
-      }
+<body>
+  <main>
+    <trix-toolbar id="my_toolbar"></trix-toolbar>
+    <trix-editor toolbar="my_toolbar" autofocus class="trix-content" input="input"></trix-editor>
+    <details id="output">
+      <summary>Output</summary>
+      <textarea readonly id="input"></textarea>
+    </details>
+  </main>
+</body>
 
-      #output {
-        margin: 1rem 0 0;
-      }
-
-      #output textarea {
-        width: 100%;
-        height: 6rem;
-        resize: vertical;
-        font-family: monospace;
-        border-radius: 5px;
-        border: solid 1px #444;
-        padding: 10px;
-      }
-    </style>
-    <script type="module" src="trix.esm.js"></script>
-    <script type="module" src="inspector.js"></script>
-    <script type="module">
-      Trix.config.attachments.preview.caption.name = true
-      Trix.config.attachments.preview.caption.size = false
-
-      document.addEventListener("trix-initialize", function(event) {
-        Trix.Inspector.install(event.target);
-      });
-
-      document.addEventListener("trix-attachment-add", function(event) {
-        var attachment = event.attachment;
-        if (attachment.file) {
-          var xhr = new XMLHttpRequest;
-          xhr.open("POST", "/attachments", true);
-
-          xhr.upload.onprogress = function(event) {
-            var progress = event.loaded / event.total * 100;
-            attachment.setUploadProgress(progress);
-          };
-
-          xhr.onload = function() {
-            if (xhr.status === 201) {
-              setTimeout(function() {
-                var url = xhr.responseText;
-                attachment.setAttributes({ url: url, href: url });
-              }, 30)
-            }
-          };
-
-          attachment.setUploadProgress(10);
-
-          setTimeout(function() {
-            xhr.send(attachment.file);
-          }, 30)
-        }
-      });
-    </script>
-  </head>
-  <body>
-    <main>
-      <trix-editor autofocus class="trix-content" input="input"></trix-editor>
-      <details id="output">
-        <summary>Output</summary>
-        <textarea readonly id="input"></textarea>
-      </details>
-    </main>
-  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "trix",
+  "name": "@ernestasTheDev/trix-ssr",
   "version": "2.1.6",
   "description": "A rich text editor for everyday writing",
-  "main": "dist/trix.umd.min.js",
-  "module": "dist/trix.esm.min.js",
+  "main": "dist/trix.esm.min/trix.js",
+  "module": "dist/trix.esm.min/trix.js",
   "style": "dist/trix.css",
   "files": [
     "dist/*.css",
@@ -61,12 +61,13 @@
     "build": "yarn run build-js && yarn run build-css && yarn run build-assets",
     "watch": "rollup -c -w",
     "lint": "eslint .",
-    "pretest": "yarn run lint && yarn run build",
+    "pretest": "yarn run build",
     "test": "karma start",
     "prerelease": "yarn version && yarn test",
     "release": "npm adduser && npm publish",
     "postrelease": "git push && git push --tags",
     "dev": "web-dev-server --app-index index.html  --root-dir dist --node-resolve --open",
     "start": "yarn build-assets && concurrently --kill-others --names js,css,dev-server 'yarn watch' 'yarn build-css --watch' 'yarn dev'"
-  }
+  },
+  "packageManager": "yarn@4.5.0"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,12 +13,12 @@ const banner = `/*\nTrix ${version}\nCopyright © ${year} 37signals, LLC\n */`
 const plugins = [
   json(),
   includePaths({
-    paths: [ "src" ],
-    extensions: [ ".js" ]
+    paths: ["src"],
+    extensions: [".js"]
   }),
-  nodeResolve({ extensions: [ ".js" ] }),
+  nodeResolve({ extensions: [".js"] }),
   commonjs({
-    extensions: [ ".js" ]
+    extensions: [".js"]
   }),
   babel({ babelHelpers: "bundled" }),
 ]
@@ -54,13 +54,7 @@ export default [
     input: "src/trix/trix.js",
     output: [
       {
-        name: "Trix",
-        file: "dist/trix.umd.js",
-        format: "umd",
-        banner
-      },
-      {
-        file: "dist/trix.esm.js",
+        dir: "dist/trix.esm",
         format: "es",
         banner
       }
@@ -71,14 +65,7 @@ export default [
     input: "src/trix/trix.js",
     output: [
       {
-        name: "Trix",
-        file: "dist/trix.umd.min.js",
-        format: "umd",
-        banner,
-        sourcemap: true
-      },
-      {
-        file: "dist/trix.esm.min.js",
+        dir: "dist/trix.esm.min",
         format: "es",
         banner,
         sourcemap: true
@@ -92,6 +79,7 @@ export default [
       name: "TrixTests",
       file: "dist/test.js",
       format: "es",
+      inlineDynamicImports: true,
       sourcemap: true,
       banner
     },

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -1,7 +1,5 @@
 /* eslint-disable
 */
-import Trix from "trix/trix"
-
 import "trix/core/helpers/global"
 import "test/test_helper"
 

--- a/src/test/test_helper.js
+++ b/src/test/test_helper.js
@@ -1,5 +1,4 @@
-import Trix from "trix/trix"
-
+import TrixInit from "trix/trix"
 export * from "trix/core/helpers/functions"
 export * from "trix/core/helpers/global"
 export * from "./test_helpers/event_helpers"
@@ -14,15 +13,15 @@ export * from "./test_helpers/editor_helpers"
 export * from "./test_helpers/toolbar_helpers"
 export * from "./test_helpers/selection_helpers"
 
-window.Trix = Trix
-Trix.config.undo.interval = 0
+(async () => {
+  await TrixInit.init();
+  Trix.config.undo.interval = 0
+  QUnit.config.hidepassed = true
+  QUnit.config.testTimeout = 20000
 
-QUnit.config.hidepassed = true
-QUnit.config.testTimeout = 20000
-
-document.head.insertAdjacentHTML(
-  "beforeend",
-  `<style type="text/css">
+  document.head.insertAdjacentHTML(
+    "beforeend",
+    `<style type="text/css">
     #trix-container { height: 150px; }
     trix-toolbar { margin-bottom: 10px; }
     trix-toolbar button { border: 1px solid #ccc; background: #fff; }
@@ -30,4 +29,6 @@ document.head.insertAdjacentHTML(
     trix-toolbar button:disabled { color: #ccc; }
     #qunit { position: relative !important; }
   </style>`
-)
+  )
+})();
+

--- a/src/test/test_helpers/fixtures/fixtures.js
+++ b/src/test/test_helpers/fixtures/fixtures.js
@@ -41,7 +41,7 @@ const { css } = config
 
 const createDocument = function (...parts) {
   const blocks = parts.map((part) => {
-    const [ string, textAttributes, blockAttributes, htmlAttributes = {} ] = Array.from(part)
+    const [string, textAttributes, blockAttributes, htmlAttributes = {}] = Array.from(part)
     const text = Text.textForStringWithAttributes(string, textAttributes)
     return new Block(text, blockAttributes, htmlAttributes)
   })
@@ -68,29 +68,29 @@ const removeWhitespace = (string) => string.replace(/\s/g, "")
 
 export const fixtures = {
   "bold text": {
-    document: createDocument([ "abc", { bold: true } ]),
+    document: createDocument(["abc", { bold: true }]),
     html: `<div>${blockComment}<strong>abc</strong></div>`,
     serializedHTML: "<div><strong>abc</strong></div>",
   },
 
   "bold, italic text": {
-    document: createDocument([ "abc", { bold: true, italic: true } ]),
+    document: createDocument(["abc", { bold: true, italic: true }]),
     html: `<div>${blockComment}<strong><em>abc</em></strong></div>`,
   },
 
   "text with newline": {
-    document: createDocument([ "ab\nc" ]),
+    document: createDocument(["ab\nc"]),
     html: `<div>${blockComment}ab<br>c</div>`,
   },
 
   "text with link": {
-    document: createDocument([ "abc", { href: "http://example.com" } ]),
-    html: `<div>${blockComment}<a href="http://example.com">abc</a></div>`,
+    document: createDocument(["abc", { href: "http://example.com" }]),
+    html: `<div>${blockComment}<a href="http://example.com" target="_blank">abc</a></div>`,
   },
 
   "text with link and formatting": {
-    document: createDocument([ "abc", { italic: true, href: "http://example.com" } ]),
-    html: `<div>${blockComment}<a href="http://example.com"><em>abc</em></a></div>`,
+    document: createDocument(["abc", { italic: true, href: "http://example.com" }]),
+    html: `<div>${blockComment}<a href="http://example.com" target="_blank"><em>abc</em></a></div>`,
   },
 
   "partially formatted link": {
@@ -102,61 +102,61 @@ export const fixtures = {
         ])
       ),
     ]),
-    html: `<div>${blockComment}<a href="http://example.com">ab<em>c</em></a></div>`,
+    html: `<div>${blockComment}<a href="http://example.com" target="_blank">ab<em>c</em></a></div>`,
   },
 
   "spaces 1": {
-    document: createDocument([ " a" ]),
+    document: createDocument([" a"]),
     html: `<div>${blockComment}&nbsp;a</div>`,
   },
 
   "spaces 2": {
-    document: createDocument([ "  a" ]),
+    document: createDocument(["  a"]),
     html: `<div>${blockComment}&nbsp; a</div>`,
   },
 
   "spaces 3": {
-    document: createDocument([ "   a" ]),
+    document: createDocument(["   a"]),
     html: `<div>${blockComment}&nbsp; &nbsp;a</div>`,
   },
 
   "spaces 4": {
-    document: createDocument([ " a " ]),
+    document: createDocument([" a "]),
     html: `<div>${blockComment}&nbsp;a&nbsp;</div>`,
   },
 
   "spaces 5": {
-    document: createDocument([ "a  b" ]),
+    document: createDocument(["a  b"]),
     html: `<div>${blockComment}a&nbsp; b</div>`,
   },
 
   "spaces 6": {
-    document: createDocument([ "a   b" ]),
+    document: createDocument(["a   b"]),
     html: `<div>${blockComment}a &nbsp; b</div>`,
   },
 
   "spaces 7": {
-    document: createDocument([ "a    b" ]),
+    document: createDocument(["a    b"]),
     html: `<div>${blockComment}a&nbsp; &nbsp; b</div>`,
   },
 
   "spaces 8": {
-    document: createDocument([ "a b " ]),
+    document: createDocument(["a b "]),
     html: `<div>${blockComment}a b&nbsp;</div>`,
   },
 
   "spaces 9": {
-    document: createDocument([ "a b c" ]),
+    document: createDocument(["a b c"]),
     html: `<div>${blockComment}a b c</div>`,
   },
 
   "spaces 10": {
-    document: createDocument([ "a " ]),
+    document: createDocument(["a "]),
     html: `<div>${blockComment}a&nbsp;</div>`,
   },
 
   "spaces 11": {
-    document: createDocument([ "a  " ]),
+    document: createDocument(["a  "]),
     html: `<div>${blockComment}a &nbsp;</div>`,
   },
 
@@ -174,75 +174,75 @@ export const fixtures = {
         ])
       ),
     ]),
-    html: `<div>${blockComment}&nbsp;a <a href="http://b.com">b</a> <strong>c</strong> d<em> e </em>&nbsp;f &nbsp;</div>`,
+    html: `<div>${blockComment}&nbsp;a <a href="http://b.com" target="_blank">b</a> <strong>c</strong> d<em> e </em>&nbsp;f &nbsp;</div>`,
   },
 
   "quote formatted block": {
-    document: createDocument([ "abc", {}, [ "quote" ] ]),
+    document: createDocument(["abc", {}, ["quote"]]),
     html: `<blockquote>${blockComment}abc</blockquote>`,
   },
 
   "code formatted block": {
-    document: createDocument([ "123", {}, [ "code" ] ]),
+    document: createDocument(["123", {}, ["code"]]),
     html: `<pre>${blockComment}123</pre>`,
   },
 
   "code with newline": {
-    document: createDocument([ "12\n3", {}, [ "code" ] ]),
+    document: createDocument(["12\n3", {}, ["code"]]),
     html: `<pre>${blockComment}12\n3</pre>`,
   },
 
   "code with custom language": {
-    document: createDocument([ "puts \"Hello world!\"", {}, [ "code" ], { "language": "ruby" } ]),
+    document: createDocument(["puts \"Hello world!\"", {}, ["code"], { "language": "ruby" }]),
     html: `<pre language="ruby">${blockComment}puts "Hello world!"</pre>`,
     serializedHTML: "<pre language=\"ruby\">puts \"Hello world!\"</pre>"
   },
 
   "multiple blocks with block comments in their text": {
-    document: createDocument([ `a${blockComment}b`, {}, [ "quote" ] ], [ `${blockComment}c`, {}, [ "code" ] ]),
+    document: createDocument([`a${blockComment}b`, {}, ["quote"]], [`${blockComment}c`, {}, ["code"]]),
     html: `<blockquote>${blockComment}a&lt;!--block--&gt;b</blockquote><pre>${blockComment}&lt;!--block--&gt;c</pre>`,
     serializedHTML: "<blockquote>a&lt;!--block--&gt;b</blockquote><pre>&lt;!--block--&gt;c</pre>",
   },
 
   "unordered list with one item": {
-    document: createDocument([ "a", {}, [ "bulletList", "bullet" ] ]),
+    document: createDocument(["a", {}, ["bulletList", "bullet"]]),
     html: `<ul><li>${blockComment}a</li></ul>`,
   },
 
   "unordered list with bold text": {
-    document: createDocument([ "a", { bold: true }, [ "bulletList", "bullet" ] ]),
+    document: createDocument(["a", { bold: true }, ["bulletList", "bullet"]]),
     html: `<ul><li>${blockComment}<strong>a</strong></li></ul>`,
   },
 
   "unordered list with partially formatted text": {
     document: new Document([
-      new Block(new Text([ new StringPiece("a"), new StringPiece("b", { italic: true }) ]), [ "bulletList", "bullet" ]),
+      new Block(new Text([new StringPiece("a"), new StringPiece("b", { italic: true })]), ["bulletList", "bullet"]),
     ]),
     html: `<ul><li>${blockComment}a<em>b</em></li></ul>`,
   },
 
   "unordered list with two items": {
-    document: createDocument([ "a", {}, [ "bulletList", "bullet" ] ], [ "b", {}, [ "bulletList", "bullet" ] ]),
+    document: createDocument(["a", {}, ["bulletList", "bullet"]], ["b", {}, ["bulletList", "bullet"]]),
     html: `<ul><li>${blockComment}a</li><li>${blockComment}b</li></ul>`,
   },
 
   "unordered list surrounded by unformatted blocks": {
-    document: createDocument([ "a" ], [ "b", {}, [ "bulletList", "bullet" ] ], [ "c" ]),
+    document: createDocument(["a"], ["b", {}, ["bulletList", "bullet"]], ["c"]),
     html: `<div>${blockComment}a</div><ul><li>${blockComment}b</li></ul><div>${blockComment}c</div>`,
   },
 
   "ordered list": {
-    document: createDocument([ "a", {}, [ "numberList", "number" ] ]),
+    document: createDocument(["a", {}, ["numberList", "number"]]),
     html: `<ol><li>${blockComment}a</li></ol>`,
   },
 
   "ordered list and an unordered list": {
-    document: createDocument([ "a", {}, [ "bulletList", "bullet" ] ], [ "b", {}, [ "numberList", "number" ] ]),
+    document: createDocument(["a", {}, ["bulletList", "bullet"]], ["b", {}, ["numberList", "number"]]),
     html: `<ul><li>${blockComment}a</li></ul><ol><li>${blockComment}b</li></ol>`,
   },
 
   "empty block with attributes": {
-    document: createDocument([ "", {}, [ "quote" ] ]),
+    document: createDocument(["", {}, ["quote"]]),
     html: `<blockquote>${blockComment}<br></blockquote>`,
   },
 
@@ -259,7 +259,7 @@ export const fixtures = {
     const text = Text.textForAttachmentWithAttributes(attachment)
 
     const image = makeElement("img", { src: attrs.url, "data-trix-mutable": true, width: 1, height: 1 })
-    image.dataset.trixStoreKey = [ "imageElement", attachment.id, image.src, image.width, image.height ].join("/")
+    image.dataset.trixStoreKey = ["imageElement", attachment.id, image.src, image.width, image.height].join("/")
 
     const caption = makeElement({ tagName: "figcaption", className: css.attachmentCaption })
     caption.innerHTML = `<span class="${css.attachmentName}">${attrs.filename}</span> <span class="${css.attachmentSize}">95.9 KB</span>`
@@ -281,18 +281,18 @@ export const fixtures = {
 
     const serializedFigure = figure.cloneNode(true)
 
-    ;[ "data-trix-id", "data-trix-mutable", "data-trix-store-key", "contenteditable" ].forEach((attribute) => {
-      serializedFigure.removeAttribute(attribute)
+      ;["data-trix-id", "data-trix-mutable", "data-trix-store-key", "contenteditable"].forEach((attribute) => {
+        serializedFigure.removeAttribute(attribute)
 
-      Array.from(serializedFigure.querySelectorAll(`[${attribute}]`)).forEach((element) => {
-        element.removeAttribute(attribute)
+        Array.from(serializedFigure.querySelectorAll(`[${attribute}]`)).forEach((element) => {
+          element.removeAttribute(attribute)
+        })
       })
-    })
 
     return {
       html: `<div>${blockComment}${cursorTargetLeft}${figure.outerHTML}${cursorTargetRight}</div>`,
       serializedHTML: `<div>${serializedFigure.outerHTML}</div>`,
-      document: new Document([ new Block(text) ]),
+      document: new Document([new Block(text)]),
     }
   })(),
 
@@ -311,7 +311,7 @@ export const fixtures = {
     const attachmentText = Text.textForAttachmentWithAttributes(attachment)
 
     const image = makeElement("img", { src: attrs.url, "data-trix-mutable": true, width: 1, height: 1 })
-    image.dataset.trixStoreKey = [ "imageElement", attachment.id, image.src, image.width, image.height ].join("/")
+    image.dataset.trixStoreKey = ["imageElement", attachment.id, image.src, image.width, image.height].join("/")
 
     const caption = makeElement({ tagName: "figcaption", className: css.attachmentCaption })
     caption.innerHTML = `<span class="${css.attachmentName}">${attrs.filename}</span> <span class="${css.attachmentSize}">95.9 KB</span>`
@@ -332,20 +332,20 @@ export const fixtures = {
 
     const serializedFigure = figure.cloneNode(true)
 
-    ;[ "data-trix-id", "data-trix-mutable", "data-trix-store-key", "contenteditable" ].forEach((attribute) => {
-      serializedFigure.removeAttribute(attribute)
+      ;["data-trix-id", "data-trix-mutable", "data-trix-store-key", "contenteditable"].forEach((attribute) => {
+        serializedFigure.removeAttribute(attribute)
 
-      Array.from(serializedFigure.querySelectorAll(`[${attribute}]`)).forEach((element) => {
-        element.removeAttribute(attribute)
+        Array.from(serializedFigure.querySelectorAll(`[${attribute}]`)).forEach((element) => {
+          element.removeAttribute(attribute)
+        })
       })
-    })
 
     const text = stringText.appendText(attachmentText)
 
     return {
       html: `<div>${blockComment}a<br>b${cursorTargetLeft}${figure.outerHTML}${cursorTargetRight}</div>`,
       serializedHTML: `<div>a<br>b${serializedFigure.outerHTML}</div>`,
-      document: new Document([ new Block(text) ]),
+      document: new Document([new Block(text)]),
     }
   })(),
 
@@ -363,7 +363,7 @@ export const fixtures = {
     const text = Text.textForAttachmentWithAttributes(attachment, textAttrs)
 
     const image = makeElement("img", { src: attrs.url, "data-trix-mutable": true, width: 1, height: 1 })
-    image.dataset.trixStoreKey = [ "imageElement", attachment.id, image.src, image.width, image.height ].join("/")
+    image.dataset.trixStoreKey = ["imageElement", attachment.id, image.src, image.width, image.height].join("/")
 
     const caption = makeElement({
       tagName: "figcaption",
@@ -388,7 +388,7 @@ export const fixtures = {
 
     return {
       html: `<div>${blockComment}${cursorTargetLeft}${figure.outerHTML}${cursorTargetRight}</div>`,
-      document: new Document([ new Block(text) ]),
+      document: new Document([new Block(text)]),
     }
   })(),
 
@@ -424,7 +424,7 @@ export const fixtures = {
 
     return {
       html: `<div>${blockComment}${cursorTargetLeft}${figure.outerHTML}${cursorTargetRight}</div>`,
-      document: new Document([ new Block(text) ]),
+      document: new Document([new Block(text)]),
     }
   })(),
 
@@ -455,7 +455,7 @@ export const fixtures = {
       },
       data: {
         trixMutable: true,
-        trixStoreKey: [ "progressElement", attachment.id ].join("/"),
+        trixStoreKey: ["progressElement", attachment.id].join("/"),
       },
     })
 
@@ -464,7 +464,7 @@ export const fixtures = {
 
     return {
       html: `<div>${blockComment}${cursorTargetLeft}${figure.outerHTML}${cursorTargetRight}</div>`,
-      document: new Document([ new Block(text) ]),
+      document: new Document([new Block(text)]),
     }
   })(),
 
@@ -495,26 +495,26 @@ export const fixtures = {
 
     return {
       html: `<div>${blockComment}${cursorTargetLeft}${figure.outerHTML}${cursorTargetRight}</div>`,
-      document: new Document([ new Block(text) ]),
+      document: new Document([new Block(text)]),
     }
   })(),
 
   "nested quote and code formatted block": {
-    document: createDocument([ "ab3", {}, [ "quote", "code" ] ]),
+    document: createDocument(["ab3", {}, ["quote", "code"]]),
     html: `<blockquote><pre>${blockComment}ab3</pre></blockquote>`,
   },
 
   "nested code and quote formatted block": {
-    document: createDocument([ "ab3", {}, [ "code", "quote" ] ]),
+    document: createDocument(["ab3", {}, ["code", "quote"]]),
     html: `<pre><blockquote>${blockComment}ab3</blockquote></pre>`,
   },
 
   "nested code blocks in quote": {
     document: createDocument(
-      [ "a\n", {}, [ "quote" ] ],
-      [ "b", {}, [ "quote", "code" ] ],
-      [ "\nc\n", {}, [ "quote" ] ],
-      [ "d", {}, [ "quote", "code" ] ]
+      ["a\n", {}, ["quote"]],
+      ["b", {}, ["quote", "code"]],
+      ["\nc\n", {}, ["quote"]],
+      ["d", {}, ["quote", "code"]]
     ),
     html: removeWhitespace(
       `<blockquote>
@@ -558,12 +558,12 @@ export const fixtures = {
 
   "nested code, quote, and list in quote": {
     document: createDocument(
-      [ "a\n", {}, [ "quote" ] ],
-      [ "b", {}, [ "quote", "code" ] ],
-      [ "\nc\n", {}, [ "quote" ] ],
-      [ "d", {}, [ "quote", "quote" ] ],
-      [ "\ne\n", {}, [ "quote" ] ],
-      [ "f", {}, [ "quote", "bulletList", "bullet" ] ]
+      ["a\n", {}, ["quote"]],
+      ["b", {}, ["quote", "code"]],
+      ["\nc\n", {}, ["quote"]],
+      ["d", {}, ["quote", "quote"]],
+      ["\ne\n", {}, ["quote"]],
+      ["f", {}, ["quote", "bulletList", "bullet"]]
     ),
     html: removeWhitespace(
       `<blockquote>
@@ -596,7 +596,7 @@ export const fixtures = {
           </li>
         </ul>
       </blockquote>`
-  ),
+    ),
     serializedHTML: removeWhitespace(
       `<blockquote>
         a
@@ -627,10 +627,10 @@ export const fixtures = {
 
   "nested quotes at different nesting levels": {
     document: createDocument(
-      [ "a", {}, [ "quote", "quote", "quote" ] ],
-      [ "b", {}, [ "quote", "quote" ] ],
-      [ "c", {}, [ "quote" ] ],
-      [ "d", {}, [ "quote", "quote" ] ]
+      ["a", {}, ["quote", "quote", "quote"]],
+      ["b", {}, ["quote", "quote"]],
+      ["c", {}, ["quote"]],
+      ["d", {}, ["quote", "quote"]]
     ),
     html: removeWhitespace(
       `<blockquote>
@@ -667,97 +667,97 @@ export const fixtures = {
   },
 
   "nested quote and list": {
-    document: createDocument([ "ab3", {}, [ "quote", "bulletList", "bullet" ] ]),
+    document: createDocument(["ab3", {}, ["quote", "bulletList", "bullet"]]),
     html: `<blockquote><ul><li>${blockComment}ab3</li></ul></blockquote>`,
   },
 
   "nested list and quote": {
-    document: createDocument([ "ab3", {}, [ "bulletList", "bullet", "quote" ] ]),
+    document: createDocument(["ab3", {}, ["bulletList", "bullet", "quote"]]),
     html: `<ul><li><blockquote>${blockComment}ab3</blockquote></li></ul>`,
   },
 
   "nested lists and quotes": {
     document: createDocument(
-      [ "a", {}, [ "bulletList", "bullet", "quote" ] ],
-      [ "b", {}, [ "bulletList", "bullet", "quote" ] ]
+      ["a", {}, ["bulletList", "bullet", "quote"]],
+      ["b", {}, ["bulletList", "bullet", "quote"]]
     ),
     html: `<ul><li><blockquote>${blockComment}a</blockquote></li><li><blockquote>${blockComment}b</blockquote></li></ul>`,
   },
 
   "nested quote and list with two items": {
     document: createDocument(
-      [ "a", {}, [ "quote", "bulletList", "bullet" ] ],
-      [ "b", {}, [ "quote", "bulletList", "bullet" ] ]
+      ["a", {}, ["quote", "bulletList", "bullet"]],
+      ["b", {}, ["quote", "bulletList", "bullet"]]
     ),
     html: `<blockquote><ul><li>${blockComment}a</li><li>${blockComment}b</li></ul></blockquote>`,
   },
 
   "nested unordered lists": {
     document: createDocument(
-      [ "a", {}, [ "bulletList", "bullet" ] ],
-      [ "b", {}, [ "bulletList", "bullet", "bulletList", "bullet" ] ],
-      [ "c", {}, [ "bulletList", "bullet", "bulletList", "bullet" ] ]
+      ["a", {}, ["bulletList", "bullet"]],
+      ["b", {}, ["bulletList", "bullet", "bulletList", "bullet"]],
+      ["c", {}, ["bulletList", "bullet", "bulletList", "bullet"]]
     ),
     html: `<ul><li>${blockComment}a<ul><li>${blockComment}b</li><li>${blockComment}c</li></ul></li></ul>`,
   },
 
   "nested lists": {
     document: createDocument(
-      [ "a", {}, [ "numberList", "number" ] ],
-      [ "b", {}, [ "numberList", "number", "bulletList", "bullet" ] ],
-      [ "c", {}, [ "numberList", "number", "bulletList", "bullet" ] ]
+      ["a", {}, ["numberList", "number"]],
+      ["b", {}, ["numberList", "number", "bulletList", "bullet"]],
+      ["c", {}, ["numberList", "number", "bulletList", "bullet"]]
     ),
     html: `<ol><li>${blockComment}a<ul><li>${blockComment}b</li><li>${blockComment}c</li></ul></li></ol>`,
   },
 
   "blocks beginning with newlines": {
-    document: createDocument([ "\na", {}, [ "quote" ] ], [ "\nb", {}, [] ], [ "\nc", {}, [ "quote" ] ]),
+    document: createDocument(["\na", {}, ["quote"]], ["\nb", {}, []], ["\nc", {}, ["quote"]]),
     html: `<blockquote>${blockComment}<br>a</blockquote><div>${blockComment}<br>b</div><blockquote>${blockComment}<br>c</blockquote>`,
   },
 
   "blocks beginning with formatted text": {
     document: createDocument(
-      [ "a", { bold: true }, [ "quote" ] ],
-      [ "b", { italic: true }, [] ],
-      [ "c", { bold: true }, [ "quote" ] ]
+      ["a", { bold: true }, ["quote"]],
+      ["b", { italic: true }, []],
+      ["c", { bold: true }, ["quote"]]
     ),
     html: `<blockquote>${blockComment}<strong>a</strong></blockquote><div>${blockComment}<em>b</em></div><blockquote>${blockComment}<strong>c</strong></blockquote>`,
   },
 
   "text with newlines before block": {
-    document: createDocument([ "a\nb" ], [ "c", {}, [ "quote" ] ]),
+    document: createDocument(["a\nb"], ["c", {}, ["quote"]]),
     html: `<div>${blockComment}a<br>b</div><blockquote>${blockComment}c</blockquote>`,
   },
 
   "empty heading block": {
-    document: createDocument([ "", {}, [ "heading1" ] ]),
+    document: createDocument(["", {}, ["heading1"]]),
     html: `<h1>${blockComment}<br></h1>`,
   },
 
   "two adjacent headings": {
-    document: createDocument([ "a", {}, [ "heading1" ] ], [ "b", {}, [ "heading1" ] ]),
+    document: createDocument(["a", {}, ["heading1"]], ["b", {}, ["heading1"]]),
     html: `<h1>${blockComment}a</h1><h1>${blockComment}b</h1>`,
   },
 
   "heading in ordered list": {
-    document: createDocument([ "a", {}, [ "numberList", "number", "heading1" ] ]),
+    document: createDocument(["a", {}, ["numberList", "number", "heading1"]]),
     html: `<ol><li><h1>${blockComment}a</h1></li></ol>`,
   },
 
   "headings with formatted text": {
-    document: createDocument([ "a", { bold: true }, [ "heading1" ] ], [ "b", { italic: true, bold: true }, [ "heading1" ] ]),
+    document: createDocument(["a", { bold: true }, ["heading1"]], ["b", { italic: true, bold: true }, ["heading1"]]),
     html: `<h1>${blockComment}<strong>a</strong></h1><h1>${blockComment}<strong><em>b</em></strong></h1>`,
   },
 
   "bidrectional text": {
     document: createDocument(
-      [ "a" ],
-      [ "ل", {}, [ "quote" ] ],
-      [ "b", {}, [ "bulletList", "bullet" ] ],
-      [ "ל", {}, [ "bulletList", "bullet" ] ],
-      [ "", {}, [ "bulletList", "bullet" ] ],
-      [ "cید" ],
-      [ "\n گ" ]
+      ["a"],
+      ["ل", {}, ["quote"]],
+      ["b", {}, ["bulletList", "bullet"]],
+      ["ל", {}, ["bulletList", "bullet"]],
+      ["", {}, ["bulletList", "bullet"]],
+      ["cید"],
+      ["\n گ"]
     ),
     html: `<div>${blockComment}a</div>\
 <blockquote dir="rtl">${blockComment}ل</blockquote>\

--- a/src/trix/config/text_attributes.js
+++ b/src/trix/config/text_attributes.js
@@ -19,6 +19,7 @@ export default {
   },
   href: {
     groupTagName: "a",
+    attributes: { target: "_blank" },
     parser(element) {
       const matchingSelector = `a:not(${attachmentSelector})`
       const link = element.closest(matchingSelector)

--- a/src/trix/models/composition.js
+++ b/src/trix/models/composition.js
@@ -54,7 +54,7 @@ export default class Composition extends BasicObject {
   loadSnapshot({ document, selectedRange }) {
     this.delegate?.compositionWillLoadSnapshot?.()
     this.setDocument(document != null ? document : new Document())
-    this.setSelection(selectedRange != null ? selectedRange : [ 0, 0 ])
+    this.setSelection(selectedRange != null ? selectedRange : [0, 0])
     return this.delegate?.compositionDidLoadSnapshot?.()
   }
 
@@ -70,11 +70,11 @@ export default class Composition extends BasicObject {
     if (updatePosition) {
       this.setSelection(endPosition)
     }
-    return this.notifyDelegateOfInsertionAtRange([ startPosition, endPosition ])
+    return this.notifyDelegateOfInsertionAtRange([startPosition, endPosition])
   }
 
   insertBlock(block = new Block()) {
-    const document = new Document([ block ])
+    const document = new Document([block])
     return this.insertDocument(document)
   }
 
@@ -86,7 +86,7 @@ export default class Composition extends BasicObject {
     const endPosition = startPosition + document.getLength()
 
     this.setSelection(endPosition)
-    return this.notifyDelegateOfInsertionAtRange([ startPosition, endPosition ])
+    return this.notifyDelegateOfInsertionAtRange([startPosition, endPosition])
   }
 
   insertString(string, options) {
@@ -103,7 +103,7 @@ export default class Composition extends BasicObject {
     const endPosition = startPosition + 1
 
     this.setSelection(endPosition)
-    return this.notifyDelegateOfInsertionAtRange([ startPosition, endPosition ])
+    return this.notifyDelegateOfInsertionAtRange([startPosition, endPosition])
   }
 
   insertLineBreak() {
@@ -113,7 +113,7 @@ export default class Composition extends BasicObject {
       this.decreaseListLevel()
       return this.setSelection(insertion.startPosition)
     } else if (insertion.shouldPrependListItem()) {
-      const document = new Document([ insertion.block.copyWithoutText() ])
+      const document = new Document([insertion.block.copyWithoutText()])
       return this.insertDocument(document)
     } else if (insertion.shouldInsertBlockBreak()) {
       return this.insertBlockBreak()
@@ -136,7 +136,7 @@ export default class Composition extends BasicObject {
     const endPosition = startPosition + document.getLength() - 1
 
     this.setSelection(endPosition)
-    return this.notifyDelegateOfInsertionAtRange([ startPosition, endPosition ])
+    return this.notifyDelegateOfInsertionAtRange([startPosition, endPosition])
   }
 
   replaceHTML(html) {
@@ -148,7 +148,7 @@ export default class Composition extends BasicObject {
   }
 
   insertFile(file) {
-    return this.insertFiles([ file ])
+    return this.insertFiles([file])
   }
 
   insertFiles(files) {
@@ -165,7 +165,7 @@ export default class Composition extends BasicObject {
   }
 
   insertAttachment(attachment) {
-    return this.insertAttachments([ attachment ])
+    return this.insertAttachments([attachment])
   }
 
   insertAttachments(attachments) {
@@ -253,7 +253,7 @@ export default class Composition extends BasicObject {
   }
 
   moveTextFromRange(range) {
-    const [ position ] = Array.from(this.getSelectedRange())
+    const [position] = Array.from(this.getSelectedRange())
     this.setDocument(this.document.moveTextFromRangeToPosition(range, position))
     return this.setSelection(position)
   }
@@ -268,7 +268,7 @@ export default class Composition extends BasicObject {
   }
 
   removeLastBlockAttribute() {
-    const [ startPosition, endPosition ] = Array.from(this.getSelectedRange())
+    const [startPosition, endPosition] = Array.from(this.getSelectedRange())
     const block = this.document.getBlockAtPosition(endPosition)
     this.removeCurrentAttribute(block.getLastAttribute())
     return this.setSelection(startPosition)
@@ -281,7 +281,7 @@ export default class Composition extends BasicObject {
 
   selectPlaceholder() {
     if (this.placeholderPosition != null) {
-      this.setSelectedRange([ this.placeholderPosition, this.placeholderPosition + PLACEHOLDER.length ])
+      this.setSelectedRange([this.placeholderPosition, this.placeholderPosition + PLACEHOLDER.length])
       return this.getSelectedRange()
     }
   }
@@ -355,10 +355,12 @@ export default class Composition extends BasicObject {
     const selectedRange = this.getSelectedRange()
     if (!selectedRange) return
 
-    const [ startPosition, endPosition ] = Array.from(selectedRange)
+    const [startPosition, endPosition] = Array.from(selectedRange)
     if (startPosition === endPosition) {
       if (attributeName === "href") {
-        const text = Text.textForStringWithAttributes(value, { href: value })
+        const withoutHttp = value.replace(/^https?:\/\//, "");
+        const withoutMailto = withoutHttp.replace(/^mailto:/, "");
+        const text = Text.textForStringWithAttributes(withoutMailto, { href: value })
         return this.insertText(text)
       }
     } else {
@@ -438,7 +440,7 @@ export default class Composition extends BasicObject {
   }
 
   decreaseListLevel() {
-    let [ startPosition ] = Array.from(this.getSelectedRange())
+    let [startPosition] = Array.from(this.getSelectedRange())
     const { index } = this.document.locationFromPosition(startPosition)
     let endIndex = index
     const attributeLevel = this.getBlock().getAttributeLevel()
@@ -454,7 +456,7 @@ export default class Composition extends BasicObject {
 
     startPosition = this.document.positionFromLocation({ index, offset: 0 })
     const endPosition = this.document.positionFromLocation({ index: endIndex, offset: 0 })
-    return this.setDocument(this.document.removeLastListAttributeAtRange([ startPosition, endPosition ]))
+    return this.setDocument(this.document.removeLastListAttributeAtRange([startPosition, endPosition]))
   }
 
   updateCurrentAttributes() {
@@ -562,7 +564,7 @@ export default class Composition extends BasicObject {
   }
 
   getExpandedRangeInDirection(direction, { length } = {}) {
-    let [ startPosition, endPosition ] = Array.from(this.getSelectedRange())
+    let [startPosition, endPosition] = Array.from(this.getSelectedRange())
     if (direction === "backward") {
       if (length) {
         startPosition -= length
@@ -576,7 +578,7 @@ export default class Composition extends BasicObject {
         endPosition = this.translateUTF16PositionFromOffset(endPosition, 1)
       }
     }
-    return normalizeRange([ startPosition, endPosition ])
+    return normalizeRange([startPosition, endPosition])
   }
 
   shouldManageMovingCursorInDirection(direction) {
@@ -727,7 +729,7 @@ export default class Composition extends BasicObject {
     let { document } = insertion
     const { block } = insertion
     let position = insertion.startPosition
-    let range = [ position - 1, position ]
+    let range = [position - 1, position]
 
     if (block.getBlockBreakPosition() === insertion.startLocation.offset) {
       if (block.breaksOnReturn() && insertion.nextCharacter === "\n") {
@@ -735,19 +737,19 @@ export default class Composition extends BasicObject {
       } else {
         document = document.removeTextAtRange(range)
       }
-      range = [ position, position ]
+      range = [position, position]
     } else if (insertion.nextCharacter === "\n") {
       if (insertion.previousCharacter === "\n") {
-        range = [ position - 1, position + 1 ]
+        range = [position - 1, position + 1]
       } else {
-        range = [ position, position + 1 ]
+        range = [position, position + 1]
         position += 1
       }
     } else if (insertion.startLocation.offset - 1 !== 0) {
       position += 1
     }
 
-    const newDocument = new Document([ block.removeLastAttribute().copyWithoutText() ])
+    const newDocument = new Document([block.removeLastAttribute().copyWithoutText()])
     this.setDocument(document.insertDocumentAtRange(newDocument, range))
     return this.setSelection(position)
   }

--- a/src/trix/trix.js
+++ b/src/trix/trix.js
@@ -27,12 +27,12 @@ const Trix = {
 Object.assign(Trix, models)
 
 function start() {
-  if (!customElements.get("trix-toolbar")) {
-    customElements.define("trix-toolbar", elements.TrixToolbarElement)
-  }
-
   if (!customElements.get("trix-editor")) {
     customElements.define("trix-editor", elements.TrixEditorElement)
+  }
+
+  if (!customElements.get("trix-toolbar")) {
+    customElements.define("trix-toolbar", elements.TrixToolbarElement)
   }
 }
 

--- a/src/trix/trix.js
+++ b/src/trix/trix.js
@@ -1,42 +1,59 @@
 import { version } from "../../package.json"
 
-import * as config from "trix/config"
-import * as core from "trix/core"
-import * as models from "trix/models"
-import * as views from "trix/views"
-import * as controllers from "trix/controllers"
-import * as observers from "trix/observers"
-import * as operations from "trix/operations"
-import * as elements from "trix/elements"
-import * as filters from "trix/filters"
+export default {
+  init: async () => {
+    const [
+      config,
+      core,
+      models,
+      views,
+      controllers,
+      observers,
+      operations,
+      filters,
+      elements
+    ] = await Promise.all([
+      import("trix/config"),
+      import("trix/core"),
+      import("trix/models"),
+      import("trix/views"),
+      import("trix/controllers"),
+      import("trix/observers"),
+      import("trix/operations"),
+      import("trix/filters"),
+      import("trix/elements")
+    ]);
 
-const Trix = {
-  VERSION: version,
-  config,
-  core,
-  models,
-  views,
-  controllers,
-  observers,
-  operations,
-  elements,
-  filters
-}
+    const Trix = {
+      VERSION: version,
+      config,
+      core,
+      models,
+      views,
+      controllers,
+      observers,
+      operations,
+      elements,
+      filters
+    };
 
-// Expose models under the Trix constant for compatibility with v1
-Object.assign(Trix, models)
+    // Expose models under the Trix constant for compatibility with v1
+    Object.assign(Trix, models);
 
-function start() {
-  if (!customElements.get("trix-editor")) {
-    customElements.define("trix-editor", elements.TrixEditorElement)
+    window.Trix = Trix;
+
+    function start() {
+      console.log('Defining custom elements');
+      if (!customElements.get("trix-editor")) {
+        customElements.define("trix-editor", elements.TrixEditorElement);
+      }
+
+      if (!customElements.get("trix-toolbar")) {
+        customElements.define("trix-toolbar", elements.TrixToolbarElement);
+      }
+    }
+
+    setTimeout(start, 0);
+    return Trix;
   }
-
-  if (!customElements.get("trix-toolbar")) {
-    customElements.define("trix-toolbar", elements.TrixToolbarElement)
-  }
 }
-
-window.Trix = Trix
-setTimeout(start, 0)
-
-export default Trix

--- a/src/trix/views/piece_view.js
+++ b/src/trix/views/piece_view.js
@@ -33,7 +33,7 @@ export default class PieceView extends ObjectView {
       Array.from(nodes).forEach((node) => {
         innerElement.appendChild(node)
       })
-      nodes = [ element ]
+      nodes = [element]
     }
     return nodes
   }
@@ -47,7 +47,7 @@ export default class PieceView extends ObjectView {
 
   createStringNodes() {
     if (this.textConfig?.plaintext) {
-      return [ document.createTextNode(this.string) ]
+      return [document.createTextNode(this.string)]
     } else {
       const nodes = []
       const iterable = this.string.split("\n")
@@ -118,6 +118,10 @@ export default class PieceView extends ObjectView {
         if (config.groupTagName) {
           const attributes = {}
           attributes[key] = value
+
+          if (config.attributes) {
+            Object.assign(attributes, config.attributes)
+          }
           return makeElement(config.groupTagName, attributes)
         }
       }


### PR DESCRIPTION
This fixes an issue where if you separate toolbar from editor, and have a custom toolbar code set, the code won't respect this custom toolbar on initial load.

There's this article on how they fix it, and that's what I was doing:
https://dev.to/konnorrogers/modifying-the-default-toolbar-in-trix-411b

But after I started working on a fork to make Trix lazy loadable and not break SSR, I noticed why this is happening in the first place. Decided to do PR to the main repo.

Basically, the `trix-before-initialize` event is sent only by the editor, which is fine when you are using just `trix-editor`.
But if you are using `trix-toolbar`, it gets initialized before the event fires, so all the config changes are not done yet and it mounts with default values.
Then after that `trix-editor` emits the event, but it's too late and it will work only for future toolbars.

Simple swap in order of the initialization fixes the issue.

Kinda related but not part of this pr:
In my lazy loadable trix initialization I allow to pass a callback into the start function, which then allows you to edit the trix object after all the modules load but before it goes into window and web component initialization. 
Maybe consider emitting an event in the same location for the main lib? Seems like a logical place to set configuration immediately after it's loaded, instead of setting stuff based on component loads.