### PR TITLE
docs: explain how to set attachment image alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,18 @@ addEventListener("trix-attachment-add", (event) => {
 })
 ```
 
+You can also set image-specific attributes in the same handler. For example, set an attachment's `alt` text with `setAttributes`:
+
+```js
+addEventListener("trix-attachment-add", (event) => {
+  if (event.attachment.file instanceof File) {
+    event.attachment.setAttributes({ alt: "A friendly description of the image" })
+  }
+})
+```
+
+`figcaption` content is edited through the attachment `caption`, but it does not automatically become the image's `alt` text. If you need both, set them explicitly.
+
 # Editing Text Programmatically
 
 You can manipulate a Trix editor programmatically through the `Trix.Editor` interface, available on each `<trix-editor>` element through its `editor` property.


### PR DESCRIPTION
## Summary
- document how to set attachment image lt text in the 	rix-attachment-add handler
- clarify that attachment captions do not automatically become the image lt attribute
- point readers to setAttributes for cases where they want both

Closes #1230.

## Validation
- git diff --check -- README.md
- attempted targeted accessibility coverage with 
ode .\\node_modules\\@web\\test-runner\\dist\\bin.js src/test/system/accessibility_test.js --playwright --browsers chromium after 
pm install, but the local environment hit dependency resolution errors under Node 24 before the suite could start
