### PR TITLE
Add `8-1-stable` branch to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,13 @@ jobs:
             rails_branch: 8-0-stable
 
           - ruby: "3.2"
+            rails_branch: 8-1-stable
+          - ruby: "3.3"
+            rails_branch: 8-1-stable
+          - ruby: "3.4"
+            rails_branch: 8-1-stable
+
+          - ruby: "3.2"
             rails_branch: main
             experimental: true
           - ruby: "3.3"


### PR DESCRIPTION
[Rails 8.1. has been released][rails@8.1], so update the
`.github/workflows/ci.yml` to include entries for the new release.

[rails@8.1]: https://rubyonrails.org/2025/10/22/rails-8-1