### PR TITLE
Report web-test-runner test failures

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -58,6 +58,7 @@ Copyright © 2026 37signals, LLC
   	"rollup-plugin-includepaths": "^0.2.4",
   	"rollup-plugin-terser": "^7.0.2",
   	sass: "^1.83.0",
+  	"source-map": "^0.7.6",
   	svgo: "^2.8.0",
   	webdriverio: "^7.19.5"
   };

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "rollup-plugin-includepaths": "^0.2.4",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.83.0",
+    "source-map": "^0.7.6",
     "svgo": "^2.8.0",
     "webdriverio": "^7.19.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5170,7 +5170,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.3, source-map@^0.7.6:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
   integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==


### PR DESCRIPTION
The test runner reporter now emits failure details, taking care to sourcemap the stack trace.

Example:

```
FAIL: HTMLSanitizer > failure test
  Message: Assertion Error
  Expected: 2
  Actual: 1
  Stack:
        at Object.<anonymous> (src/test/unit/html_sanitizer_test.js:32:11)
        at runTest (http://0.0.0.0:8000/qunit/qunit/qunit.js:2983:35)
        at Test.run (http://0.0.0.0:8000/qunit/qunit/qunit.js:2966:9)
        at http://0.0.0.0:8000/qunit/qunit/qunit.js:3259:16
        at processTaskQueue (http://0.0.0.0:8000/qunit/qunit/qunit.js:2525:26)
        at advanceTaskQueue (http://0.0.0.0:8000/qunit/qunit/qunit.js:2508:5)
```