### PR TITLE
Store only key-value pairs in Hash arrays

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -1397,7 +1397,7 @@ $\
         const result = [];
         for (const key in this.values) {
           const value = this.values[key];
-          result.push(result.push(key, value));
+          result.push(key, value);
         }
         this.array = result.slice(0);
       }

--- a/src/test/unit/hash_test.js
+++ b/src/test/unit/hash_test.js
@@ -1,0 +1,9 @@
+import { assert, test, testGroup } from "test/test_helper"
+
+import Hash from "trix/core/collections/hash"
+
+testGroup("Hash", () => {
+  test("toArray returns flattened key-value pairs", () => {
+    assert.deepEqual(new Hash({ a: 1, b: 2 }).toArray(), [ "a", 1, "b", 2 ])
+  })
+})

--- a/src/trix/core/collections/hash.js
+++ b/src/trix/core/collections/hash.js
@@ -80,7 +80,7 @@ export default class Hash extends TrixObject {
       const result = []
       for (const key in this.values) {
         const value = this.values[key]
-        result.push(result.push(key, value))
+        result.push(key, value)
       }
       this.array = result.slice(0)
     }


### PR DESCRIPTION
## Summary

Remove the nested `result.push` in `Hash#toArray`.

The inner push already appends the key and value; pushing its numeric return value again inserts cumulative array lengths. The corrected method produces the intended flat key/value sequence while preserving the serialized JSON output.

The generated Action Text asset is rebuilt with the same one-line change.

## Verification

- focused model: `["a", 1, 2, "b", 2, 5]` becomes `["a", 1, "b", 2]`; JSON remains identical
- complete Chromium suite: 501 total, 472 pass, 0 fail, 29 conditional skips
- frozen Yarn install, ESLint, Rollup/Sass/assets and gem build pass
- Action Text wrapper test and Rails loading pass on Ruby 4.0.6 and Ruby 3.2.11

No public API or dependency change.