### PR TITLE
Docs: warn that inline <trix-editor> child HTML must be trusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,22 @@ To populate a `<trix-editor>` with stored content, include that content in the a
 </form>
 ```
 
-Use an associated input element to initially populate an editor. When an associated input element is absent, Trix will safely sanitize then load any HTML content inside a `<trix-editor>…</trix-editor>` tag.
+Use an associated input element to initially populate an editor. When an associated input element is absent, Trix sanitizes the HTML content inside a `<trix-editor>…</trix-editor>` tag as it loads that content into the editor.
 
 ```html
 <form …>
   <trix-editor>Editor content goes here</trix-editor>
 </form>
 ```
+
+> [!CAUTION]
+> Never place untrusted or user-controlled HTML directly inside a
+> `<trix-editor>` tag. This inline content is live DOM: the browser parses it
+> before Trix connects and sanitizes the editor value, so any active content in
+> it — for example an `<img onerror>` — runs on page load. Trix's sanitization
+> applies to the value it loads into the editor, not to the raw children as the
+> browser parses them. To initialize an editor with untrusted initial content,
+> put it in an associated hidden input instead.
 
 > [!WARNING]
 > When a `<trix-editor>` element initially connects with both HTML content *and*

--- a/README.md
+++ b/README.md
@@ -196,7 +196,11 @@ Use an associated input element to initially populate an editor. When an associa
 > it — for example an `<img onerror>` — runs on page load. Trix's sanitization
 > applies to the value it loads into the editor, not to the raw children as the
 > browser parses them. To initialize an editor with untrusted initial content,
-> put it in an associated hidden input instead.
+> put it in an associated hidden input — with the value HTML-attribute-escaped,
+> as server-side templating does by default, or assigned through the input's DOM
+> `value` property. An unescaped value interpolated into the `value="…"`
+> attribute can itself break out of the attribute and become live DOM,
+> recreating the same problem.
 
 > [!WARNING]
 > When a `<trix-editor>` element initially connects with both HTML content *and*


### PR DESCRIPTION
## What

Clarifies the README's initial-content section: Trix sanitizes the value it loads into the editor, **not** the raw children the browser parses. Inline HTML inside a `<trix-editor>` tag is live DOM, so any active content in it (e.g. `<img onerror>`) executes on page load — before Trix's custom element connects and sanitizes. Adds a `[!CAUTION]` steering untrusted initial content to an associated hidden input.

## Why

The prior wording ("Trix will safely sanitize then load any HTML content inside a `<trix-editor>…</trix-editor>` tag") can be read as a guarantee that untrusted HTML is safe to render as raw children. It isn't, and no code change can make it so: the browser parses and activates a custom element's children before any of the element's own JavaScript runs, so `setTimeout`-deferred registration and `connectedCallback` sanitization both come too late to prevent execution. The associated-hidden-input path is unaffected (the value stays an attribute string until Trix parses and sanitizes it).

Docs-only; no code paths touched. Surfaced via HackerOne report #3985804.