### PR TITLE
Sanitize under DOMPurify's SAFE_FOR_XML mode by default

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -223,7 +223,7 @@ Copyright © 2026 37signals, LLC
 
   var dompurify = {
     ADD_ATTR: ["language"],
-    SAFE_FOR_XML: false,
+    SAFE_FOR_XML: true,
     RETURN_DOM: true
   };
 
@@ -10264,11 +10264,7 @@ $\
       }
     }
     insertHTML(html) {
-      const document = HTMLParser.parse(html, {
-        purifyOptions: {
-          SAFE_FOR_XML: true
-        }
-      }).getDocument();
+      const document = HTMLParser.parse(html).getDocument();
       const selectedRange = this.getSelectedRange();
       this.setDocument(this.document.mergeDocumentAtRange(document, selectedRange));
       const startPosition = selectedRange[0];

--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -10264,7 +10264,11 @@ $\
       }
     }
     insertHTML(html) {
-      const document = HTMLParser.parse(html).getDocument();
+      const document = HTMLParser.parse(html, {
+        purifyOptions: {
+          SAFE_FOR_XML: true
+        }
+      }).getDocument();
       const selectedRange = this.getSelectedRange();
       this.setDocument(this.document.mergeDocumentAtRange(document, selectedRange));
       const startPosition = selectedRange[0];

--- a/src/test/system/html_loading_test.js
+++ b/src/test/system/html_loading_test.js
@@ -119,7 +119,7 @@ testGroup("HTML loading", () => {
   testGroup("attachment content", { template: "editor_empty" }, () => {
     test("drops a style element whose text would parse as markup", async () => {
       window.trixProbe = 0
-      const content = `<svg><p><style><a title="</style><img src="${TEST_IMAGE_URL}" onerror="window.trixProbe = 1">"></style></p></svg>`
+      const content = "<svg><p><style><a title=\"</style><img src=\"data:image/gif;base64,TOTALLYBOGUS\" onerror=\"window.trixProbe = 1\">\"></style></p></svg>"
       getEditor().loadHTML(attachmentHTML({ contentType: "text/html", content }))
       await delay(20)
 

--- a/src/test/system/html_loading_test.js
+++ b/src/test/system/html_loading_test.js
@@ -1,4 +1,4 @@
-import { TEST_IMAGE_URL, assert, expectDocument, test, testGroup } from "test/test_helper"
+import { TEST_IMAGE_URL, assert, attachmentHTML, expectDocument, test, testGroup } from "test/test_helper"
 import { OBJECT_REPLACEMENT_CHARACTER } from "trix/constants"
 import { delay } from "../test_helpers/timing_helpers"
 
@@ -113,6 +113,22 @@ testGroup("HTML loading", () => {
       assert.blockAttributes([ 0, 2 ], [ "heading1" ])
       assert.blockAttributes([ 2, 4 ], [])
       expectDocument("a\nb\n")
+    })
+  })
+
+  testGroup("attachment content", { template: "editor_empty" }, () => {
+    test("drops a style element whose text would parse as markup", async () => {
+      window.trixProbe = 0
+      const content = `<svg><p><style><a title="</style><img src="${TEST_IMAGE_URL}" onerror="window.trixProbe = 1">"></style></p></svg>`
+      getEditor().loadHTML(attachmentHTML({ contentType: "text/html", content }))
+      await delay(20)
+
+      const figure = getEditorElement().querySelector("figure")
+      assert.ok(figure, "attachment was dropped")
+      assert.notOk(figure.querySelector("style"), figure.innerHTML)
+      assert.notOk(figure.querySelector("[onerror]"), figure.innerHTML)
+      assert.equal(window.trixProbe, 0, "attachment content ran a handler")
+      delete window.trixProbe
     })
   })
 })

--- a/src/test/unit/composition_test.js
+++ b/src/test/unit/composition_test.js
@@ -2,6 +2,7 @@ import { assert, test, testGroup } from "test/test_helper"
 
 import Composition from "trix/models/composition"
 import { TestCompositionDelegate } from "test/test_helpers/test_stubs"
+import * as config from "trix/config"
 
 let composition = null
 const setup = () => {
@@ -9,11 +10,29 @@ const setup = () => {
   composition.delegate = new TestCompositionDelegate()
 }
 
-testGroup("Composition", { setup }, () =>
+testGroup("Composition", { setup }, () => {
   test("deleteInDirection respects UTF-16 character boundaries", () => {
     composition.insertString("abc😭")
     composition.deleteInDirection("backward")
     composition.insertString("d")
     assert.equal(composition.document.toString(), "abcd\n")
   })
-)
+
+  test("insertHTML sanitizes for XML even when the config turns it off", () => {
+    withSafeForXML(false, () => composition.insertHTML("<a href=\"https://example.com/#-->\">link</a>"))
+
+    const [ piece ] = composition.document.getPieces()
+    assert.equal(piece.toString(), "link")
+    assert.notOk(piece.getAttribute("href"), "SAFE_FOR_XML drops an attribute whose value carries -->")
+  })
+})
+
+const withSafeForXML = (value, fn) => {
+  const original = config.dompurify.SAFE_FOR_XML
+  config.dompurify.SAFE_FOR_XML = value
+  try {
+    fn()
+  } finally {
+    config.dompurify.SAFE_FOR_XML = original
+  }
+}

--- a/src/test/unit/html_sanitizer_test.js
+++ b/src/test/unit/html_sanitizer_test.js
@@ -41,6 +41,14 @@ testGroup("HTMLSanitizer", () => {
     })
   })
 
+  test("removes a style element whose text would parse as markup", () => {
+    const html = "<svg><p><style><a title=\"</style><img src=x onerror=xss()>\"></style></p></svg>"
+    const body = HTMLSanitizer.sanitize(html).getBody()
+
+    assert.notOk(body.querySelector("style"), body.innerHTML)
+    assert.notOk(body.querySelector("[onerror]"), body.innerHTML)
+  })
+
   test("strips data-trix-serialized-attributes containing markup when sanitizing for XML", () => {
     const html = "<div data-trix-serialized-attributes='{\"a\":\"</style>\"}'>content</div>"
     const body = HTMLSanitizer.sanitize(html, { purifyOptions: { SAFE_FOR_XML: true } }).getBody()
@@ -185,6 +193,7 @@ const withConfig = (section, newConfig = {}, fn) => {
     copy(section, newConfig)
     fn()
   } finally {
-    copy(section, originalConfig)
+    Object.keys(config[section]).forEach((key) => delete config[section][key])
+    Object.assign(config[section], originalConfig)
   }
 }

--- a/src/trix/config/dompurify.js
+++ b/src/trix/config/dompurify.js
@@ -1,5 +1,5 @@
 export default {
   ADD_ATTR: [ "language" ],
-  SAFE_FOR_XML: false,
+  SAFE_FOR_XML: true,
   RETURN_DOM: true
 }

--- a/src/trix/models/composition.js
+++ b/src/trix/models/composition.js
@@ -127,7 +127,7 @@ export default class Composition extends BasicObject {
   }
 
   insertHTML(html) {
-    const document = HTMLParser.parse(html).getDocument()
+    const document = HTMLParser.parse(html, { purifyOptions: { SAFE_FOR_XML: true } }).getDocument()
     const selectedRange = this.getSelectedRange()
 
     this.setDocument(this.document.mergeDocumentAtRange(document, selectedRange))

--- a/src/trix/models/composition.js
+++ b/src/trix/models/composition.js
@@ -127,7 +127,7 @@ export default class Composition extends BasicObject {
   }
 
   insertHTML(html) {
-    const document = HTMLParser.parse(html, { purifyOptions: { SAFE_FOR_XML: true } }).getDocument()
+    const document = HTMLParser.parse(html).getDocument()
     const selectedRange = this.getSelectedRange()
 
     this.setDocument(this.document.mergeDocumentAtRange(document, selectedRange))


### PR DESCRIPTION
One config flip plus the tests that pin it. Follows #1337 and #1338, both now in `main`; it depends on #1338's escaping.

## What

`src/trix/config/dompurify.js` now sets `SAFE_FOR_XML: true`. `composition.insertHTML` keeps its per-call `{ purifyOptions: { SAFE_FOR_XML: true } }`: `Trix.config.dompurify` is the documented way for an application to set DOMPurify's options, and an application that set `SAFE_FOR_XML = false` as a workaround for the attachment breakage #1213 fixed may still carry that override. `loadHTML` and `replaceHTML` honor it, since that is the application's own content; pasted HTML is foreign, and the paste path has forced the mode on since 5f61df05, so flipping the default leaves that guarantee where it is.

## Why

692fa988 (#1213) turned `SAFE_FOR_XML` off solely because DOMPurify's attribute-value rule dropped any attachment JSON containing `-->` — Rails view-annotation comments in rendered attachment content were the reported case — and that rule runs before `forceKeepAttr` is honored. #1338 escapes the angle brackets in both JSON attachment attributes before DOMPurify sees them, on the emitting side and the sanitizing side, so that trigger no longer exists.

What was left behind by turning the mode off globally: the paste path opted back in per call, but `editor.loadHTML`, `composition.replaceHTML`, both `serialization.js` parses and the attachment render path (`attachment_view.js:38` and `:178`, which set the sanitized DOM's `innerHTML` into the live editor — a serialize-then-reparse step, which is exactly where mutation XSS bites) all ran without DOMPurify's namespace-confusion checks. Making the mode the default gives every parse the same treatment, and subsumes the per-call flags #1334 proposed for `loadHTML` and `replaceHTML` (closed in favor of this).

## Tests

- `html_sanitizer_test`: with the default config, `<svg><p><style><a title="</style><img src=x onerror=xss()>">` comes out with no `<style>` element and no handler. Red with the flag off, green with it on.
- `html_loading_test` (system): `editor.loadHTML` of an attachment whose content is that shape renders a figure with no `<style>`, no `[onerror]`, and the probe handler never runs. Red with the flag off, green with it on.
- `composition_test`: with `config.dompurify.SAFE_FOR_XML = false`, `insertHTML` still drops an `href` carrying `-->`. Red with the per-call flag removed, green with it kept.
- The tests from #1337 and #1338 that pass `purifyOptions: { SAFE_FOR_XML: true }` explicitly are kept as they are; they pin the behavior regardless of the default.
- The config helper in `html_sanitizer_test` restored the original config by skipping falsy values, which deleted `SAFE_FOR_XML: false` after the custom-tags test and left DOMPurify at its own default (`true`) for every test that followed in the bundle. It now restores the whole section, so the red run above is real: with the flag off, only the two new tests fail.
- Full suite locally on the rebase onto `main`: 539 tests, 510 passed, 0 failed, 29 skipped. Bundle rebuilt and idempotent.
