### PR TITLE
Toolbar Button: Handle `click` instead of `mousedown`

### DIFF
--- a/src/test/test_helpers/toolbar_helpers.js
+++ b/src/test/test_helpers/toolbar_helpers.js
@@ -5,7 +5,7 @@ import { delay, nextFrame } from "./timing_helpers"
 export const clickToolbarButton = async (selector) => {
   selectionChangeObserver.update()
   const button = getToolbarButton(selector)
-  triggerEvent(button, "mousedown")
+  triggerEvent(button, "click")
   await delay(5)
 }
 

--- a/src/trix/controllers/toolbar_controller.js
+++ b/src/trix/controllers/toolbar_controller.js
@@ -33,12 +33,12 @@ export default class ToolbarController extends BasicObject {
     this.actions = {}
     this.resetDialogInputs()
 
-    handleEvent("mousedown", {
+    handleEvent("click", {
       onElement: this.element,
       matchingSelector: actionButtonSelector,
       withCallback: this.didClickActionButton,
     })
-    handleEvent("mousedown", {
+    handleEvent("click", {
       onElement: this.element,
       matchingSelector: attributeButtonSelector,
       withCallback: this.didClickAttributeButton,


### PR DESCRIPTION
Revert [c4b9d5b][]

Requiring mouse events to trigger `<button>` element event listeners poses accessibility issues for keyboard users.

The context in the original commit ([c4b9d5b][]) is fairly light, and there doesn't appear to be a link to a GitHub pull request with more information. The provided context is:

> Prevents flickering of the placeholder text when clicking block
> formatting buttons on an empty document.

Since the commit is from 2014, there is hope that the underlying flicker might have been resolved through the natural course of browser improvements and device enhancements.

The benefit of responding to keyboard events when the `<button>` element has focus outweighs the potential downsides.

[c4b9d5b]: https://github.com/basecamp/trix/commit/c4b9d5b5f18bc41b6cedcc0ffbadf33db2ab240e