### PR TITLE
Pin shell-quote >= 1.8.4 (GHSA-w7jw-789q-3m8p)

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -63,7 +63,8 @@ Copyright © 2026 37signals, LLC
   	webdriverio: "^7.19.5"
   };
   var resolutions = {
-  	webdriverio: "^7.19.5"
+  	webdriverio: "^7.19.5",
+  	"shell-quote": "^1.8.4"
   };
   var scripts = {
   	"build-css": "bin/sass-build assets/trix.scss dist/trix.css action_text-trix/app/assets/stylesheets/trix.css",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "webdriverio": "^7.19.5"
   },
   "resolutions": {
-    "webdriverio": "^7.19.5"
+    "webdriverio": "^7.19.5",
+    "shell-quote": "^1.8.4"
   },
   "scripts": {
     "build-css": "bin/sass-build assets/trix.scss dist/trix.css action_text-trix/app/assets/stylesheets/trix.css",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,10 +5183,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.7.3:
-  version "1.8.1"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz"
-  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
+shell-quote@^1.7.3, shell-quote@^1.8.4:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.10.0.tgz#482033e192e4f5c07151521ffa03400ec71b1b0f"
+  integrity sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==
 
 side-channel-list@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
`shell-quote` before 1.8.4 does not escape newline characters in object `.op` values, a command-injection primitive when quoted output reaches a shell ([GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p), critical; patched in 1.8.4).

Here it's a transitive dev-tooling dependency (pulled via `concurrently`), so real exposure is low — but the fix is trivial. Forces `shell-quote >= 1.8.4` through a yarn `resolutions` entry; resolves to 1.10.0. Lockfile-only change, no source touched.