### PR TITLE
Fix stored XSS via data-trix-serialized-attributes bypass

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -3118,6 +3118,10 @@ $\
   var purify = createDOMPurify();
 
   purify.addHook("uponSanitizeAttribute", function (node, data) {
+    if (data.attrName === "data-trix-serialized-attributes") {
+      data.keepAttr = false;
+      return;
+    }
     const allowedAttributePattern = /^data-trix-/;
     if (allowedAttributePattern.test(data.attrName)) {
       data.forceKeepAttr = true;

--- a/src/test/system/pasting_test.js
+++ b/src/test/system/pasting_test.js
@@ -164,6 +164,23 @@ testGroup("Pasting", { template: "editor_empty" }, () => {
     delete window.unsanitized
   })
 
+  test("paste data-trix-attachment with serialized-attributes XSS", async () => {
+    const pasteData = {
+      "text/plain": "x",
+      "text/html": `\
+      copy<div data-trix-attachment="{&quot;contentType&quot;:&quot;text/html&quot;,&quot;content&quot;:&quot;&lt;img src=\\&quot;x\\&quot; data-trix-serialized-attributes=\\&quot;{&amp;quot;onerror&amp;quot;:&amp;quot;alert(1)&amp;quot;}\\&quot;&gt;&quot;}"></div>me
+      `,
+    }
+
+    await pasteContent(pasteData)
+    await delay(20)
+    const div = document.createElement("div")
+    div.innerHTML = getEditorElement().value
+    const img = div.querySelector("img")
+    assert.ok(img, "serialized HTML should contain an img element")
+    assert.notOk(img.hasAttribute("onerror"), "img should not have an onerror attribute")
+  })
+
   test("prefers plain text when html lacks formatting", async () => {
     const pasteData = {
       "text/html": "<meta charset='utf-8'>a\nb",

--- a/src/test/unit/html_sanitizer_test.js
+++ b/src/test/unit/html_sanitizer_test.js
@@ -15,6 +15,18 @@ testGroup("HTMLSanitizer", () => {
     assert.equal(document, expectedHTML)
   })
 
+  test("strips data-trix-serialized-attributes", () => {
+    const html = "<div data-trix-serialized-attributes=\"{}\">content</div>"
+    const sanitized = HTMLSanitizer.sanitize(html).body.innerHTML
+    assert.notOk(sanitized.includes("data-trix-serialized-attributes"))
+  })
+
+  test("preserves other data-trix-* attributes", () => {
+    const html = "<div data-trix-attachment=\"{}\">content</div>"
+    const sanitized = HTMLSanitizer.sanitize(html).body.innerHTML
+    assert.ok(sanitized.includes("data-trix-attachment"))
+  })
+
   test("keeps custom tags configured for DOMPurify", () => {
     const config = {
       ADD_TAGS: [ "custom-tag" ],
@@ -27,6 +39,7 @@ testGroup("HTMLSanitizer", () => {
       assert.equal(document, expectedHTML)
     })
   })
+
 })
 
 const withDOMPurifyConfig = (attrConfig = {}, fn) => {

--- a/src/trix/models/html_sanitizer.js
+++ b/src/trix/models/html_sanitizer.js
@@ -5,6 +5,11 @@ import DOMPurify from "dompurify"
 import * as config from "trix/config"
 
 DOMPurify.addHook("uponSanitizeAttribute", function (node, data) {
+  if (data.attrName === "data-trix-serialized-attributes") {
+    data.keepAttr = false
+    return
+  }
+
   const allowedAttributePattern = /^data-trix-/
   if (allowedAttributePattern.test(data.attrName)) {
     data.forceKeepAttr = true


### PR DESCRIPTION
## Summary

- Strips `data-trix-serialized-attributes` in the DOMPurify `uponSanitizeAttribute` hook before the `data-trix-*` force-keep logic runs, closing a stored XSS vector (H1 #3581911)
- This is the only `data-trix-*` attribute whose value is later expanded into arbitrary DOM attributes via `setAttribute()` in the serialization code — no other `data-trix-*` attribute has this property
- The legitimate producer (`PreviewableAttachmentView`) sets this attribute at runtime on live DOM elements and never goes through DOMPurify, so it is unaffected

## Test plan

- [x] Unit test: DOMPurify strips `data-trix-serialized-attributes` from sanitized HTML
- [x] Unit test: DOMPurify preserves other `data-trix-*` attributes (e.g. `data-trix-attachment`)
- [x] System test: end-to-end paste of three-level attack payload (pasted HTML → `data-trix-attachment` JSON → `content` with `data-trix-serialized-attributes`) asserts serialized output has no `onerror` attribute
- [x] All tests verified to fail without the fix and pass with it
- [x] Full test suite passes (497 tests, 0 failures)