### PR TITLE
CI: run downstream Rails integration tests on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,8 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 18
+          # Rails' own yarn.lock requires node >= 24
+          node-version: 24
           cache: "yarn"
       - uses: ruby/setup-ruby-pkgs@2233d39c1315c667a2970436418b520a6300124e # v1.33.5
         with:


### PR DESCRIPTION
The **Downstream Rails integration tests** job fails repo-wide (on `main` and every open PR) at the `yarn install --frozen-lockfile` step inside the freshly-cloned Rails tree:

```
error errorstacks@2.4.2: The engine "node" is incompatible with this module. Expected version ">=24". Got "18.20.8"
```

Rails' own `yarn.lock` now pulls in packages that declare `engines.node >= 24`, but this job pins Node 18. This is unrelated to any individual PR's changes — it's a moving upstream dependency floor.

**Fix:** bump only the `rails-tests` job to Node 24. The **Browser tests** and **Action Text tests** matrix jobs stay on Node 18 — they build/test against Trix's own lockfile (`engines.node >= 18`), which is unaffected.

Isolated here so it can land on `main` independently and unblock the other open PRs, which all trip the same failure.