### PR TITLE
Remove block markers as nodes so <style>/raw-text content isn't corrupted

### DIFF
--- a/action_text-trix/app/assets/javascripts/trix.js
+++ b/action_text-trix/app/assets/javascripts/trix.js
@@ -9976,7 +9976,6 @@ $\
   const unserializableAttributeNames = ["contenteditable", "data-trix-id", "data-trix-store-key", "data-trix-mutable", "data-trix-placeholder", "tabindex"];
   const serializedAttributesAttribute = "data-trix-serialized-attributes";
   const serializedAttributesSelector = "[".concat(serializedAttributesAttribute, "]");
-  const blockCommentPattern = new RegExp("<!--block-->", "g");
   const serializers = {
     "application/json": function (serializable) {
       let document;
@@ -10022,7 +10021,21 @@ $\
           }
         } catch (error) {}
       });
-      return element.innerHTML.replace(blockCommentPattern, "");
+
+      // Strip Trix's block boundary markers structurally, as comment nodes. A
+      // string replace over serialized HTML cannot tell Trix's own <!--block-->
+      // comment nodes from the identical byte sequence sitting in a text node
+      // (e.g. inside a raw-text <style> element), where removing it corrupts
+      // benign content and can fuse inert text into real markup.
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_COMMENT);
+      const markers = [];
+      while (walker.nextNode()) {
+        if (walker.currentNode.data === "block") {
+          markers.push(walker.currentNode);
+        }
+      }
+      markers.forEach(node => node.remove());
+      return element.innerHTML;
     }
   };
   const deserializers = {

--- a/src/test/unit/serialization_test.js
+++ b/src/test/unit/serialization_test.js
@@ -9,4 +9,61 @@ testGroup("serializeToContentType", () => {
       })
     }
   })
+
+  testGroup("block boundary marker removal", () => {
+    test("removes real block marker comment nodes", () => {
+      const element = document.createElement("div")
+      const block = document.createElement("div")
+      block.appendChild(document.createComment("block"))
+      block.appendChild(document.createTextNode("abc"))
+      element.appendChild(block)
+
+      assert.equal(serializeToContentType(element, "text/html"), "<div>abc</div>")
+    })
+
+    test("preserves comment nodes that are not Trix block markers", () => {
+      const element = document.createElement("div")
+      const block = document.createElement("div")
+      block.appendChild(document.createComment("block"))
+      block.appendChild(document.createComment("keep"))
+      block.appendChild(document.createTextNode("abc"))
+      element.appendChild(block)
+
+      assert.equal(serializeToContentType(element, "text/html"), "<div><!--keep-->abc</div>")
+    })
+
+    test("preserves a literal block-marker byte sequence sitting in raw text", () => {
+      const element = document.createElement("div")
+      element.innerHTML = "<style>x<!--block-->y</style>"
+
+      // Inside a raw-text element the bytes "<!--block-->" are a text node, not
+      // a comment node, so they must survive serialization verbatim.
+      const style = element.querySelector("style")
+      assert.equal(style.childNodes.length, 1)
+      assert.equal(style.childNodes[0].nodeType, Node.TEXT_NODE)
+
+      assert.equal(serializeToContentType(element, "text/html"), "<style>x<!--block-->y</style>")
+    })
+
+    test("does not splice a literal marker into a real end tag", () => {
+      const element = document.createElement("div")
+      element.innerHTML = "<style>a</st<!--block-->yle>b</style>"
+
+      // The whole payload is one inert text node inside the <style> element.
+      const style = element.querySelector("style")
+      assert.equal(style.childNodes.length, 1)
+      assert.equal(style.textContent, "a</st<!--block-->yle>b")
+
+      const output = serializeToContentType(element, "text/html")
+
+      // Round-tripping the serialized value must yield the same structure: one
+      // <style> element whose text is intact, with nothing fused into a real
+      // </style> end tag that leaks "b" out of the raw-text context.
+      const reparsed = document.createElement("div")
+      reparsed.innerHTML = output
+      assert.equal(reparsed.querySelectorAll("style").length, 1)
+      assert.equal(reparsed.querySelector("style").childNodes.length, 1)
+      assert.equal(reparsed.querySelector("style").textContent, "a</st<!--block-->yle>b")
+    })
+  })
 })

--- a/src/trix/core/serialization.js
+++ b/src/trix/core/serialization.js
@@ -19,8 +19,6 @@ const unserializableAttributeNames = [
 const serializedAttributesAttribute = "data-trix-serialized-attributes"
 const serializedAttributesSelector = `[${serializedAttributesAttribute}]`
 
-const blockCommentPattern = new RegExp("<!--block-->", "g")
-
 const serializers = {
   "application/json": function(serializable) {
     let document
@@ -69,7 +67,21 @@ const serializers = {
       } catch (error) {}
     })
 
-    return element.innerHTML.replace(blockCommentPattern, "")
+    // Strip Trix's block boundary markers structurally, as comment nodes. A
+    // string replace over serialized HTML cannot tell Trix's own <!--block-->
+    // comment nodes from the identical byte sequence sitting in a text node
+    // (e.g. inside a raw-text <style> element), where removing it corrupts
+    // benign content and can fuse inert text into real markup.
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_COMMENT)
+    const markers = []
+    while (walker.nextNode()) {
+      if (walker.currentNode.data === "block") {
+        markers.push(walker.currentNode)
+      }
+    }
+    markers.forEach((node) => node.remove())
+
+    return element.innerHTML
   },
 }
 


### PR DESCRIPTION
## Problem

`serializeToContentType(..., "text/html")` strips Trix's `<!--block-->` boundary markers with a context-free global string replace over the *already-serialized* HTML:

```js
return element.innerHTML.replace(blockCommentPattern, "")
```

That replace can't distinguish Trix's own comment nodes (created in `BlockView` via `document.createComment("block")`) from the identical byte sequence `<!--block-->` sitting in a **text node**. So it corrupts content that merely happens to contain those bytes.

The clearest case is a raw-text element like `<style>`, whose contents are text, not parsed markup:

- `<style>x<!--block-->y</style>` serializes to `<style>xy</style>` — the inner text is silently mangled.
- The bytes can also be planted so that removing the marker fuses adjacent text into real markup, e.g. `</st<!--block-->yle>` (one inert text node) collapses into a real `</style>` end tag that wasn't in the sanitized DOM.

## Fix

Remove the markers **structurally**, as comment nodes, instead of as text. Walk the serializable element for comment nodes and remove exactly Trix's own `block` markers:

```js
const walker = document.createTreeWalker(element, NodeFilter.SHOW_COMMENT)
const markers = []
while (walker.nextNode()) {
  if (walker.currentNode.data === "block") markers.push(walker.currentNode)
}
markers.forEach((node) => node.remove())
return element.innerHTML
```

`element` here is always the serializer's own working copy — a `cloneNode(true)` of the input element, or a freshly `DocumentView.render`ed tree — never the live editor DOM, so mutating it in place is safe. The now-unused `blockCommentPattern` constant is removed.

## Tests

Added regression coverage in `serialization_test.js`:

- A literal `<!--block-->` byte sequence in a `<style>` text node round-trips verbatim (it's not a comment node, so it must be preserved).
- The `</st<!--block-->yle>` shape does not splice into a real `</style>` end tag — the serialized value re-parses to the same single `<style>` element with intact text.
- Real `<!--block-->` comment nodes are still removed (existing behavior), and non-`block` comment nodes are left alone.

The two corruption tests fail against the old string-replace implementation and pass with this change. Full suite green locally; the vendored Action Text bundle is regenerated via `yarn build`.
