### PR TITLE
Fix bullets merging with prior elements on Firefox when the first node is removed

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -10044,6 +10044,15 @@ $\
         } else {
           if (node.parentNode === container) {
             if (childIndex++ === offset) {
+              if (!strict && nodeIsBlockStart(node, {
+                strict
+              })) {
+                if (foundBlock) {
+                  location.index++;
+                }
+                location.offset = 0;
+                foundBlock = true;
+              }
               break;
             }
           } else if (!elementContainsNode(container, node)) {

--- a/src/test/system/level_2_input_test.js
+++ b/src/test/system/level_2_input_test.js
@@ -272,6 +272,41 @@ testGroup("Level 2 Input", testOptions, () => {
     }
     expectDocument("a\n\nb\n\nc\n")
   })
+
+  // Firefox provides element-level target ranges (startContainer: <li>)
+  // rather than text-node-level ranges for deleteContentBackward. When the
+  // container is an element and offset is 0, the location mapper must count
+  // the block-start comment before breaking, or the block index will be wrong
+  // and the bullet list structure gets corrupted.
+  // - https://github.com/basecamp/trix/issues/1259
+  test("deleteContentBackward with element-level target range in a bullet list (Firefox)", async () => {
+    await clickToolbarButton({ attribute: "bullet" })
+    insertString("foo bar")
+    getComposition().setSelectedRange([ 0, 3 ])
+    await nextFrame()
+
+    // Simulate Firefox's target range: startContainer is the <li> element
+    // (not the text node), startOffset 0, endContainer is the text node, endOffset 3
+    const element = getEditorElement()
+    const li = element.querySelector("li")
+    const textNode = li.lastChild
+
+    const targetRange = document.createRange()
+    targetRange.setStart(li, 0)
+    targetRange.setEnd(textNode, 3)
+
+    const event = createEvent("beforeinput", {
+      inputType: "deleteContentBackward",
+      getTargetRanges: () => [ targetRange ],
+    })
+    document.activeElement.dispatchEvent(event)
+
+    await nextFrame()
+    await nextFrame()
+
+    assert.blockAttributes([ 0, 5 ], [ "bulletList", "bullet" ])
+    expectDocument(" bar\n")
+  })
 })
 
 const createFile = () => {

--- a/src/trix/models/location_mapper.js
+++ b/src/trix/models/location_mapper.js
@@ -45,6 +45,13 @@ export default class LocationMapper {
       } else {
         if (node.parentNode === container) {
           if (childIndex++ === offset) {
+            if (!strict && nodeIsBlockStart(node, { strict })) {
+              if (foundBlock) {
+                location.index++
+              }
+              location.offset = 0
+              foundBlock = true
+            }
             break
           }
         } else if (!elementContainsNode(container, node)) {


### PR DESCRIPTION
This fixes a bug whereby selecting nodes at the start of a list and removing them causes the bullet to disappear and the remaining content to merge with the prior node.

Bug in action:

https://github.com/user-attachments/assets/f0b472e8-797f-4e02-9409-45fca8f28f11

Fix in action:

https://github.com/user-attachments/assets/f6866f8f-bc7d-4c35-9f3f-bd8dd739247d

This should also fix: https://github.com/basecamp/trix/issues/1259