### PR TITLE
Allow comments in attachments

### DIFF
--- a/src/trix/config/dompurify.js
+++ b/src/trix/config/dompurify.js
@@ -1,4 +1,5 @@
 export default {
   ADD_ATTR: [ "language" ],
+  SAFE_FOR_XML: false,
   RETURN_DOM: true
 }


### PR DESCRIPTION
If SAFE_FOR_XML is true all comments are removed from attachments.

See: https://github.com/basecamp/trix/pull/1213