### PR TITLE
Say why the Action Text job installs gems ad hoc, for zizmor 1.30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         # and the request body fails to serialize. Rails' own CI runs only `rake actiontext`
         # (no system tests), so upstream doesn't see it. Keep json 2.x here until the helper
         # or selenium-webdriver stops mixing key types.
-        run: |
+        run: | # zizmor: ignore[adhoc-packages] -- the two bundle add lines pin json 2.x with a written version and install the gem under test from this checkout
           cd rails
           yarn install --frozen-lockfile
           bundle remove json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         # and the request body fails to serialize. Rails' own CI runs only `rake actiontext`
         # (no system tests), so upstream doesn't see it. Keep json 2.x here until the helper
         # or selenium-webdriver stops mixing key types.
-        run: | # zizmor: ignore[adhoc-packages] -- the two bundle add lines pin json 2.x with a written version and install the gem under test from this checkout
+        run: | # zizmor: ignore[adhoc-packages] -- `bundle add json` pins json 2.x with the version written here; `bundle add action_text-trix` installs the gem under test from this checkout
           cd rails
           yarn install --frozen-lockfile
           bundle remove json


### PR DESCRIPTION
zizmor 1.30.0 (what zizmor-action 0.6.3 runs) teaches its `adhoc-packages` audit to recognize `bundle add`, and the Action Text job runs it twice on purpose: once to pin json 2.x with a version written in the workflow, for the reason the comment above it already gives, and once to install the gem under test from this checkout, which is the point of the job. Neither is the drift the audit is after, so the step carries a `zizmor: ignore[adhoc-packages]` with that reason.

Run online with zizmor 1.30.0 at the `regular` persona the action uses: two findings before, none after. This repo is on zizmor-action 0.5.3 and #1320 moves it to 0.6.2 (zizmor 1.29, which does not flag these); the bump after that would have gone red here.