### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: npm
+    directory: "/"
+    groups:
+      npm:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
+      default-days: 7
+
+  - package-ecosystem: bundler
+    directory: "/action_text-trix"
+    groups:
+      bundler:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.11
+        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@v0.5.2
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           advanced-security: false
 
@@ -40,8 +40,8 @@ jobs:
     name: Browser tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
           cache: "yarn"
@@ -49,7 +49,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Start Sauce Connect
         if: ${{ env.SAUCE_ACCESS_KEY != '' }}
-        uses: saucelabs/sauce-connect-action@v3
+        uses: saucelabs/sauce-connect-action@cb88b508c6f9ff4d84490093733315dbd55de022 # v3
         with:
           username: ${{ env.SAUCE_USERNAME }}
           accessKey: ${{ env.SAUCE_ACCESS_KEY }}
@@ -68,12 +68,12 @@ jobs:
     name: Downstream Rails integration tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
           cache: "yarn"
-      - uses: ruby/setup-ruby-pkgs@v1
+      - uses: ruby/setup-ruby-pkgs@2233d39c1315c667a2970436418b520a6300124e # v1.33.5
         with:
           ruby-version: "3.4"
           apt-get: libvips-tools
@@ -139,12 +139,12 @@ jobs:
             rails_branch: main
             experimental: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
           cache: "yarn"
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         env:
           RAILS_BRANCH: ${{ matrix.rails_branch }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,23 @@ env:
   SAUCE_TUNNEL_IDENTIFIER: trix-${{ github.run_id }}
 
 jobs:
+  lint-actions:
+    name: GitHub Actions audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.11
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@v0.5.2
+        with:
+          advanced-security: false
+
   build:
     name: Browser tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
     types: [opened, synchronize]
     branches: [ '*' ]
 
+permissions: {}
+
 env:
   SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
   SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -22,6 +24,8 @@ jobs:
   lint-actions:
     name: GitHub Actions audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,8 +43,12 @@ jobs:
   build:
     name: Browser tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
@@ -67,8 +75,12 @@ jobs:
   rails-tests:
     name: Downstream Rails integration tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18
@@ -98,6 +110,8 @@ jobs:
   action_text-trix:
     name: Action Text tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -140,6 +154,8 @@ jobs:
             experimental: true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 18

--- a/bin/ci
+++ b/bin/ci
@@ -13,4 +13,12 @@ if [ -n "$CI" ]; then
   echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
 fi
 
+# Lint GitHub Actions workflows
+if command -v actionlint &> /dev/null; then
+  actionlint
+fi
+if command -v zizmor &> /dev/null; then
+  zizmor .
+fi
+
 yarn test

--- a/bin/setup
+++ b/bin/setup
@@ -31,6 +31,15 @@ abort() {
   return 2
 }
 
+echo "--- Installing GitHub Actions linting tools"
+{
+  for tool in actionlint shellcheck zizmor; do
+    if ! which "$tool" > /dev/null; then
+      brew_install_missing "$tool" || abort "Can't find or install $tool. Install it manually."
+    fi
+  done
+} >&3 2>&1
+
 echo "--- Installing Ruby gems"
 {
   if which rbenv > /dev/null; then


### PR DESCRIPTION
## Summary
- Add zizmor and actionlint CI job
- Configure dependabot with batched updates and cooldown periods
- Pin all GitHub Actions to SHA hashes
- Fix excessive-permissions and artipacked findings
- Scope all permissions to job-level
- Add local workflow linting to bin/setup and bin/ci

## Test plan
- [ ] CI passes (lint-actions job runs clean)
- [ ] Existing test jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)