### PR TITLE
Revert "Toolbar Button: Handle `click` instead of `mousedown`"

### DIFF
--- a/src/test/test_helpers/toolbar_helpers.js
+++ b/src/test/test_helpers/toolbar_helpers.js
@@ -5,7 +5,7 @@ import { delay, nextFrame } from "./timing_helpers"
 export const clickToolbarButton = async (selector) => {
   selectionChangeObserver.update()
   const button = getToolbarButton(selector)
-  triggerEvent(button, "click")
+  triggerEvent(button, "mousedown")
   await delay(5)
 }
 

--- a/src/trix/controllers/toolbar_controller.js
+++ b/src/trix/controllers/toolbar_controller.js
@@ -33,12 +33,12 @@ export default class ToolbarController extends BasicObject {
     this.actions = {}
     this.resetDialogInputs()
 
-    handleEvent("click", {
+    handleEvent("mousedown", {
       onElement: this.element,
       matchingSelector: actionButtonSelector,
       withCallback: this.didClickActionButton,
     })
-    handleEvent("click", {
+    handleEvent("mousedown", {
       onElement: this.element,
       matchingSelector: attributeButtonSelector,
       withCallback: this.didClickAttributeButton,


### PR DESCRIPTION
This reverts commit 1f5ee5e8daf99e52ec732682a49b8b4027db05c3.

See notes at #1201 for more context.

cc @seanpdoyle 