### PR TITLE
Pass CI

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -13323,7 +13323,7 @@ $\
     if (element.hasAttribute("contenteditable")) {
       return;
     }
-    element.setAttribute("contenteditable", "");
+    element.toggleAttribute("contenteditable", !element.disabled);
     return handleEventOnce("focus", {
       onElement: element,
       withCallback() {
@@ -13696,15 +13696,6 @@ $\
       if (this.hasAttribute("input")) {
         var _this$ownerDocument2;
         return (_this$ownerDocument2 = this.ownerDocument) === null || _this$ownerDocument2 === void 0 ? void 0 : _this$ownerDocument2.getElementById(this.getAttribute("input"));
-      } else if (this.parentNode && this.willCreateInput) {
-        const inputId = "trix-input-".concat(this.trixId);
-        this.setAttribute("input", inputId);
-        const element = makeElement("input", {
-          type: "hidden",
-          id: inputId
-        });
-        this.parentNode.insertBefore(element, this.nextElementSibling);
-        return element;
       } else {
         return undefined;
       }
@@ -13787,6 +13778,15 @@ $\
           triggerEvent("trix-before-initialize", {
             onElement: this
           });
+          if (!this.hasAttribute("input") && this.parentNode && this.willCreateInput) {
+            const inputId = "trix-input-".concat(this.trixId);
+            this.setAttribute("input", inputId);
+            const element = makeElement("input", {
+              type: "hidden",
+              id: inputId
+            });
+            this.parentNode.insertBefore(element, this.nextElementSibling);
+          }
           this.editorController = new EditorController({
             editorElement: this,
             html: this.defaultValue = this.value

--- a/src/trix/elements/trix_editor_element.js
+++ b/src/trix/elements/trix_editor_element.js
@@ -29,7 +29,7 @@ const makeEditable = function(element) {
   if (element.hasAttribute("contenteditable")) {
     return
   }
-  element.setAttribute("contenteditable", "")
+  element.toggleAttribute("contenteditable", !element.disabled)
   return handleEventOnce("focus", {
     onElement: element,
     withCallback() {
@@ -485,12 +485,6 @@ export default class TrixEditorElement extends HTMLElement {
   get inputElement() {
     if (this.hasAttribute("input")) {
       return this.ownerDocument?.getElementById(this.getAttribute("input"))
-    } else if (this.parentNode && this.willCreateInput) {
-      const inputId = `trix-input-${this.trixId}`
-      this.setAttribute("input", inputId)
-      const element = makeElement("input", { type: "hidden", id: inputId })
-      this.parentNode.insertBefore(element, this.nextElementSibling)
-      return element
     } else {
       return undefined
     }
@@ -569,6 +563,12 @@ export default class TrixEditorElement extends HTMLElement {
 
       if (!this.editorController) {
         triggerEvent("trix-before-initialize", { onElement: this })
+        if (!this.hasAttribute("input") && this.parentNode && this.willCreateInput) {
+          const inputId = `trix-input-${this.trixId}`
+          this.setAttribute("input", inputId)
+          const element = makeElement("input", { type: "hidden", id: inputId })
+          this.parentNode.insertBefore(element, this.nextElementSibling)
+        }
         this.editorController = new EditorController({
           editorElement: this,
           html: this.defaultValue = this.value


### PR DESCRIPTION
CI is currently [failing on `main`][ci]. The failure was introduced in [#1128][], despite the fact that [CI passed for that PR][pr].

To resolve the error (related to `[disabled]` and focus), this commit changes the `makeEditable(editorElement)` function so that it incorporates a check to the `TrixEditorElement.disabled` property into a call to [toggleAttribute][].

Similarly, it moves the creation of the associated `TrixEditorElement.inputElement` (that is missing at the time of the check) into the `connectedCallback()` so that the `.disabled` property access does not result in the pre-mature creation of the associated `<input>` element prior to the rest of the `connectedCallback()` logic.

[ci]: https://github.com/basecamp/trix/actions/runs/17895948161/job/50883035420
[#1128]: https://github.com/basecamp/trix/pull/1128
[pr]: https://github.com/basecamp/trix/pull/1128/checks
[toggleAttribute]: https://developer.mozilla.org/en-US/docs/Web/API/Element/toggleAttribute