### PR TITLE
Fix stale `app/assets/javascripts/trix.js` file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - run: bin/ci
+      - name: Fail when generated npm changes are not checked-in
+        run: |
+          git update-index --refresh && git diff-index --quiet HEAD --
+
   rails-tests:
     name: Downstream Rails integration tests
     runs-on: ubuntu-latest

--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -3451,11 +3451,15 @@ $\
       }
       const width = this.attachment.getWidth();
       const height = this.attachment.getHeight();
+      const alt = this.attachment.getAttribute("alt");
       if (width != null) {
         image.width = width;
       }
       if (height != null) {
         image.height = height;
+      }
+      if (alt != null) {
+        image.alt = alt;
       }
       const storeKey = ["imageElement", this.attachment.id, image.src, image.width, image.height].join("/");
       image.dataset.trixStoreKey = storeKey;
@@ -6616,6 +6620,11 @@ $\
       this.attributes = Hash.box(attributes);
       this.didChangeAttributes();
     }
+    setAttribute(attribute, value) {
+      this.setAttributes({
+        [attribute]: value
+      });
+    }
     getAttribute(attribute) {
       return this.attributes.get(attribute);
     }
@@ -8855,6 +8864,8 @@ $\
   ManagedAttachment.proxyMethod("attachment.isPending");
   ManagedAttachment.proxyMethod("attachment.isPreviewable");
   ManagedAttachment.proxyMethod("attachment.getURL");
+  ManagedAttachment.proxyMethod("attachment.getPreviewURL");
+  ManagedAttachment.proxyMethod("attachment.setPreviewURL");
   ManagedAttachment.proxyMethod("attachment.getHref");
   ManagedAttachment.proxyMethod("attachment.getFilename");
   ManagedAttachment.proxyMethod("attachment.getFilesize");
@@ -12465,12 +12476,12 @@ $\
       this.attributes = {};
       this.actions = {};
       this.resetDialogInputs();
-      handleEvent("mousedown", {
+      handleEvent("click", {
         onElement: this.element,
         matchingSelector: actionButtonSelector,
         withCallback: this.didClickActionButton
       });
-      handleEvent("mousedown", {
+      handleEvent("click", {
         onElement: this.element,
         matchingSelector: attributeButtonSelector,
         withCallback: this.didClickAttributeButton
@@ -13247,6 +13258,22 @@ $\
       if (this.innerHTML === "") {
         this.innerHTML = toolbar.getDefaultHTML();
       }
+    }
+
+    // Properties
+
+    get editorElements() {
+      if (this.id) {
+        var _this$ownerDocument;
+        const nodeList = (_this$ownerDocument = this.ownerDocument) === null || _this$ownerDocument === void 0 ? void 0 : _this$ownerDocument.querySelectorAll("trix-editor[toolbar=\"".concat(this.id, "\"]"));
+        return Array.from(nodeList);
+      } else {
+        return [];
+      }
+    }
+    get editorElement() {
+      const [editorElement] = this.editorElements;
+      return editorElement;
     }
   }
 


### PR DESCRIPTION
The changes proposed to
`action_text-trix/app/assets/javascripts/trix.js` were generated by executing the following:

```sh
yarn build
```

To reduce the risk of future commits' outputs being excluded from the commits that introduce them, this commit introduces some `git` commands to the `.github/workflows/ci.yml` file to fail CI builds when `yarn build` creates changes that are not already checked into the git commit. The commands are lifted directly from the [hotwired/turbo-rails][] version of this file.

[hotwired/turbo-rails]: https://github.com/hotwired/turbo-rails/blob/v2.0.20/.github/workflows/ci.yml#L48-L51