### PR TITLE
Allow groups of attributes to be set via a toolbar dialog

### DIFF
--- a/src/trix/config/text_attributes.js
+++ b/src/trix/config/text_attributes.js
@@ -27,6 +27,16 @@ export default {
       }
     },
   },
+  target: {
+    groupTagName: "a",
+    parser(element) {
+      const matchingSelector = `a:not(${attachmentSelector})`
+      const link = element.closest(matchingSelector)
+      if (link) {
+        return link.getAttribute("target")
+      }
+    },
+  },
   strike: {
     tagName: "del",
     inheritable: true,

--- a/src/trix/controllers/toolbar_controller.js
+++ b/src/trix/controllers/toolbar_controller.js
@@ -9,15 +9,21 @@ const dialogSelector = "[data-trix-dialog]"
 const activeDialogSelector = `${dialogSelector}[data-trix-active]`
 const dialogButtonSelector = `${dialogSelector} [data-trix-method]`
 const dialogInputSelector = `${dialogSelector} [data-trix-input]`
-const getInputForDialog = (element, attributeName) => {
-  if (!attributeName) { attributeName = getAttributeName(element) }
-  return element.querySelector(`[data-trix-input][name='${attributeName}']`)
+const getInputForDialog = (element, dialogName, attributeName) => {
+  const name = dialogName === attributeName ? dialogName : `${dialogName}[${attributeName}]`
+  return element.querySelector(`[data-trix-input][name='${name}']`)
 }
 const getActionName = (element) => element.getAttribute("data-trix-action")
 const getAttributeName = (element) => {
-  return element.getAttribute("data-trix-attribute") || element.getAttribute("data-trix-dialog-attribute")
+  return element.getAttribute("data-trix-attribute")
 }
 const getDialogName = (element) => element.getAttribute("data-trix-dialog")
+const getDialogAttributeNames = (element) => {
+  return Array.from(
+    element.getAttribute("data-trix-dialog-attribute") ||
+    element.getAttribute("data-trix-dialog-attributes").split(" ")
+  )
+}
 
 export default class ToolbarController extends BasicObject {
   constructor(element) {
@@ -94,7 +100,7 @@ export default class ToolbarController extends BasicObject {
       event.preventDefault()
       const attribute = element.getAttribute("name")
       const dialog = this.getDialog(attribute)
-      this.setAttribute(dialog)
+      this.setAttributes(dialog)
     }
     if (event.keyCode === 27) {
       // Escape key
@@ -190,36 +196,64 @@ export default class ToolbarController extends BasicObject {
       disabledInput.removeAttribute("disabled")
     })
 
-    const attributeName = getAttributeName(element)
-    if (attributeName) {
-      const input = getInputForDialog(element, dialogName)
+    const attributeNames = getDialogAttributeNames(element)
+    for (let attributeName of attributeNames) {
+      const input = getInputForDialog(element, dialogName, attributeName)
       if (input) {
-        input.value = this.attributes[attributeName] || ""
-        input.select()
+        switch (input.type) {
+          case "checkbox":
+            input.checked = this.attributes[attributeName] === input.value
+            break
+          default:
+            input.value = this.attributes[attributeName] || ""
+            input.select()
+        }
       }
     }
 
     return this.delegate?.toolbarDidShowDialog(dialogName)
   }
 
-  setAttribute(dialogElement) {
-    const attributeName = getAttributeName(dialogElement)
-    const input = getInputForDialog(dialogElement, attributeName)
-    if (input.willValidate && !input.checkValidity()) {
-      input.setAttribute("data-trix-validate", "")
-      input.classList.add("trix-validate")
-      return input.focus()
-    } else {
-      this.delegate?.toolbarDidUpdateAttribute(attributeName, input.value)
-      return this.hideDialog()
+  setAttributes(dialogElement) {
+    const dialogName = getDialogName(dialogElement)
+    const attributeNames = getDialogAttributeNames(dialogElement)
+
+    for (let attributeName of attributeNames) {
+      const input = getInputForDialog(dialogElement, dialogName, attributeName)
+
+      if (input.willValidate && !input.checkValidity()) {
+        input.setAttribute("data-trix-validate", "")
+        input.classList.add("trix-validate")
+        input.focus()
+      } else {
+        switch (input.type) {
+          case "checkbox":
+            if (input.checked) {
+              this.delegate?.toolbarDidUpdateAttribute(attributeName, input.value)
+            }
+            break
+          default:
+            this.delegate?.toolbarDidUpdateAttribute(attributeName, input.value)
+        }
+      }
     }
+
+    this.hideDialog()
   }
 
-  removeAttribute(dialogElement) {
-    const attributeName = getAttributeName(dialogElement)
-    this.delegate?.toolbarDidRemoveAttribute(attributeName)
+  setAttribute(dialogElement) { this.setAttributes(dialogElement) }
+
+  removeAttributes(dialogElement) {
+    const attributeNames = getDialogAttributeNames(dialogElement)
+
+    for (let attributeName of attributeNames) {
+      this.delegate?.toolbarDidRemoveAttribute(attributeName)
+    }
+
     return this.hideDialog()
   }
+
+  removeAttribute(dialogElement) { this.removeAttributes(dialogElement) }
 
   hideDialog() {
     const element = this.element.querySelector(activeDialogSelector)

--- a/src/trix/models/html_sanitizer.js
+++ b/src/trix/models/html_sanitizer.js
@@ -2,7 +2,7 @@ import BasicObject from "trix/core/basic_object"
 
 import { nodeIsAttachmentElement, removeNode, tagName, walkTree } from "trix/core/helpers"
 
-const DEFAULT_ALLOWED_ATTRIBUTES = "style href src width height language class".split(" ")
+const DEFAULT_ALLOWED_ATTRIBUTES = "style href target src width height language class".split(" ")
 const DEFAULT_FORBIDDEN_PROTOCOLS = "javascript:".split(" ")
 const DEFAULT_FORBIDDEN_ELEMENTS = "script iframe form noscript".split(" ")
 


### PR DESCRIPTION
The main point of this PR is to allow one to set `target="_blank"` on links on an optional basis (as in the dialog allows the user to tick a box to set that attribute. You'd use the following toolbar dialog:

```
<div class="trix-dialogs" data-trix-dialogs>
  <div class="trix-dialog trix-dialog--link" data-trix-dialog="href" data-trix-dialog-attributes="href target">
    <div class="trix-dialog__link-fields">
      <input type="url" name="href" class="trix-input trix-input--dialog" placeholder="${lang.urlPlaceholder}" aria-label="${lang.url}" required data-trix-input>
      
      <input type="checkbox" value="_blank" id="href_target" name="href[target]" data-trix-input>
      <label for="href_target">Open in a New Tab?</label>
      
      <div class="trix-button-group">
        <input type="button" class="trix-button trix-button--dialog" value="${lang.link}" data-trix-method="setAttribute">
        <input type="button" class="trix-button trix-button--dialog" value="${lang.unlink}" data-trix-method="removeAttribute">
      </div>
    </div>
  </div>
</div>
```

In addition, the ActionText configuration should probably be updated to allow `target` as an attribute:

```
ActionText::ContentHelper.allowed_attributes.add 'target'
```

### The Problem
This mostly works except for some reason I can't sniff out where some sanitisation is occurring. If I hard code a link in the database content with a `target="_blank"` and load it into trix, it strips the target attribute in the HTML it displays in the editor but all of the toolbar tools work just fine. The underlying document model still keeps track of the `target` attribute and the tick box ticks and unticks for a particular link depending on if the `target="_blank"` attribute exists, it's just rendered to the HTML and thus gets lost when serialising too.

I'm hoping for some help in solving this last piece of the puzzle and then I'll write some tests to make this PR legit.

https://github.com/basecamp/trix/issues/286
https://github.com/basecamp/trix/issues/55

To be clear, I'm not arguing for this to be included in the default interface, but it should still be possible to achieve with a custom toolbar and dialog. The aim is to make this change non-breaking (thus the aliased methods).