### PR TITLE
action_text-trix: pin minitest to < 6

### DIFF
--- a/action_text-trix/Gemfile
+++ b/action_text-trix/Gemfile
@@ -12,4 +12,5 @@ gem "sqlite3"
 
 group :test do
   gem "cuprite", require: "capybara/cuprite"
+  gem "minitest", "< 6.0" # can be removed once Rails' line_filtering supports Minitest 6+
 end


### PR DESCRIPTION
In minitest 6.0.0, the Runnable.run method signature changed from:

    def run(reporter, options, *args)  # old (minitest 5.x)
to:

    def run(reporter, options = {})    # new (minitest 6.x)

Rails' line_filtering.rb still uses `super(reporter, options, *args)` which passes 3 arguments.