### PR TITLE
dep: set dompurify minimum to 3.4.11 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "start": "yarn build-assets && concurrently --kill-others --names js,css,dev-server 'yarn watch' 'yarn build-css --watch' 'yarn dev'"
   },
   "dependencies": {
-    "dompurify": "^3.2.5"
+    "dompurify": "^3.4.11"
   },
   "engines": {
     "node": ">= 18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,10 +3022,10 @@ domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
-dompurify@^3.2.5:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.2.tgz#f0ff81be682c485505097ba8195a058d8f575218"
-  integrity sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==
+dompurify@^3.4.11:
+  version "3.4.11"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.11.tgz#29c8ba496475f279ef4015784068452fb14a0680"
+  integrity sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
The previous release (v2.1.19) only updated dompurify in the lockfile, leaving `package.json` at `^3.2.5`. Consumers resolving from the registry can still end up with a vulnerable version since npm/yarn/pnpm will resolve anything satisfying that range.

This bumps the declared minimum to `^3.4.11` so the registry-advertised constraint excludes vulnerable versions.

Note: Dependabot has an open branch (`dependabot/npm_and_yarn/dompurify-3.4.11`) with the same intent but it only updates the lockfile, not `package.json`.