### PR TITLE
Update dependencies

### DIFF
--- a/action_text-trix/Gemfile
+++ b/action_text-trix/Gemfile
@@ -12,5 +12,5 @@ gem "sqlite3"
 
 group :test do
   gem "cuprite", require: "capybara/cuprite"
-  gem "minitest", "< 6.0" # can be removed once Rails' line_filtering supports Minitest 6+
+  gem "minitest"
 end


### PR DESCRIPTION
Rails now supports minitest 6, so we can remove the `<6` pin.