### PR TITLE
Add 'action-text-attachment' to allowed tags

### DIFF
--- a/src/trix/config/dompurify.js
+++ b/src/trix/config/dompurify.js
@@ -1,5 +1,6 @@
 export default {
   ADD_ATTR: [ "language" ],
+  ALLOWED_TAGS: ["action-text-attachment"],
   SAFE_FOR_XML: false,
   RETURN_DOM: true
 }


### PR DESCRIPTION
Full explanation here:

https://github.com/rails/rails/pull/52093

TLDR: in cases where `#to_trix_html` is not available, ActionText returns `<action-text-attachment>` wrapping custom attachments. This will remove the attachments because they're not safelisted by DOMPurify.