### PR TITLE
Build `action_text-trix` assets with existing tools

### DIFF
--- a/action_text-trix/Rakefile
+++ b/action_text-trix/Rakefile
@@ -5,8 +5,6 @@ task :sync do
   require "json"
 
   FileUtils.cp File.expand_path("../LICENSE", __dir__), __dir__, verbose: true
-  FileUtils.cp File.expand_path("../dist/trix.umd.js", __dir__), File.expand_path("app/assets/javascripts/trix.js", __dir__), verbose: true
-  FileUtils.cp File.expand_path("../dist/trix.css", __dir__), File.expand_path("app/assets/stylesheets/trix.css", __dir__), verbose: true
 
   package_json = JSON.load(File.read(File.join(__dir__, "../package.json")))
   version = package_json["version"]

--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -66,7 +66,7 @@ Copyright © 2025 37signals, LLC
   	webdriverio: "^7.19.5"
   };
   var scripts = {
-  	"build-css": "bin/sass-build assets/trix.scss dist/trix.css",
+  	"build-css": "bin/sass-build assets/trix.scss dist/trix.css action_text-trix/app/assets/stylesheets/trix.css",
   	"build-js": "rollup -c",
   	"build-assets": "cp -f assets/*.html dist/",
   	"build-ruby": "rake -C action_text-trix sync",

--- a/bin/sass-build
+++ b/bin/sass-build
@@ -12,7 +12,7 @@ if (args.length < 2) {
   process.exit(1)
 }
 const inputFile = path.resolve(args[0])
-const outputFile = path.resolve(args[1])
+const outputFiles = args.slice(1).map(outputPath => path.resolve(outputPath))
 const watchMode = args.includes("--watch")
 
 const basePath = path.dirname(inputFile)
@@ -33,7 +33,7 @@ function compile() {
   try {
     const result = sass.compile(inputFile, { functions })
 
-    fs.writeFileSync(outputFile, result.css, "utf8")
+    outputFiles.forEach(outputFile => fs.writeFileSync(outputFile, result.css, "utf8"))
   } catch (error) {
     console.error("Error compiling SCSS:", error.message)
   }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "webdriverio": "^7.19.5"
   },
   "scripts": {
-    "build-css": "bin/sass-build assets/trix.scss dist/trix.css",
+    "build-css": "bin/sass-build assets/trix.scss dist/trix.css action_text-trix/app/assets/stylesheets/trix.css",
     "build-js": "rollup -c",
     "build-assets": "cp -f assets/*.html dist/",
     "build-ruby": "rake -C action_text-trix sync",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,7 +63,13 @@ export default [
         file: "dist/trix.esm.js",
         format: "es",
         banner
-      }
+      },
+      {
+        name: "Trix",
+        file: "action_text-trix/app/assets/javascripts/trix.js",
+        format: "umd",
+        banner
+      },
     ],
     ...defaultConfig,
   },


### PR DESCRIPTION
Removes the JavaScript and CSS file `FileUtils.cp` calls from `action_text-trix/Rakefile` so that the files can be generated by the existing tooling (`rollup.config.js` for JavaScript, `bin/sass-build` for CSS).

With this change, the project is free to continue to utilize those tools to manage the files that will be included in the Gem, without needing to span the Ruby-NodeJS boundary.