### PR TITLE
Strip HTML comments in data attributes

### DIFF
--- a/src/test/unit/html_sanitizer_test.js
+++ b/src/test/unit/html_sanitizer_test.js
@@ -27,6 +27,20 @@ testGroup("HTMLSanitizer", () => {
       assert.equal(document, expectedHTML)
     })
   })
+
+  test("strips HTML comments", () => {
+    const html = "<div><!-- --></div>"
+    const expectedHTML = "<div></div>"
+    const document = HTMLSanitizer.sanitize(html).body.innerHTML
+    assert.equal(document, expectedHTML)
+  })
+
+  test("strips HTML comments in attributes", () => {
+    const html = "<div data-trix-attachment=\"<!-- -->\"></div>"
+    const expectedHTML = "<div data-trix-attachment=\"\"></div>"
+    const document = HTMLSanitizer.sanitize(html).body.innerHTML
+    assert.equal(document, expectedHTML)
+  })
 })
 
 const withDOMPurifyConfig = (attrConfig = {}, fn) => {

--- a/src/trix/models/html_sanitizer.js
+++ b/src/trix/models/html_sanitizer.js
@@ -69,9 +69,6 @@ export default class HTMLSanitizer extends BasicObject {
             this.sanitizeElement(node)
           }
           break
-        case Node.COMMENT_NODE:
-          nodesToRemove.push(node)
-          break
       }
     }
 
@@ -124,8 +121,8 @@ export default class HTMLSanitizer extends BasicObject {
 }
 
 const createBodyElementForHTML = function(html = "") {
-  // Remove everything after </html>
-  html = html.replace(/<\/html[^>]*>[^]*$/i, "</html>")
+  // Remove everything after </html> and HTML comments
+  html = html.replace(/<\/html[^>]*>[^]*$/i, "</html>").replace(/(<!--.*?-->)/g, "")
   const doc = document.implementation.createHTMLDocument("")
   doc.documentElement.innerHTML = html
 


### PR DESCRIPTION
With `config.action_view.annotate_rendered_view_with_filenames = true` enabled in Rails, the Trix partials render with HTML comments in them. With these HTML comments, DOMPurify causes these attachments to be removed client-side and go missing in the Trix editor.

For example, here's an ActionText field with a User attachment that displays an avatar and name with view filename annotations on.

```html
<input type="hidden" name="post[body]" id="post_body_trix_input_post_2" value="&lt;div&gt;&amp;nbsp;&lt;figure data-trix-attachment=&quot;{&amp;quot;sgid&amp;quot;:&amp;quot;eyJfcmFpbHMiOnsiZGF0YSI6ImdpZDovL2p1bXBzdGFydC1hcHAvVXNlci85ODk0MjcwMTM_ZXhwaXJlc19pbiIsInB1ciI6ImF0dGFjaGFibGUifX0=--c9ef9f1ccba88eaa5288536100f0e5c011bff6e3&amp;quot;,&amp;quot;contentType&amp;quot;:&amp;quot;application/octet-stream&amp;quot;,&amp;quot;content&amp;quot;:&amp;quot;&lt;!-- BEGIN app/views/users/_user.html.erb --&gt;  &lt;span&gt;\n    &lt;img height=\&amp;quot;14\&amp;quot; width=\&amp;quot;14\&amp;quot; class=\&amp;quot;inline-block rounded-full\&amp;quot; src=\&amp;quot;https://secure.gravatar.com/avatar/ce795239ba5dd2384fc2f88ffaff5451.png?default=mp&amp;amp;amp;rating=pg&amp;amp;amp;size=48\&amp;quot; /&gt;\n    Chris Oliver\n  &lt;/span&gt;\n&lt;!-- END app/views/users/_user.html.erb --&gt;&amp;quot;}&quot;&gt;&lt;/figure&gt;&amp;nbsp;&lt;/div&gt;" autocomplete="off" /><trix-editor data-controller="mentions" data-mentions-target="field" data-direct-upload-url="http://localhost:3000/rails/active_storage/direct_uploads" data-blob-url-template="http://localhost:3000/rails/active_storage/blobs/redirect/:signed_id/:filename" id="post_body" input="post_body_trix_input_post_2" class="trix-content"></trix-editor>
```

Note the comment in the data attribute:
```
&lt;!-- END app/views/users/_user.html.erb --&gt;
```

##### Steps to Reproduce

DOMPurify `data-trix-attachment` with HTML comments:

```html
<div>&nbsp;<figure data-trix-attachment="{&quot;sgid&quot;:&quot;eyJfcmFpbHMiOnsiZGF0YSI6ImdpZDovL2p1bXBzdGFydC1hcHAvVXNlci85ODk0MjcwMTM_ZXhwaXJlc19pbiIsInB1ciI6ImF0dGFjaGFibGUifX0=--c9ef9f1ccba88eaa5288536100f0e5c011bff6e3&quot;,&quot;contentType&quot;:&quot;application/octet-stream&quot;,&quot;content&quot;:&quot;<!-- BEGIN app/views/users/_user.html.erb -->  <span>\n    <img height=\&quot;14\&quot; width=\&quot;14\&quot; class=\&quot;inline-block rounded-full\&quot; src=\&quot;https://secure.gravatar.com/avatar/ce795239ba5dd2384fc2f88ffaff5451.png?default=mp&amp;amp;rating=pg&amp;amp;size=48\&quot; />\n    Chris Oliver\n  </span>\n<!-- END app/views/users/_user.html.erb -->&quot;}"></figure>&nbsp;</div>
```

Produces: 

```html
<div>&nbsp;<figure></figure>&nbsp;</div>
```

DOMPurify `data-trix-attachment` without HTML comment works:
```
<div>&nbsp;<figure data-trix-attachment="{&quot;sgid&quot;:&quot;eyJfcmFpbHMiOnsiZGF0YSI6ImdpZDovL2p1bXBzdGFydC1hcHAvVXNlci85ODk0MjcwMTM_ZXhwaXJlc19pbiIsInB1ciI6ImF0dGFjaGFibGUifX0=--c9ef9f1ccba88eaa5288536100f0e5c011bff6e3&quot;,&quot;contentType&quot;:&quot;application/octet-stream&quot;,&quot;content&quot;:&quot;  <span>\n    <img height=\&quot;14\&quot; width=\&quot;14\&quot; class=\&quot;inline-block rounded-full\&quot; src=\&quot;https://secure.gravatar.com/avatar/ce795239ba5dd2384fc2f88ffaff5451.png?default=mp&amp;amp;rating=pg&amp;amp;size=48\&quot; />\n    Chris Oliver\n  </span>\n&quot;}"></figure>&nbsp;</div>
```

Produces:

```html
<div>&nbsp;<figure data-trix-attachment="{&quot;sgid&quot;:&quot;eyJfcmFpbHMiOnsiZGF0YSI6ImdpZDovL2p1bXBzdGFydC1hcHAvVXNlci85ODk0MjcwMTM_ZXhwaXJlc19pbiIsInB1ciI6ImF0dGFjaGFibGUifX0=--c9ef9f1ccba88eaa5288536100f0e5c011bff6e3&quot;,&quot;contentType&quot;:&quot;application/octet-stream&quot;,&quot;content&quot;:&quot;  <span>\n    <img height=\&quot;14\&quot; width=\&quot;14\&quot; class=\&quot;inline-block rounded-full\&quot; src=\&quot;https://secure.gravatar.com/avatar/ce795239ba5dd2384fc2f88ffaff5451.png?default=mp&amp;amp;rating=pg&amp;amp;size=48\&quot; />\n    Chris Oliver\n  </span>\n&quot;}"></figure>&nbsp;</div>
```

##### Solution

This should ideally be handled by Trix, not the backend.

Comment nodes are already being removed, however not comments inside of the HTML elements.
https://github.com/basecamp/trix/blob/32b04312625fd7da75a1e1a73e854bc5b02562fe/src/trix/models/html_sanitizer.js#L72-L74

Instead, I changed the sanitizer to remove all HTML comments before creating the new document. That will remove regular comments but also comments in attributes.

Alternatively, we could do this in sanitizeElement instead if that makes more sense.

https://github.com/basecamp/trix/blob/32b04312625fd7da75a1e1a73e854bc5b02562fe/src/trix/models/html_sanitizer.js#L83-L88

Thoughts on this @djmb @jorgemanrubia?