### PR TITLE
Fix the downstream Rails test job's json 3 duplicate-key failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,17 @@ jobs:
       - name: Clone Rails
         run: git clone --depth=1 https://github.com/rails/rails
       - name: Configure Rails
+        # Rails main locks json 3.0, which rejects hashes whose string and symbol keys collide.
+        # Action Text's `while_offline` system-test helper restores Chrome's string-keyed
+        # network conditions through `Object#with`, selenium-webdriver re-adds them as symbols,
+        # and the request body fails to serialize. Rails' own CI runs only `rake actiontext`
+        # (no system tests), so upstream doesn't see it. Keep json 2.x here until the helper
+        # or selenium-webdriver stops mixing key types.
         run: |
           cd rails
           yarn install --frozen-lockfile
+          bundle remove json
+          bundle add json --version "~> 2.21"
           bundle add action_text-trix --path ".."
           bundle show --paths action_text-trix
       - name: Action Text tests


### PR DESCRIPTION
The "Downstream Rails integration tests" job has been red on `main` and on every PR since 2026-09-08 (e.g. [main run 34325807733](https://github.com/basecamp/trix/actions/runs/34325807733), [#1353's run 34440774629](https://github.com/basecamp/trix/actions/runs/34440774629)). The three failing tests all go through Action Text's `while_offline` helper and die before reaching the browser:

```
JSON::GeneratorError: detected duplicate key "latency" in {"download_throughput" => -1, "latency" => 0, "offline" => false, "upload_throughput" => -1, latency: 0, download_throughput: -1, upload_throughput: -1, offline: false}
    json-3.0.1/lib/json/common.rb:126:in 'block in JSON.on_mixed_keys_hash'
    selenium-webdriver-4.32.0/lib/selenium/webdriver/remote/http/common.rb:58:in 'Selenium::WebDriver::Remote::Http::Common#call'
    selenium-webdriver-4.32.0/lib/selenium/webdriver/chromium/features.rb:71:in 'Selenium::WebDriver::Chromium::Features#network_conditions='
    selenium-webdriver-4.32.0/lib/selenium/webdriver/common/driver_extensions/has_network_conditions.rb:53:in 'Selenium::WebDriver::DriverExtensions::HasNetworkConditions#network_conditions='
    activesupport/lib/active_support/core_ext/object/with.rb:41:in 'block in Object#with'
    test/system/rich_text_editor_test.rb:104:in 'ActionText::RichTextEditorTest#while_offline'
```

## Root cause

Three things line up, none of them in Trix:

- rails/rails#58690 (merged 2026-09-08) moved Rails main's lockfile to **json 3.0.1**. json 3.0 makes `allow_duplicate_key: false` the default for generation ([CHANGES](https://github.com/ruby/json/blob/master/CHANGES.md#2026-09-07-300)), so a hash whose string and symbol keys collide now raises instead of warning.
- Action Text's [`while_offline`](https://github.com/rails/rails/blob/main/actiontext/test/system/rich_text_editor_test.rb) wraps the block in `page.driver.browser.with(network_conditions: { offline: value })`. `Object#with` reads the current value first, and Chrome returns it with **string** keys; on the way out it assigns that hash back.
- selenium-webdriver's [`HasNetworkConditions#network_conditions=`](https://github.com/SeleniumHQ/selenium/blob/trunk/rb/lib/selenium/webdriver/common/driver_extensions/has_network_conditions.rb) fills in defaults with `conditions[:latency] ||= 0` and friends — **symbol** keys, added to the string-keyed hash it was handed. Under json 2.x that serialized with a warning; under 3.0 `JSON.generate` refuses. Unchanged on selenium trunk (4.49.0 shipped today with the same code), so there is no fixed release to bump to.

Rails' own CI doesn't catch it because [buildkite-config runs `rake actiontext`](https://github.com/rails/buildkite-config/blob/main/pipelines/rails-ci/pipeline.rb) — the default `test` task, which excludes `test/system`. This job is effectively the only CI running Action Text's system tests against Rails main.

## Fix

Keep json on 2.x for this job's Rails checkout, and leave everything else alone:

```
bundle remove json
bundle add json --version "~> 2.21"
```

(`bundle add` refuses a gem already in the Gemfile, hence the remove first.) Rails' Gemfile accepts `json >= 2.0.0, != 2.7.0`, nothing else in its lockfile needs 3.x, and json 2.21.2 was the lockfile's version until the bump. The tests run on the merits — no skips, no `continue-on-error`.

### Why not the other options

- **Newer Rails ref**: no ref carries a fix; upstream doesn't run these tests.
- **Newer selenium-webdriver**: 4.49.0 has the same `||=` code path.
- **Different Ruby**: the json version comes from Rails' lockfile, not Ruby's default gems, so `ruby-version` doesn't affect it.

The durable fix belongs upstream: either `while_offline` stops round-tripping the getter's string-keyed hash through `with`, or selenium normalizes keys before merging defaults. Once one of those lands, the two `bundle` lines and the comment come back out.

## Proof

Downstream job green on this branch: https://github.com/basecamp/trix/actions/runs/34441413858/job/102757050025

#1353's downstream red is this same failure and clears once this merges and #1353 is rebased or re-run.
