### PR TITLE
ci: stabilize Sauce Labs with SC5 tunnel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ on:
     types: [opened, synchronize]
     branches: [ '*' ]
 
+env:
+  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  SAUCE_REGION: us
+  SAUCE_TUNNEL_IDENTIFIER: trix-${{ github.run_id }}
+
 jobs:
   build:
     name: Browser tests
@@ -23,6 +29,15 @@ jobs:
           cache: "yarn"
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
+      - name: Start Sauce Connect
+        if: ${{ env.SAUCE_ACCESS_KEY != '' }}
+        uses: saucelabs/sauce-connect-action@v3
+        with:
+          username: ${{ env.SAUCE_USERNAME }}
+          accessKey: ${{ env.SAUCE_ACCESS_KEY }}
+          tunnelName: ${{ env.SAUCE_TUNNEL_IDENTIFIER }}
+          region: ${{ env.SAUCE_REGION }}
+          proxyLocalhost: allow
       - run: bin/ci
       - name: Fail when generated npm changes are not checked-in
         run: |
@@ -117,7 +132,3 @@ jobs:
         continue-on-error: ${{ matrix.experimental || false }}
         working-directory: "./action_text-trix"
         run: bin/rails test:all
-
-env:
-  SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-  SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,8 @@ const config = {
     }
   },
 
-  hostname: "0.0.0.0",
+  hostname: process.env.SAUCE_ACCESS_KEY ? "localhost" : "0.0.0.0",
+  listenAddress: "0.0.0.0",
 
   singleRun: true,
   autoWatch: false,
@@ -30,17 +31,27 @@ const config = {
 /* eslint camelcase: "off",  */
 
 if (process.env.SAUCE_ACCESS_KEY) {
+  const sauceRegion = process.env.SAUCE_REGION || "us"
+  const sauceConnectVersion = process.env.SAUCE_CONNECT_VERSION || "4.9.2"
+  const sauceTunnelIdentifier = process.env.SAUCE_TUNNEL_IDENTIFIER
+
   config.customLaunchers = {
     sl_chrome_latest: {
       base: "SauceLabs",
       browserName: "chrome",
-      version: "latest"
+      browserVersion: "latest",
+      "sauce:options": {
+        tunnelName: sauceTunnelIdentifier
+      }
     },
     sl_chrome_latest_i8n: {
       base: "SauceLabs",
       browserName: "chrome",
-      version: "latest",
-      chromeOptions: {
+      browserVersion: "latest",
+      "sauce:options": {
+        tunnelName: sauceTunnelIdentifier
+      },
+      "goog:chromeOptions": {
         args: [ "--lang=tr" ]
       }
     },
@@ -51,28 +62,45 @@ if (process.env.SAUCE_ACCESS_KEY) {
       base: "SauceLabs",
       browserName: "firefox",
       browserVersion: "latest",
+      "sauce:options": {
+        tunnelName: sauceTunnelIdentifier
+      },
       "moz:debuggerAddress": true
     },
     sl_edge_latest: {
       base: "SauceLabs",
       browserName: "microsoftedge",
-      platform: "Windows 10",
-      version: "latest"
+      platformName: "Windows 10",
+      browserVersion: "latest",
+      "sauce:options": {
+        tunnelName: sauceTunnelIdentifier
+      }
     },
-    sl_android_9: {
-      base: "SauceLabs",
-      browserName: "chrome",
-      platform: "android",
-      device: "Android GoogleAPI Emulator",
-      version: "9.0"
-    },
-    sl_android_latest: {
-      base: "SauceLabs",
-      browserName: "chrome",
-      platform: "android",
-      device: "Android GoogleAPI Emulator",
-      version: "12.0"
-    }
+    // // Android is commented out because with the upgrade to SC5 I couldn't figure out how to get
+    // // the Android VM to connect through the tunnel ("localhost" in the VM resolves to the VM
+    // // itself, not the host machine). Maybe someone cleverer than me can figure this out.
+    // sl_android_9: {
+    //   base: "SauceLabs",
+    //   browserName: "chrome",
+    //   platformName: "Android",
+    //   browserVersion: "latest",
+    //   "appium:deviceName": "Android GoogleAPI Emulator",
+    //   "appium:platformVersion": "9.0",
+    //   "sauce:options": {
+    //     tunnelName: sauceTunnelIdentifier
+    //   }
+    // },
+    // sl_android_latest: {
+    //   base: "SauceLabs",
+    //   browserName: "chrome",
+    //   platformName: "Android",
+    //   browserVersion: "latest",
+    //   "appium:deviceName": "Android GoogleAPI Emulator",
+    //   "appium:platformVersion": "12.0",
+    //   "sauce:options": {
+    //     tunnelName: sauceTunnelIdentifier
+    //   }
+    // }
   }
 
   config.browsers = Object.keys(config.customLaunchers)
@@ -85,6 +113,12 @@ if (process.env.SAUCE_ACCESS_KEY) {
     commandTimeout: 600,
     maxDuration: 900,
     build: buildId(),
+    region: sauceRegion,
+    startConnect: !sauceTunnelIdentifier,
+    connectOptions: {
+      scVersion: sauceConnectVersion,
+      tunnelIdentifier: sauceTunnelIdentifier
+    }
   }
 }
 


### PR DESCRIPTION
Sauce labs connections started failing sometime after Dec 11, and I'm assuming it's because they discontinued support for earlier Sauce Connect versions.

This was all made much harder because karma is EOL and code is rotting out from under us.

Note that this commit also removes (comments out) integration test coverage for Android, because I couldn't figure out how to get the Android VM to connect through the tunnel.