### PR TITLE
Refactor HTML to remove type attribute from style tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The easiest way to start with Trix is including it from an npm CDN in the `<head
 ```html
 <head>
   …
-  <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.0.8/dist/trix.css">
+  <link rel="stylesheet" href="https://unpkg.com/trix@2.0.8/dist/trix.css">
   <script type="text/javascript" src="https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js"></script>
 </head>
 ```

--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -1060,7 +1060,6 @@ $\
   };
   const insertStyleElementForTagName = function (tagName) {
     const element = document.createElement("style");
-    element.setAttribute("type", "text/css");
     element.setAttribute("data-tag-name", tagName.toLowerCase());
     const nonce = getCSPNonce();
     if (nonce) {

--- a/assets/index.html
+++ b/assets/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="csp-nonce" content="topsecret">
     <link rel="icon" href="data:,">
-    <link rel="stylesheet" type="text/css" href="trix.css">
-    <style type="text/css">
+    <link rel="stylesheet" href="trix.css">
+    <style>
       * {
         box-sizing: border-box;
       }

--- a/assets/test.html
+++ b/assets/test.html
@@ -3,7 +3,7 @@
 <title>Test Suite</title>
 <link rel="icon" href="data:,">
 <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.19.1.css">
-<link rel="stylesheet" type="text/css" href="trix.css">
+<link rel="stylesheet" href="trix.css">
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>

--- a/src/test/test_helper.js
+++ b/src/test/test_helper.js
@@ -22,7 +22,7 @@ QUnit.config.testTimeout = 20000
 
 document.head.insertAdjacentHTML(
   "beforeend",
-  `<style type="text/css">
+  `<style>
     #trix-container { height: 150px; }
     trix-toolbar { margin-bottom: 10px; }
     trix-toolbar button { border: 1px solid #ccc; background: #fff; }

--- a/src/test/test_helpers/fixtures/editor_with_block_styles.js
+++ b/src/test/test_helpers/fixtures/editor_with_block_styles.js
@@ -1,5 +1,5 @@
 export default () =>
-  `<style type="text/css">
+  `<style>
     blockquote { font-style: italic; }
     li { font-weight: bold; }
   </style>

--- a/src/test/test_helpers/fixtures/editor_with_bold_styles.js
+++ b/src/test/test_helpers/fixtures/editor_with_bold_styles.js
@@ -1,5 +1,5 @@
 export default () =>
-  `<style type="text/css">
+  `<style>
     strong { font-weight: 500; }
     span { font-weight: 600; }
     article { font-weight: bold; }

--- a/src/test/test_helpers/fixtures/editor_with_styled_content.js
+++ b/src/test/test_helpers/fixtures/editor_with_styled_content.js
@@ -1,5 +1,5 @@
 export default () =>
-  `<style type="text/css">
+  `<style>
     .trix-content figure.attachment {
       display: inline-block;
     }

--- a/src/trix/core/helpers/custom_elements.js
+++ b/src/trix/core/helpers/custom_elements.js
@@ -7,7 +7,6 @@ export const installDefaultCSSForTagName = function(tagName, defaultCSS) {
 
 const insertStyleElementForTagName = function(tagName) {
   const element = document.createElement("style")
-  element.setAttribute("type", "text/css")
   element.setAttribute("data-tag-name", tagName.toLowerCase())
   const nonce = getCSPNonce()
   if (nonce) {


### PR DESCRIPTION
This pull request standardizes the way CSS stylesheets and style elements are included throughout the project by removing the unnecessary `type="text/css"` attribute from `<link>` and `<style>` tags. This change simplifies the code and aligns with current HTML standards, as specifying the type is no longer required.