### PR TITLE
Dispatch `trix-before-render` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,36 @@ For example if you want to keep a custom tag, you can access do that with:
 Trix.config.dompurify.ADD_TAGS = [ "my-custom-tag" ]
 ```
 
+## HTML Rendering
+
+Trix renders changes to editor content by replacing existing nodes with new nodes.
+
+To customize how Trix renders changes, set the `<trix-editor>` element's
+`render` property to a function that accepts a `<trix-editor>` instance and a
+[DocumentFragment][]:
+
+```js
+document.addEventListener("trix-before-render", (event) => {
+  const defaultRender = event.render
+
+  event.render = function(editorElement, documentFragment) {
+    // modify the documentFragment…
+    customize(documentFragment)
+
+    // render it with the default rendering function
+    defaultRender(editorElement, documentFragment)
+  }
+})
+```
+
+> [!CAUTION]
+> By the time that `render(editorElement, documentFragment)` is
+> invoked, Trix will have finalized modifications to the HTML content (like HTML
+> sanitization, for example). If you make further modifications to the content,
+> be sure that they are safe.
+
+[DocumentFragment]: https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment
+
 ## Observing Editor Changes
 
 The `<trix-editor>` element emits several events which you can use to observe and respond to changes in editor state.
@@ -567,6 +597,8 @@ The `<trix-editor>` element emits several events which you can use to observe an
 * `trix-initialize` fires when the `<trix-editor>` element is attached to the DOM and its `editor` object is ready for use.
 
 * `trix-change` fires whenever the editor’s contents have changed.
+
+* `trix-before-render` fires before the editor’s new contents are rendered. You can override the function used to render the content through the `render` property on the event. The `render` function expects two positional arguments: the `<trix-editor>` element that will render and a [DocumentFragment](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment) instance that contains the new content. Read [HTML Rendering](#html-rendering) to learn more.
 
 * `trix-paste` fires whenever text is pasted into the editor. The `paste` property on the event contains the pasted `string` or `html`, and the `range` of the inserted text.
 

--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -48,6 +48,7 @@ Copyright © 2025 37signals, LLC
   	concurrently: "^7.4.0",
   	eslint: "^7.32.0",
   	esm: "^3.2.25",
+  	idiomorph: "^0.7.3",
   	karma: "6.4.1",
   	"karma-chrome-launcher": "3.2.0",
   	"karma-qunit": "^4.1.2",
@@ -326,6 +327,21 @@ Copyright © 2025 37signals, LLC
     options.times = 1;
     return handleEvent(eventName, options);
   };
+  const createEvent = function (eventName) {
+    let {
+      bubbles,
+      cancelable,
+      attributes
+    } = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    bubbles = bubbles !== false;
+    cancelable = cancelable !== false;
+    const event = document.createEvent("Events");
+    event.initEvent(eventName, bubbles, cancelable);
+    if (attributes != null) {
+      extend.call(event, attributes);
+    }
+    return event;
+  };
   const triggerEvent = function (eventName) {
     let {
       onElement,
@@ -334,13 +350,11 @@ Copyright © 2025 37signals, LLC
       attributes
     } = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     const element = onElement != null ? onElement : html$2;
-    bubbles = bubbles !== false;
-    cancelable = cancelable !== false;
-    const event = document.createEvent("Events");
-    event.initEvent(eventName, bubbles, cancelable);
-    if (attributes != null) {
-      extend.call(event, attributes);
-    }
+    const event = createEvent(eventName, {
+      bubbles,
+      cancelable,
+      attributes
+    });
     return element.dispatchEvent(event);
   };
   const elementMatchesSelector = function (element, selector) {
@@ -3719,11 +3733,21 @@ $\
       return elementsHaveEqualHTML(this.shadowElement, this.element);
     }
     sync() {
+      const render = (element, documentFragment) => {
+        while (element.lastChild) {
+          element.removeChild(element.lastChild);
+        }
+        element.appendChild(documentFragment);
+      };
+      const event = createEvent("trix-before-render", {
+        cancelable: false,
+        attributes: {
+          render
+        }
+      });
+      this.element.dispatchEvent(event);
       const fragment = this.createDocumentFragmentForSync();
-      while (this.element.lastChild) {
-        this.element.removeChild(this.element.lastChild);
-      }
-      this.element.appendChild(fragment);
+      event.render(this.element, fragment);
       return this.didSync();
     }
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "concurrently": "^7.4.0",
     "eslint": "^7.32.0",
     "esm": "^3.2.25",
+    "idiomorph": "^0.7.3",
     "karma": "6.4.1",
     "karma-chrome-launcher": "3.2.0",
     "karma-qunit": "^4.1.2",

--- a/src/test/system/morphing_test.js
+++ b/src/test/system/morphing_test.js
@@ -1,6 +1,58 @@
 import { assert, test, testGroup } from "test/test_helper"
 import { nextFrame } from "../test_helpers/timing_helpers"
 
+import { Idiomorph } from "idiomorph"
+
+function renderWithMorph(event) {
+  event.render = (editorElement, documentFragment) => {
+    Idiomorph.morph(editorElement, documentFragment, { morphStyle: "innerHTML" })
+  }
+}
+
+testGroup("morphing editor content", {
+  template: "editor_empty",
+  beforeSetup: () => addEventListener("trix-before-render", renderWithMorph),
+  afterTeardown: () => removeEventListener("trix-before-render", renderWithMorph)
+}, () => {
+  test("renders changed elements with morphing", () => {
+    const element = getEditorElement()
+
+    element.editor.loadHTML("<div>hello</div>")
+
+    const before = element.firstElementChild
+    assert.equal(before.textContent, "hello")
+
+    element.editor.loadHTML("<div>goodbye</div>")
+
+    const after = element.firstElementChild
+    assert.equal(after.textContent, "goodbye")
+    assert.strictEqual(after, before, "preserves element across renders")
+  })
+
+  test("renders with morphing when ancestor elements are morphed", () => {
+    const element = getEditorElement()
+
+    Idiomorph.morph(
+      element.parentElement,
+      "<trix-editor><div>hello</div></trix-editor>",
+      { morphStyle: "innerHTML" }
+    )
+
+    const before = element.firstElementChild
+    assert.equal(before.textContent, "hello")
+
+    Idiomorph.morph(
+      element.parentElement,
+      "<trix-editor><div>goodbye</div></trix-editor>",
+      { morphStyle: "innerHTML" }
+    )
+
+    const after = element.firstElementChild
+    assert.equal(after.textContent, "goodbye")
+    assert.strictEqual(after, before, "preserves element across renders")
+  })
+})
+
 testGroup("morphing with internal toolbar", { template: "editor_empty" }, () => {
   test("removing the 'connected' attribute will reset the editor and recreate toolbar", async () => {
     const element = getEditorElement()

--- a/src/test/test_helpers/test_helpers.js
+++ b/src/test/test_helpers/test_helpers.js
@@ -13,11 +13,15 @@ const setFixtureHTML = function (html, container = "form") {
 }
 
 export const testGroup = function (name, options, callback) {
-  let container, setup, teardown, template
+  let container, beforeSetup, setup, teardown, afterTeardown, template
   if (callback != null) {
-    ({ container, template, setup, teardown } = options)
+    ({ container, template, beforeSetup, setup, teardown, afterTeardown } = options)
   } else {
     callback = options
+  }
+
+  const before = () => {
+    if (beforeSetup) beforeSetup()
   }
 
   const beforeEach = async () => {
@@ -37,14 +41,20 @@ export const testGroup = function (name, options, callback) {
     return teardown?.()
   }
 
+  const after = () => {
+    if (afterTeardown) afterTeardown()
+  }
+
   if (callback != null) {
     return QUnit.module(name, function (hooks) {
+      hooks.before(before)
       hooks.beforeEach(beforeEach)
       hooks.afterEach(afterEach)
+      hooks.after(after)
       callback()
     })
   } else {
-    return QUnit.module(name, { beforeEach, afterEach })
+    return QUnit.module(name, { before, beforeEach, afterEach, after })
   }
 }
 

--- a/src/trix/core/helpers/dom.js
+++ b/src/trix/core/helpers/dom.js
@@ -35,8 +35,7 @@ export const handleEventOnce = function(eventName, options = {}) {
   return handleEvent(eventName, options)
 }
 
-export const triggerEvent = function(eventName, { onElement, bubbles, cancelable, attributes } = {}) {
-  const element = onElement != null ? onElement : html
+export const createEvent = function(eventName, { bubbles, cancelable, attributes } = {}) {
   bubbles = bubbles !== false
   cancelable = cancelable !== false
 
@@ -45,6 +44,12 @@ export const triggerEvent = function(eventName, { onElement, bubbles, cancelable
   if (attributes != null) {
     extend.call(event, attributes)
   }
+  return event
+}
+
+export const triggerEvent = function(eventName, { onElement, bubbles, cancelable, attributes } = {}) {
+  const element = onElement != null ? onElement : html
+  const event = createEvent(eventName, { bubbles, cancelable, attributes })
   return element.dispatchEvent(event)
 }
 

--- a/src/trix/elements/trix_editor_element.js
+++ b/src/trix/elements/trix_editor_element.js
@@ -489,7 +489,7 @@ export default class TrixEditorElement extends HTMLElement {
         triggerEvent("trix-before-initialize", { onElement: this })
         this.editorController = new EditorController({
           editorElement: this,
-          html: this.defaultValue = this.value,
+          html: this.defaultValue = this.value
         })
         requestAnimationFrame(() => triggerEvent("trix-initialize", { onElement: this }))
       }

--- a/src/trix/views/document_view.js
+++ b/src/trix/views/document_view.js
@@ -1,4 +1,4 @@
-import { makeElement } from "trix/core/helpers"
+import { createEvent, makeElement } from "trix/core/helpers"
 
 import ElementStore from "trix/core/collections/element_store"
 import ObjectGroup from "trix/core/collections/object_group"
@@ -49,11 +49,18 @@ export default class DocumentView extends ObjectView {
   }
 
   sync() {
-    const fragment = this.createDocumentFragmentForSync()
-    while (this.element.lastChild) {
-      this.element.removeChild(this.element.lastChild)
+    const render = (element, documentFragment) => {
+      while (element.lastChild) {
+        element.removeChild(element.lastChild)
+      }
+      element.appendChild(documentFragment)
     }
-    this.element.appendChild(fragment)
+
+    const event = createEvent("trix-before-render", { cancelable: false, attributes: { render } })
+    this.element.dispatchEvent(event)
+
+    const fragment = this.createDocumentFragmentForSync()
+    event.render(this.element, fragment)
     return this.didSync()
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3645,6 +3645,11 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+idiomorph@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/idiomorph/-/idiomorph-0.7.3.tgz#50f9a30ce5bdb4a2937153b3cbca24b8a0361b95"
+  integrity sha512-YI/L1QQkBRDtiaGZN+/KolIkNoZuIsCgus1ciueosiqdyWz/weeP+ghFgDQpk2vzA3BkX6/M/kY5SCM03LBDkA==
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"


### PR DESCRIPTION
Prior to this change, Trix's rendering process was managed internally,
and was not open for extension or customization. While it's critical
that Trix manages its own content (through parsing HTML, scrubbing
attributes and sanitizing content, reifying attachments, etc.), the
"rendering" of that content amounts to the replacement of a collection
of DOM nodes.

Advanced use cases (like integration with "morph" style rendering) can
benefit from customizing the process of rendering Trix's content.

This commit introduces a `trix-before-render` event to with a `render`
property to configure an individual `<trix-editor>` element's rendering
process. By default, the event's `render` property maintains the
existing "replace" behavior. When overridden, the function expects two
arguments: a `<trix-editor>` element along with with a
[DocumentFragment][] instance.

```js
document.addEventListener("trix-before-render", (event) => {
  const defaultRender = event.render

  event.render = function(editorElement, documentFragment) {
    // modify the documentFragment…
    customize(documentFragment)

    // render it with the default rendering function
    defaultRender(editorElement, documentFragment)
  }
})
```

[DocumentFragment]: https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment

