### PR TITLE
Detect silent DataTransfer write failures

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -1110,7 +1110,7 @@ $\
       const value = testTransferData[key];
       try {
         dataTransfer.setData(key, value);
-        if (!dataTransfer.getData(key) === value) return false;
+        if (dataTransfer.getData(key) !== value) return false;
       } catch (error) {
         return false;
       }

--- a/src/trix/core/helpers/events.js
+++ b/src/trix/core/helpers/events.js
@@ -28,7 +28,7 @@ export const dataTransferIsWritable = function(dataTransfer) {
 
     try {
       dataTransfer.setData(key, value)
-      if (!dataTransfer.getData(key) === value) return false
+      if (dataTransfer.getData(key) !== value) return false
     } catch (error) {
       return false
     }


### PR DESCRIPTION
## Summary

Correct the write verification in `dataTransferIsWritable`.

The current `!getData(...) === value` expression applies boolean negation before strict equality, so it never detects a setter that silently refuses to persist the probe value. Comparing the retrieved value directly makes the helper return `false` for both throwing and non-persisting implementations.

The generated Action Text asset is rebuilt with the same one-line change.

## Verification

- focused model: silent write rejection changes from writable=`true` to writable=`false`; normal and missing-setter cases remain unchanged
- complete Chromium suite: 501 total, 472 pass, 0 fail, 29 conditional skips
- frozen Yarn install, ESLint, Rollup/Sass/assets and gem build pass
- Action Text wrapper test and Rails loading pass on Ruby 4.0.6 and Ruby 3.2.11

No public API or dependency change.