### PR TITLE
Cancel the default paste when Trix handles a paste as a file paste

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -13484,6 +13484,7 @@ $\
         };
       } else if (processableFilePaste(this.event)) {
         var _this$delegate22;
+        this.event.preventDefault();
         paste.type = "File";
         paste.file = dataTransfer.files[0];
         (_this$delegate22 = this.delegate) === null || _this$delegate22 === void 0 || _this$delegate22.inputControllerWillPaste(paste);

--- a/src/test/system/level_2_input_test.js
+++ b/src/test/system/level_2_input_test.js
@@ -205,6 +205,25 @@ testGroup("Level 2 Input", testOptions, () => {
     expectDocument(`${OBJECT_REPLACEMENT_CHARACTER}\n`)
   })
 
+  test("pasting a file alongside HTML cancels the browser's default paste", async () => {
+    const file = await createFile()
+    const dataTransfer = createDataTransfer({
+      "text/html": "<img src=x data-trix-serialized-attributes='{\"onerror\":\"alert(1)\"}'>",
+      "text/plain": "x",
+      Files: [ file ],
+    })
+
+    const inputEvent = createEvent("beforeinput", { inputType: "insertFromPaste", dataTransfer })
+    const notPrevented = document.activeElement.dispatchEvent(inputEvent)
+    await delay(60)
+
+    assert.notOk(notPrevented, "the default paste must be canceled so the browser cannot insert the clipboard HTML")
+
+    const attachments = getDocument().getAttachments()
+    assert.equal(attachments.length, 1, "the pasted file is inserted as an attachment")
+    assert.notOk(getEditorElement().value.includes("onerror"), "no attribute from the clipboard HTML survives")
+  })
+
   // "insertFromPaste InputEvent missing pasted files in dataTransfer"
   // - https://bugs.webkit.org/show_bug.cgi?id=194921
   test("pasting a file in Safari", async () => {

--- a/src/trix/controllers/level_2_input_controller.js
+++ b/src/trix/controllers/level_2_input_controller.js
@@ -403,6 +403,7 @@ export default class Level2InputController extends InputController {
           return this.delegate?.inputControllerDidPaste(paste)
         }
       } else if (processableFilePaste(this.event)) {
+        this.event.preventDefault()
         paste.type = "File"
         paste.file = dataTransfer.files[0]
         this.delegate?.inputControllerWillPaste(paste)


### PR DESCRIPTION
## What

When a paste carries a file alongside HTML (a common mixed-clipboard shape — e.g. an image plus its `text/html` representation), `insertFromPaste`'s `processableFilePaste` branch inserted the file but did not call `preventDefault()`. Every other branch in `insertFromPaste` (the URL, plain-text, and HTML branches) cancels the browser's default paste; this one didn't.

The result: Trix inserted the file **and** the browser's default action inserted the accompanying clipboard HTML directly into the contenteditable — unsanitized — until the next editor redraw replaced it with sanitized DOM.

## Why it matters

The safety of that markup depends entirely on the redraw running and replacing it. If the redraw is disrupted, the browser-inserted markup survives in the live DOM and is later serialized back into the editor's value. Trix's serializer re-inflates `data-trix-serialized-attributes` into real element attributes, so surviving attacker markup on that path can be turned into executable content. Relying on a post-hoc redraw to clean up unsanitized DOM that was never supposed to be inserted is the wrong invariant.

## The fix

Add `this.event.preventDefault()` to the file-paste branch so Trix fully owns the paste — the browser never inserts the accompanying clipboard HTML, and no untrusted markup lands in the editor DOM in the first place. This also matches the documented intent to prioritize files over HTML on paste (#1148), rather than inserting both.

## Test

`src/test/system/level_2_input_test.js` adds a case dispatching a mixed file + `text/html` paste and asserting the `beforeinput`/`insertFromPaste` default is canceled, the file is inserted as an attachment, and none of the clipboard HTML's attributes survive into the editor value. Red before the one-line change, green after. Full suite green (473 passed).

## Note for maintainers

This closes the paste entry vector. As defense in depth, the serializer's re-inflation of `data-trix-serialized-attributes` into arbitrary attributes (`src/trix/core/serialization.js`) remains a sharp edge that trusts sanitized DOM; it's worth a hard look at that sink independently, since its only legitimate producer emits a single `src` override.